### PR TITLE
chore: disable `noUnusedLocals` in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -83,7 +83,7 @@
     "noImplicitThis": true /* Enable error reporting when `this` is given the type `any`. */,
     // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
     "alwaysStrict": true /* Ensure 'use strict' is always emitted. */,
-    "noUnusedLocals": true /* Enable error reporting when a local variables aren't read. */,
+    // "noUnusedLocals": true /* Enable error reporting when a local variables aren't read. */,
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */


### PR DESCRIPTION
We have coverage for this in our eslint rules, and it makes debugging annoying (e.g. comment out a line to try something out, and your code no longer compiles)