### PR TITLE
chore: remove lots of unnecessary uses of choice state

### DIFF
--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -61,7 +61,7 @@ export async function cli<Writer extends (msg: string) => void>(argv: string[], 
 
     case "json": {
       const graph = compile(blocks, choices)
-      const wizard = wizardify(graph, choices)
+      const wizard = wizardify(graph)
       console.log(JSON.stringify(wizard, undefined, 2))
       break
     }

--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -48,7 +48,7 @@ export class Guide {
 
   private questions() {
     const graph = compile(this.blocks, this.choices)
-    const steps = wizardify(graph, this.choices)
+    const steps = wizardify(graph)
 
     const choiceSteps = steps.filter(isChoiceStep)
     const taskSteps = steps.filter(isTaskStep)
@@ -158,7 +158,7 @@ export class Guide {
         message: this.separator("This guidebook is ready for execution"),
         choices: [
           { value: "auto", name: "Run unattended 🤖" },
-          { value: "step", name: "Step me through it 🐌" },
+          { value: "step", name: "Step me through it 🐢" },
           { value: "stop", name: "Cancel 🛑" },
         ],
       },

--- a/src/fe/main.ts
+++ b/src/fe/main.ts
@@ -27,8 +27,8 @@ import { newChoiceState } from "../choices"
  */
 export async function main(input: VFileCompatible, choices = newChoiceState()) {
   const { blocks } = await blockify(input, choices)
-  const dag = compile(blocks, choices)
-  const wizard = wizardify(dag, choices)
+  const graph = compile(blocks, choices)
+  const wizard = wizardify(graph)
 
-  return { blocks, dag, wizard, choices }
+  return { blocks, graph, wizard, choices }
 }

--- a/src/graph/optimize.ts
+++ b/src/graph/optimize.ts
@@ -23,5 +23,5 @@ import collapseMadeChoices from "./collapseMadeChoices"
 import deadCodeElimination from "./deadCodeElimination"
 
 export default function optimize(graph: Graph, choices: ChoiceState) {
-  return propagateTitles(deadCodeElimination(hoistSubTasks(collapseMadeChoices(graph, choices), choices)))
+  return propagateTitles(deadCodeElimination(hoistSubTasks(collapseMadeChoices(graph, choices))))
 }

--- a/src/wizard/index.ts
+++ b/src/wizard/index.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { ChoiceState } from "../choices"
 import {
   Graph,
   Choice,
@@ -101,8 +100,8 @@ function wizardStepForChoiceOnFrontier(graph: Choice, isFirstChoice: boolean): W
 type Wizard = WizardStepWithGraph[]
 export { Wizard }
 
-export function wizardify(graph: Graph, choices: ChoiceState): Wizard {
-  const frontier = findChoiceFrontierWithFallbacks(graph, choices)
+export function wizardify(graph: Graph): Wizard {
+  const frontier = findChoiceFrontierWithFallbacks(graph)
 
   // the steps will be the interleaved ((...prereqs, choice), ...)
   // dictated by the this.state.frontier model, which comes from


### PR DESCRIPTION
Let's just simplify this and assume for now that `collapseMadeChoices` transformer is applied to the graph. This will let us consolidate all of the choice state checking into that one transformer.