### PR TITLE
fix: delay expensive calls to toMarkdownString

### DIFF
--- a/src/codeblock/CodeBlockProps.ts
+++ b/src/codeblock/CodeBlockProps.ts
@@ -39,7 +39,7 @@ export interface Description {
 }
 
 export type Source = {
-  source: string
+  source: () => string
 }
 
 /**

--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -83,7 +83,7 @@ export async function cli<Writer extends (msg: string) => boolean>(argv: string[
     case "json": {
       const graph = compile(blocks, choices)
       const wizard = wizardify(graph)
-      console.log(JSON.stringify(wizard, undefined, 2))
+      console.log(JSON.stringify(wizard, (key, value) => (key === "source" ? "placeholder" : value), 2))
       break
     }
 

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -187,7 +187,7 @@ export function subtask<T extends Unordered | Ordered = Unordered>(
   description: string,
   filepath: string,
   graph: Sequence<T>,
-  source: Source["source"] = ""
+  source: Source["source"] = () => ""
 ): SubTask<Unordered> {
   return {
     key,

--- a/src/parser/markdown/util/toMarkdownString.ts
+++ b/src/parser/markdown/util/toMarkdownString.ts
@@ -173,11 +173,7 @@ function hasChildren(node: Something): node is Parent {
   return Array.isArray((node as { children: Node[] }).children)
 }
 
-/**
- * Turn a hast tree back into a markdown string. We need to do a small
- * bit of munging on the data structures to facilitate the operation.
- */
-export default function toMarkdownString(root: Something): string {
+export function toMarkdownString(root: Something): string {
   if (hasValue(root) && !hasChildren(root)) {
     return root.value
   }
@@ -186,4 +182,12 @@ export default function toMarkdownString(root: Something): string {
     .replace(/(\\)+([=`-][=`-][=`-])/g, "$2")
     .replace(/(\\)+([[\]()*<>`])/g, "$2")
     .replace(/&#x20;/g, " ")
+}
+
+/**
+ * Turn a hast tree back into a markdown string. We need to do a small
+ * bit of munging on the data structures to facilitate the operation.
+ */
+export default function toMarkdownStringDelayed(root: Something) {
+  return () => toMarkdownString(root)
 }

--- a/src/wizard/index.ts
+++ b/src/wizard/index.ts
@@ -70,7 +70,7 @@ function wizardStepForPrereq<G extends Graph>(graph: G): WizardStepWithGraph<G, 
     step: {
       name: extractTitle(graph),
       description: extractDescription(graph),
-      content: hasSource(graph) ? graph.source : isLeafNode(graph) ? bodySource(graph) : "",
+      content: hasSource(graph) ? graph.source() : isLeafNode(graph) ? bodySource(graph) : "",
     },
   }
 }

--- a/test/inputs/1/wizard.json
+++ b/test/inputs/1/wizard.json
@@ -1,28 +1,25 @@
 [
   {
     "graph": {
-      "group": "c06fe391-d966-5797-b9d0-3aebb3ba6c0f",
-      "source": "=== \"Tab1Title\"\n\n    Tab1Content\n    \n    ```bash\n    echo 111\n    ```\n    \n\n=== \"Tab2Title\"\n\n    Tab2Content\n    \n    ```bash\n    echo 222\n    ```\n    \n",
+      "group": "aff787ef-5b66-5fd9-a6a4-93eb35b8fee9",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "cbadaa4e-cd7d-4e0a-bd8b-9dc3d93d4fc4",
+            "key": "5eb6201e-7240-495f-9ce3-c83829423e86",
             "sequence": [
               {
                 "body": "echo 111",
                 "language": "bash",
-                "id": "73b257ec-d2e4-49a8-aacc-3af1385ab52d-0",
+                "id": "4ee8d971-d984-49a7-b3eb-675d9df86ae5-0",
                 "nesting": [
                   {
                     "kind": "Choice",
-                    "source": "Tab1Content\n\n```bash\necho 111\n```\n",
-                    "group": "c06fe391-d966-5797-b9d0-3aebb3ba6c0f",
+                    "group": "aff787ef-5b66-5fd9-a6a4-93eb35b8fee9",
                     "title": "Tab1Title",
                     "member": 0,
-                    "groupDetail": {
-                      "source": "=== \"Tab1Title\"\n\n    Tab1Content\n    \n    ```bash\n    echo 111\n    ```\n    \n\n=== \"Tab2Title\"\n\n    Tab2Content\n    \n    ```bash\n    echo 222\n    ```\n    \n"
-                    }
+                    "groupDetail": {}
                   }
                 ]
               }
@@ -33,22 +30,19 @@
         {
           "member": 1,
           "graph": {
-            "key": "66224ff8-e7da-4ece-bba9-dec52b7b5b39",
+            "key": "2f703e00-bcd9-4561-9324-a9b64e088021",
             "sequence": [
               {
                 "body": "echo 222",
                 "language": "bash",
-                "id": "73b257ec-d2e4-49a8-aacc-3af1385ab52d-1",
+                "id": "4ee8d971-d984-49a7-b3eb-675d9df86ae5-1",
                 "nesting": [
                   {
                     "kind": "Choice",
-                    "source": "Tab2Content\n\n```bash\necho 222\n```\n",
-                    "group": "c06fe391-d966-5797-b9d0-3aebb3ba6c0f",
+                    "group": "aff787ef-5b66-5fd9-a6a4-93eb35b8fee9",
                     "title": "Tab2Title",
                     "member": 1,
-                    "groupDetail": {
-                      "source": "=== \"Tab1Title\"\n\n    Tab1Content\n    \n    ```bash\n    \n    ---\n    id: 73b257ec-d2e4-49a8-aacc-3af1385ab52d-0\n    \n    ---\n    echo 111\n    ```\n    \n\n=== \"Tab2Title\"\n\n    Tab2Content\n    \n    ```bash\n    echo 222\n    ```\n    \n"
-                    }
+                    "groupDetail": {}
                   }
                 ]
               }
@@ -63,13 +57,13 @@
       "content": [
         {
           "title": "Tab1Title",
-          "group": "c06fe391-d966-5797-b9d0-3aebb3ba6c0f",
+          "group": "aff787ef-5b66-5fd9-a6a4-93eb35b8fee9",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "Tab2Title",
-          "group": "c06fe391-d966-5797-b9d0-3aebb3ba6c0f",
+          "group": "aff787ef-5b66-5fd9-a6a4-93eb35b8fee9",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/10/wizard-darwin.json
+++ b/test/inputs/10/wizard-darwin.json
@@ -1,114 +1,106 @@
 [
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md",
+      "key": "test/inputs/snippets/importgg.md",
       "title": "importgg.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md",
+      "filepath": "test/inputs/snippets/importgg.md",
       "graph": {
-        "key": "5ceca124-b096-4b60-ad3f-b335e64c3abc",
+        "key": "75cf7462-f800-4368-b40f-8dfd021fea47",
         "sequence": [
           {
             "body": "echo MMM",
             "language": "bash",
-            "id": "1982514b-9cb1-446b-9970-db135a1f6eac-0",
+            "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-0",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md",
+                "key": "test/inputs/snippets/importgg.md",
                 "title": "importgg.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md"
+                "filepath": "test/inputs/snippets/importgg.md"
               },
               {
                 "kind": "Choice",
-                "source": "```bash\necho MMM\n```\n",
                 "group": "org.kubernetes-sigs.kui/choice/platform",
                 "title": "Darwin",
                 "member": 0,
-                "groupDetail": {
-                  "source": "=== \"Darwin\"\n\n    ```bash\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
-                }
+                "groupDetail": {}
               }
             ]
           }
         ]
       },
-      "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importgg.md",
       "description": "",
-      "content": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md",
+      "key": "test/inputs/snippets/importaa.md",
       "title": "importaa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md",
+      "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "1841cbb0-6bc7-47a4-95a9-aac01a141494",
+        "key": "c640c065-e606-4908-9bcf-ea9b78a56a12",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "1982514b-9cb1-446b-9970-db135a1f6eac-3",
+            "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-3",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md",
+                "key": "test/inputs/snippets/importaa.md",
                 "title": "importaa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md"
+                "filepath": "test/inputs/snippets/importaa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importaa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "fc453ea2-b178-5080-83d2-852c10dd04e4",
+      "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
       "title": "DDD",
-      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "0570d9d6-e601-4395-98bc-2bd7b4047aa4",
+            "key": "3539d3c2-b3e2-4159-af76-882f8572df29",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "1982514b-9cb1-446b-9970-db135a1f6eac-4",
+                "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-4",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "fc453ea2-b178-5080-83d2-852c10dd04e4",
+                    "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -117,24 +109,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "1982514b-9cb1-446b-9970-db135a1f6eac-5",
+                "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-5",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: 1982514b-9cb1-446b-9970-db135a1f6eac-4\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "fc453ea2-b178-5080-83d2-852c10dd04e4",
+                    "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -143,24 +132,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "1982514b-9cb1-446b-9970-db135a1f6eac-6",
+                "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-6",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: 1982514b-9cb1-446b-9970-db135a1f6eac-4\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: 1982514b-9cb1-446b-9970-db135a1f6eac-5\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "fc453ea2-b178-5080-83d2-852c10dd04e4",
+                    "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -172,30 +158,27 @@
         {
           "member": 1,
           "graph": {
-            "key": "69ab33fa-e6b8-4ca1-8284-5070ed2ea4c3",
+            "key": "9aa33492-3eae-4e37-83d3-3720ef34d5b9",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "1982514b-9cb1-446b-9970-db135a1f6eac-7",
+                "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-7",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-7\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                    "group": "fc453ea2-b178-5080-83d2-852c10dd04e4",
+                    "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 1982514b-9cb1-446b-9970-db135a1f6eac-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -212,13 +195,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "fc453ea2-b178-5080-83d2-852c10dd04e4",
+          "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "fc453ea2-b178-5080-83d2-852c10dd04e4",
+          "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/10/wizard-linux.json
+++ b/test/inputs/10/wizard-linux.json
@@ -1,114 +1,106 @@
 [
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md",
+      "key": "test/inputs/snippets/importgg.md",
       "title": "importgg.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md",
+      "filepath": "test/inputs/snippets/importgg.md",
       "graph": {
-        "key": "ca685098-3f2a-49fe-8eb6-105f9c31e5d4",
+        "key": "d82af8d0-fcfb-413e-bb86-61f2a30ac802",
         "sequence": [
           {
             "body": "echo LLL",
             "language": "bash",
-            "id": "a7b5eaa0-2157-47cc-b55d-d9609391de03-1",
+            "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-1",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    \n    ---\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-1\n    \n    ---\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md",
+                "key": "test/inputs/snippets/importgg.md",
                 "title": "importgg.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md"
+                "filepath": "test/inputs/snippets/importgg.md"
               },
               {
                 "kind": "Choice",
-                "source": "```bash\necho LLL\n```\n",
                 "group": "org.kubernetes-sigs.kui/choice/platform",
                 "title": "Linux",
                 "member": 1,
-                "groupDetail": {
-                  "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
-                }
+                "groupDetail": {}
               }
             ]
           }
         ]
       },
-      "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importgg.md",
       "description": "",
-      "content": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md",
+      "key": "test/inputs/snippets/importaa.md",
       "title": "importaa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md",
+      "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "6c8ddda2-1563-414b-b080-cbc3dde4d5bc",
+        "key": "34178019-5aa2-4ead-830f-11cd0bcd1f96",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "a7b5eaa0-2157-47cc-b55d-d9609391de03-3",
+            "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-3",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md",
+                "key": "test/inputs/snippets/importaa.md",
                 "title": "importaa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md"
+                "filepath": "test/inputs/snippets/importaa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importaa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "da686de2-6e52-55a2-96c4-fca8c9f30703",
+      "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
       "title": "DDD",
-      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "6c8f8d5d-ed06-421c-b0fd-56169c641a3a",
+            "key": "58b69b96-ac48-4e0a-b5e4-c5d2bf37d860",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "a7b5eaa0-2157-47cc-b55d-d9609391de03-4",
+                "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-4",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "da686de2-6e52-55a2-96c4-fca8c9f30703",
+                    "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -117,24 +109,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "a7b5eaa0-2157-47cc-b55d-d9609391de03-5",
+                "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-5",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: a7b5eaa0-2157-47cc-b55d-d9609391de03-4\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "da686de2-6e52-55a2-96c4-fca8c9f30703",
+                    "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -143,24 +132,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "a7b5eaa0-2157-47cc-b55d-d9609391de03-6",
+                "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-6",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: a7b5eaa0-2157-47cc-b55d-d9609391de03-4\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: a7b5eaa0-2157-47cc-b55d-d9609391de03-5\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "da686de2-6e52-55a2-96c4-fca8c9f30703",
+                    "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -172,30 +158,27 @@
         {
           "member": 1,
           "graph": {
-            "key": "332cb0f4-315a-4c4a-82b9-9a04f038d232",
+            "key": "503ef61b-31c0-4668-87cb-734b7f93c784",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "a7b5eaa0-2157-47cc-b55d-d9609391de03-7",
+                "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-7",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-7\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                    "group": "da686de2-6e52-55a2-96c4-fca8c9f30703",
+                    "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: a7b5eaa0-2157-47cc-b55d-d9609391de03-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -212,13 +195,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "da686de2-6e52-55a2-96c4-fca8c9f30703",
+          "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "da686de2-6e52-55a2-96c4-fca8c9f30703",
+          "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/10/wizard-win32.json
+++ b/test/inputs/10/wizard-win32.json
@@ -1,114 +1,106 @@
 [
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md",
+      "key": "test/inputs/snippets/importgg.md",
       "title": "importgg.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md",
+      "filepath": "test/inputs/snippets/importgg.md",
       "graph": {
-        "key": "d7549e03-23e6-4b15-a479-7838e44b9fc0",
+        "key": "d3b4de93-62c6-4cf8-bcd5-8165786b8906",
         "sequence": [
           {
             "body": "echo WWW",
             "language": "bash",
-            "id": "03025fa1-d49f-469e-8aa4-4fce36220ea3-2",
+            "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-2",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    \n    ---\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-1\n    \n    ---\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    \n    ---\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-2\n    \n    ---\n    echo WWW\n    ```\n    \n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md",
+                "key": "test/inputs/snippets/importgg.md",
                 "title": "importgg.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importgg.md"
+                "filepath": "test/inputs/snippets/importgg.md"
               },
               {
                 "kind": "Choice",
-                "source": "```bash\necho WWW\n```\n",
                 "group": "org.kubernetes-sigs.kui/choice/platform",
                 "title": "Win32",
                 "member": 2,
-                "groupDetail": {
-                  "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    \n    ---\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-1\n    \n    ---\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
-                }
+                "groupDetail": {}
               }
             ]
           }
         ]
       },
-      "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importgg.md",
       "description": "",
-      "content": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md",
+      "key": "test/inputs/snippets/importaa.md",
       "title": "importaa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md",
+      "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "456b363c-b143-4afb-8c9b-835a5ecb78b4",
+        "key": "8429616b-907b-4ab1-badf-dbc5bd5818f7",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "03025fa1-d49f-469e-8aa4-4fce36220ea3-3",
+            "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-3",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md",
+                "key": "test/inputs/snippets/importaa.md",
                 "title": "importaa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importaa.md"
+                "filepath": "test/inputs/snippets/importaa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importaa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "e71be90d-16a3-518d-b6e5-6068b1929e25",
+      "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
       "title": "DDD",
-      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "1dbcfdef-e5b9-4b20-84cd-a9944f5e8b90",
+            "key": "2cfd922c-fb20-4fd9-8798-97318030fccf",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "03025fa1-d49f-469e-8aa4-4fce36220ea3-4",
+                "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-4",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "e71be90d-16a3-518d-b6e5-6068b1929e25",
+                    "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -117,24 +109,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "03025fa1-d49f-469e-8aa4-4fce36220ea3-5",
+                "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-5",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: 03025fa1-d49f-469e-8aa4-4fce36220ea3-4\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "e71be90d-16a3-518d-b6e5-6068b1929e25",
+                    "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -143,24 +132,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "03025fa1-d49f-469e-8aa4-4fce36220ea3-6",
+                "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-6",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: 03025fa1-d49f-469e-8aa4-4fce36220ea3-4\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: 03025fa1-d49f-469e-8aa4-4fce36220ea3-5\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "e71be90d-16a3-518d-b6e5-6068b1929e25",
+                    "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -172,30 +158,27 @@
         {
           "member": 1,
           "graph": {
-            "key": "65202bfb-839a-4184-a978-fce07fbc75d8",
+            "key": "a1eda799-10f4-4120-8538-f3256efe5ff1",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "03025fa1-d49f-469e-8aa4-4fce36220ea3-7",
+                "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-7",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-7\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md",
+                    "key": "test/inputs/snippets/importdd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importdd.md"
+                    "filepath": "test/inputs/snippets/importdd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                    "group": "e71be90d-16a3-518d-b6e5-6068b1929e25",
+                    "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 03025fa1-d49f-469e-8aa4-4fce36220ea3-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -212,13 +195,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "e71be90d-16a3-518d-b6e5-6068b1929e25",
+          "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "e71be90d-16a3-518d-b6e5-6068b1929e25",
+          "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/3/wizard.json
+++ b/test/inputs/3/wizard.json
@@ -1,84 +1,78 @@
 [
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "key": "test/inputs/snippets/importa.md",
       "title": "importa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "d2b846c3-ae4a-44a3-8455-91b835c166c2",
+        "key": "983ba647-3f46-4e1e-8e03-0a89abf02ac7",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "600e8caa-fb91-4b31-83d5-f1fc301b03f7-0",
+            "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-0",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    imports:\n    \n    *   importc.md\n    \n    \n    ???+ tip \"TipTitle\"\n    \n        TipContent\n        \n    \n\n\nDDD\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md",
+                "key": "test/inputs/snippets/snippets-in-tab3.md",
                 "title": "snippets-in-tab3.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md"
+                "filepath": "test/inputs/snippets/snippets-in-tab3.md"
               },
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+                "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md"
+                "filepath": "test/inputs/snippets/importa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "26e69b69-4f1f-56e2-a853-e0cf5bd76281",
+      "group": "665ed6b2-d77f-52ca-9bf4-c45e96a9e612",
       "title": "EEE",
-      "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    echo EEE\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "e5aee0e4-6fd6-4d8c-8ce0-f05d3c9ca5cf",
+            "key": "f93f6091-08dd-4b6c-903c-2fd9f623610d",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "600e8caa-fb91-4b31-83d5-f1fc301b03f7-1",
+                "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-1",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    imports:\n    \n    *   importc.md\n    \n    \n    ???+ tip \"TipTitle\"\n    \n        TipContent\n        \n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md",
+                    "key": "test/inputs/snippets/snippets-in-tab3.md",
                     "title": "snippets-in-tab3.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab3.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    \n    ---\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-1\n    \n    ---\n    echo EEE\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importe.md",
+                    "key": "test/inputs/snippets/importe.md",
                     "title": "EEE",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importe.md"
+                    "filepath": "test/inputs/snippets/importe.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "EEE1Content\n\n```bash\necho EEE\n```\n",
-                    "group": "26e69b69-4f1f-56e2-a853-e0cf5bd76281",
+                    "group": "665ed6b2-d77f-52ca-9bf4-c45e96a9e612",
                     "title": "TabE1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "EEE",
-                      "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    echo EEE\n    ```\n    \n"
+                      "title": "EEE"
                     }
                   }
                 ]
@@ -95,7 +89,7 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "26e69b69-4f1f-56e2-a853-e0cf5bd76281",
+          "group": "665ed6b2-d77f-52ca-9bf4-c45e96a9e612",
           "member": 0,
           "isFirstChoice": true
         }
@@ -104,51 +98,46 @@
   },
   {
     "graph": {
-      "group": "0318dfb4-1f76-577c-913b-f77477b0c1bb",
+      "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
       "title": "DDD",
-      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "dae126ee-998f-46d0-9cd9-1e5a102c1466",
+            "key": "1542e2d9-a39e-4001-8064-4a5ca5aff15c",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "600e8caa-fb91-4b31-83d5-f1fc301b03f7-2",
+                "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-2",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    imports:\n    \n    *   importc.md\n    \n    \n    ???+ tip \"TipTitle\"\n    \n        TipContent\n        \n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md",
+                    "key": "test/inputs/snippets/snippets-in-tab3.md",
                     "title": "snippets-in-tab3.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab3.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "***\n\nimports: - importd.md\n\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importf.md",
+                    "key": "test/inputs/snippets/importf.md",
                     "title": "importf.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importf.md"
+                    "filepath": "test/inputs/snippets/importf.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "0318dfb4-1f76-577c-913b-f77477b0c1bb",
+                    "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -157,38 +146,33 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "600e8caa-fb91-4b31-83d5-f1fc301b03f7-3",
+                "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-3",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    imports:\n    \n    *   importc.md\n    \n    \n    ???+ tip \"TipTitle\"\n    \n        TipContent\n        \n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md",
+                    "key": "test/inputs/snippets/snippets-in-tab3.md",
                     "title": "snippets-in-tab3.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab3.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "***\n\nimports: - importd.md\n\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importf.md",
+                    "key": "test/inputs/snippets/importf.md",
                     "title": "importf.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importf.md"
+                    "filepath": "test/inputs/snippets/importf.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-2\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "0318dfb4-1f76-577c-913b-f77477b0c1bb",
+                    "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -197,38 +181,33 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "600e8caa-fb91-4b31-83d5-f1fc301b03f7-4",
+                "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-4",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    imports:\n    \n    *   importc.md\n    \n    \n    ???+ tip \"TipTitle\"\n    \n        TipContent\n        \n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md",
+                    "key": "test/inputs/snippets/snippets-in-tab3.md",
                     "title": "snippets-in-tab3.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab3.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "***\n\nimports: - importd.md\n\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importf.md",
+                    "key": "test/inputs/snippets/importf.md",
                     "title": "importf.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importf.md"
+                    "filepath": "test/inputs/snippets/importf.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-4\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-2\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-3\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "0318dfb4-1f76-577c-913b-f77477b0c1bb",
+                    "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -240,44 +219,39 @@
         {
           "member": 1,
           "graph": {
-            "key": "48849235-e9bd-4ac7-b402-e8c6c786c6c1",
+            "key": "c812ae1e-2bd3-4ac5-8a69-acec46e16e90",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "600e8caa-fb91-4b31-83d5-f1fc301b03f7-5",
+                "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-5",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    imports:\n    \n    *   importc.md\n    \n    \n    ???+ tip \"TipTitle\"\n    \n        TipContent\n        \n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md",
+                    "key": "test/inputs/snippets/snippets-in-tab3.md",
                     "title": "snippets-in-tab3.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab3.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "***\n\nimports: - importd.md\n\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importf.md",
+                    "key": "test/inputs/snippets/importf.md",
                     "title": "importf.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importf.md"
+                    "filepath": "test/inputs/snippets/importf.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-4\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-5\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                    "group": "0318dfb4-1f76-577c-913b-f77477b0c1bb",
+                    "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 600e8caa-fb91-4b31-83d5-f1fc301b03f7-4\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -294,13 +268,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "0318dfb4-1f76-577c-913b-f77477b0c1bb",
+          "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
           "member": 0,
           "isFirstChoice": false
         },
         {
           "title": "SubTab2",
-          "group": "0318dfb4-1f76-577c-913b-f77477b0c1bb",
+          "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
           "member": 1,
           "isFirstChoice": false
         }
@@ -309,59 +283,54 @@
   },
   {
     "graph": {
-      "group": "8bba74a6-9e93-5972-960d-116e8e0dcfd7",
+      "group": "dc8ba323-49e8-5421-8189-21303fbc4a22",
       "title": "Main Tasks",
-      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    imports:\n    \n    *   importc.md\n    \n    \n    ???+ tip \"TipTitle\"\n    \n        TipContent\n        \n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "dc420c8a-ed85-47da-98d3-99de6e60acb7",
+            "key": "b54bf381-89fa-49c0-b155-dbf7989daf59",
             "sequence": [
               {
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importc.md",
+                "key": "test/inputs/snippets/importc.md",
                 "title": "importc.md",
                 "description": "",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importc.md",
+                "filepath": "test/inputs/snippets/importc.md",
                 "graph": {
-                  "key": "4f9bdac5-0abf-4519-a333-ee5502a6e0bf",
+                  "key": "6e365160-d306-463c-be9d-24ef2c95bc96",
                   "sequence": [
                     {
                       "body": "echo CCC",
                       "language": "bash",
                       "validate": true,
-                      "id": "600e8caa-fb91-4b31-83d5-f1fc301b03f7-10",
+                      "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-10",
                       "nesting": [
                         {
                           "kind": "Import",
-                          "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    imports:\n    \n    *   importc.md\n    \n    \n    ???+ tip \"TipTitle\"\n    \n        TipContent\n        \n    \n\n\nDDD\n",
-                          "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md",
+                          "key": "test/inputs/snippets/snippets-in-tab3.md",
                           "title": "snippets-in-tab3.md",
-                          "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab3.md"
+                          "filepath": "test/inputs/snippets/snippets-in-tab3.md"
                         },
                         {
                           "kind": "Choice",
-                          "source": "imports:\n\n*   importc.md\n\n\n???+ tip \"TipTitle\"\n\n    TipContent\n    \n",
-                          "group": "8bba74a6-9e93-5972-960d-116e8e0dcfd7",
+                          "group": "dc8ba323-49e8-5421-8189-21303fbc4a22",
                           "title": "Tab2",
                           "description": "imports:\n",
                           "member": 1,
-                          "groupDetail": {
-                            "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    imports:\n    \n    *   importc.md\n    \n    \n    ???+ tip \"TipTitle\"\n    \n        TipContent\n        \n    \n"
-                          }
+                          "groupDetail": {}
                         },
                         {
                           "kind": "Import",
-                          "source": "```bash\n---\nvalidate: true\n---\necho CCC\n```\n",
-                          "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importc.md",
+                          "key": "test/inputs/snippets/importc.md",
                           "title": "importc.md",
-                          "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importc.md"
+                          "filepath": "test/inputs/snippets/importc.md"
                         }
                       ]
                     }
                   ]
                 },
-                "source": "```bash\n---\nvalidate: true\n---\necho CCC\n```\n"
+                "source": "placeholder"
               }
             ]
           },
@@ -376,7 +345,7 @@
       "content": [
         {
           "title": "Tab2",
-          "group": "8bba74a6-9e93-5972-960d-116e8e0dcfd7",
+          "group": "dc8ba323-49e8-5421-8189-21303fbc4a22",
           "member": 1,
           "isFirstChoice": false,
           "description": "imports:\n"

--- a/test/inputs/4/wizard.json
+++ b/test/inputs/4/wizard.json
@@ -1,84 +1,78 @@
 [
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "key": "test/inputs/snippets/importa.md",
       "title": "importa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "d38174d2-df25-4e89-8603-40909c0c7d93",
+        "key": "988305c0-7d19-4b31-aa0f-8168795da502",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "b2903233-5502-450b-9a23-6b7de8c88d81-0",
+            "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-0",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n\nDDD\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md",
+                "key": "test/inputs/snippets/snippets-in-tab4.md",
                 "title": "snippets-in-tab4.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md"
+                "filepath": "test/inputs/snippets/snippets-in-tab4.md"
               },
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+                "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md"
+                "filepath": "test/inputs/snippets/importa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "4d0a015f-d9dd-5833-9632-b34b6b4e9458",
+      "group": "c8839442-2f89-53df-9b9a-09266fa2f943",
       "title": "EEE",
-      "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    echo EEE\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "984521a8-6fbb-482f-a24e-9b2bfbf94a53",
+            "key": "9eca0bd4-c456-44ca-b2f5-b9e3b626cf1d",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "b2903233-5502-450b-9a23-6b7de8c88d81-1",
+                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-1",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md",
+                    "key": "test/inputs/snippets/snippets-in-tab4.md",
                     "title": "snippets-in-tab4.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    \n    ---\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-1\n    \n    ---\n    echo EEE\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importe.md",
+                    "key": "test/inputs/snippets/importe.md",
                     "title": "EEE",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importe.md"
+                    "filepath": "test/inputs/snippets/importe.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "EEE1Content\n\n```bash\necho EEE\n```\n",
-                    "group": "4d0a015f-d9dd-5833-9632-b34b6b4e9458",
+                    "group": "c8839442-2f89-53df-9b9a-09266fa2f943",
                     "title": "TabE1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "EEE",
-                      "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    echo EEE\n    ```\n    \n"
+                      "title": "EEE"
                     }
                   }
                 ]
@@ -95,7 +89,7 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "4d0a015f-d9dd-5833-9632-b34b6b4e9458",
+          "group": "c8839442-2f89-53df-9b9a-09266fa2f943",
           "member": 0,
           "isFirstChoice": true
         }
@@ -104,73 +98,66 @@
   },
   {
     "graph": {
-      "group": "c37e18d1-ef54-51ef-b23f-c012332fd9ea",
+      "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
       "title": "Main Tasks",
-      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "ba5f6d33-6897-489c-8634-b1ad164e827d",
+            "key": "68a5f282-2f9d-4cb5-953e-3d45d0780b80",
             "sequence": [
               {
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "description": "",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "37a80a9b-2322-4b39-9a14-f01182ca7c60",
+                  "key": "a5e42ef1-37a1-4352-8cfe-2b7c72a3ab07",
                   "sequence": [
                     {
-                      "group": "c4ab1f48-1cbb-5614-9329-166c168503f8",
+                      "group": "3e96a744-4524-51bb-bef6-9d212184c9cd",
                       "title": "DDD",
-                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+                      "source": "placeholder",
                       "choices": [
                         {
                           "member": 0,
                           "graph": {
-                            "key": "6524123d-a0b6-4c0c-b0db-b303d039d53a",
+                            "key": "f35601b7-4e68-4895-871f-91dd0861b552",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "b2903233-5502-450b-9a23-6b7de8c88d81-2",
+                                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-2",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab4.md",
                                     "title": "snippets-in-tab4.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nBBBoo\n",
-                                    "group": "c37e18d1-ef54-51ef-b23f-c012332fd9ea",
+                                    "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                                    "group": "c4ab1f48-1cbb-5614-9329-166c168503f8",
+                                    "group": "3e96a744-4524-51bb-bef6-9d212184c9cd",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -179,42 +166,35 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "b2903233-5502-450b-9a23-6b7de8c88d81-3",
+                                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-3",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab4.md",
                                     "title": "snippets-in-tab4.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nBBBoo\n",
-                                    "group": "c37e18d1-ef54-51ef-b23f-c012332fd9ea",
+                                    "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n\n---\nvalidate: true\nid: b2903233-5502-450b-9a23-6b7de8c88d81-2\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                                    "group": "c4ab1f48-1cbb-5614-9329-166c168503f8",
+                                    "group": "3e96a744-4524-51bb-bef6-9d212184c9cd",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -223,42 +203,35 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "b2903233-5502-450b-9a23-6b7de8c88d81-4",
+                                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-4",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab4.md",
                                     "title": "snippets-in-tab4.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nBBBoo\n",
-                                    "group": "c37e18d1-ef54-51ef-b23f-c012332fd9ea",
+                                    "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-4\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n\n---\nvalidate: true\nid: b2903233-5502-450b-9a23-6b7de8c88d81-2\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: b2903233-5502-450b-9a23-6b7de8c88d81-3\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                                    "group": "c4ab1f48-1cbb-5614-9329-166c168503f8",
+                                    "group": "3e96a744-4524-51bb-bef6-9d212184c9cd",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -270,48 +243,41 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "b5a59ff7-d905-42d5-9176-a80354597eb2",
+                            "key": "6bbe8ecb-edc2-4230-a747-b06dbc23209a",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "b2903233-5502-450b-9a23-6b7de8c88d81-5",
+                                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-5",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab4.md",
                                     "title": "snippets-in-tab4.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nBBBoo\n",
-                                    "group": "c37e18d1-ef54-51ef-b23f-c012332fd9ea",
+                                    "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-4\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-5\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                                    "group": "c4ab1f48-1cbb-5614-9329-166c168503f8",
+                                    "group": "3e96a744-4524-51bb-bef6-9d212184c9cd",
                                     "title": "SubTab2",
                                     "member": 1,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-4\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -324,7 +290,7 @@
                     }
                   ]
                 },
-                "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                "source": "placeholder"
               }
             ]
           },
@@ -334,29 +300,25 @@
         {
           "member": 1,
           "graph": {
-            "key": "4fe45456-02ed-454e-81bc-49ae681d381f",
+            "key": "18fcbfc6-48d2-4502-bacd-7d686eb4e499",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "b2903233-5502-450b-9a23-6b7de8c88d81-6",
+                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-6",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: b2903233-5502-450b-9a23-6b7de8c88d81-6\n    \n    ---\n    echo XXX\n    ```\n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md",
+                    "key": "test/inputs/snippets/snippets-in-tab4.md",
                     "title": "snippets-in-tab4.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab4.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "BBBoo\n\n```bash\necho XXX\n```\n",
-                    "group": "c37e18d1-ef54-51ef-b23f-c012332fd9ea",
+                    "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
                     "title": "Tab2",
                     "member": 1,
-                    "groupDetail": {
-                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n"
-                    }
+                    "groupDetail": {}
                   }
                 ]
               }
@@ -372,14 +334,14 @@
       "content": [
         {
           "title": "Tab1",
-          "group": "c37e18d1-ef54-51ef-b23f-c012332fd9ea",
+          "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
           "member": 0,
           "isFirstChoice": false,
           "description": "imports:\n"
         },
         {
           "title": "Tab2",
-          "group": "c37e18d1-ef54-51ef-b23f-c012332fd9ea",
+          "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
           "member": 1,
           "isFirstChoice": false
         }

--- a/test/inputs/5/wizard.json
+++ b/test/inputs/5/wizard.json
@@ -1,84 +1,78 @@
 [
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "key": "test/inputs/snippets/importa.md",
       "title": "importa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "892f5553-49b1-4a9c-9327-4b739c6bf351",
+        "key": "af0807ea-7bf8-4e85-b6c5-125dd588bf60",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "79ab15f3-7e20-4982-ad85-530331be9787-0",
+            "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-0",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                "key": "test/inputs/snippets/snippets-in-tab5.md",
                 "title": "snippets-in-tab5.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                "filepath": "test/inputs/snippets/snippets-in-tab5.md"
               },
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+                "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md"
+                "filepath": "test/inputs/snippets/importa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "58ffa9c7-b29e-5c6e-8286-9347280e97fa",
+      "group": "6eddc154-5e0e-5d0b-b277-f16fe216dc41",
       "title": "EEE",
-      "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    echo EEE\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "318739d5-ae46-444b-bc45-657ec3b93075",
+            "key": "6155934c-9bc8-4d0e-8b60-872abff78262",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "79ab15f3-7e20-4982-ad85-530331be9787-1",
+                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-1",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                     "title": "snippets-in-tab5.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    \n    ---\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-1\n    \n    ---\n    echo EEE\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importe.md",
+                    "key": "test/inputs/snippets/importe.md",
                     "title": "EEE",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importe.md"
+                    "filepath": "test/inputs/snippets/importe.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "EEE1Content\n\n```bash\necho EEE\n```\n",
-                    "group": "58ffa9c7-b29e-5c6e-8286-9347280e97fa",
+                    "group": "6eddc154-5e0e-5d0b-b277-f16fe216dc41",
                     "title": "TabE1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "EEE",
-                      "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    echo EEE\n    ```\n    \n"
+                      "title": "EEE"
                     }
                   }
                 ]
@@ -95,7 +89,7 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "58ffa9c7-b29e-5c6e-8286-9347280e97fa",
+          "group": "6eddc154-5e0e-5d0b-b277-f16fe216dc41",
           "member": 0,
           "isFirstChoice": true
         }
@@ -104,73 +98,66 @@
   },
   {
     "graph": {
-      "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+      "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
       "title": "Main Tasks",
-      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "26ddbefa-c5db-4c6b-b644-b91fa87abba8",
+            "key": "b8a87711-e5bb-4491-96e4-708fa80c7548",
             "sequence": [
               {
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "description": "",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "4ffe2a78-fefa-4b9a-80f8-3c6140313a11",
+                  "key": "69d520c1-d795-41be-87a0-5de2e31e722a",
                   "sequence": [
                     {
-                      "group": "abea886f-acf0-5473-91b4-6cae6b0bf4f0",
+                      "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
                       "title": "DDD",
-                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+                      "source": "placeholder",
                       "choices": [
                         {
                           "member": 0,
                           "graph": {
-                            "key": "9eb4931b-91b7-4915-b63a-2af7853a2605",
+                            "key": "04ceaf97-63c3-41dd-9879-efb4581d084a",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "79ab15f3-7e20-4982-ad85-530331be9787-2",
+                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-2",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                                     "title": "snippets-in-tab5.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nBBBoo\n",
-                                    "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                                    "group": "abea886f-acf0-5473-91b4-6cae6b0bf4f0",
+                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -179,42 +166,35 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "79ab15f3-7e20-4982-ad85-530331be9787-3",
+                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-3",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                                     "title": "snippets-in-tab5.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nBBBoo\n",
-                                    "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n\n---\nvalidate: true\nid: 79ab15f3-7e20-4982-ad85-530331be9787-2\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                                    "group": "abea886f-acf0-5473-91b4-6cae6b0bf4f0",
+                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -223,42 +203,35 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "79ab15f3-7e20-4982-ad85-530331be9787-4",
+                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-4",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                                     "title": "snippets-in-tab5.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nBBBoo\n",
-                                    "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-4\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n\n---\nvalidate: true\nid: 79ab15f3-7e20-4982-ad85-530331be9787-2\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: 79ab15f3-7e20-4982-ad85-530331be9787-3\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                                    "group": "abea886f-acf0-5473-91b4-6cae6b0bf4f0",
+                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -270,48 +243,41 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "7d2882ba-5b8d-4a60-92a8-4a7ca1f4bead",
+                            "key": "8e3e4992-86e0-4ee9-a5f0-f39e9e2cd0c8",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "79ab15f3-7e20-4982-ad85-530331be9787-5",
+                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-5",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                                     "title": "snippets-in-tab5.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nBBBoo\n",
-                                    "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-4\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-5\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                                    "group": "abea886f-acf0-5473-91b4-6cae6b0bf4f0",
+                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
                                     "title": "SubTab2",
                                     "member": 1,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-3\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-4\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -324,7 +290,7 @@
                     }
                   ]
                 },
-                "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-2\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                "source": "placeholder"
               }
             ]
           },
@@ -334,29 +300,25 @@
         {
           "member": 1,
           "graph": {
-            "key": "8b08b380-4b0e-4fb8-861b-e0d83b7e2807",
+            "key": "ee406cbb-4209-45a4-92b8-998840eafc9b",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "79ab15f3-7e20-4982-ad85-530331be9787-6",
+                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-6",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-6\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                     "title": "snippets-in-tab5.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "BBBoo\n\n```bash\necho XXX\n```\n",
-                    "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
                     "title": "Tab2",
                     "member": 1,
-                    "groupDetail": {
-                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                    }
+                    "groupDetail": {}
                   }
                 ]
               }
@@ -367,66 +329,59 @@
         {
           "member": 2,
           "graph": {
-            "key": "4978673c-f2e0-40b2-8c47-19594c149533",
+            "key": "b38d61ce-e2ba-4256-9a22-1d9b9aa5b254",
             "sequence": [
               {
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "description": "",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "69f4a44e-d2b3-4e41-97e7-36d644de7381",
+                  "key": "f9a4f7a4-bbbb-45d9-9c88-35390fd59a18",
                   "sequence": [
                     {
-                      "group": "abea886f-acf0-5473-91b4-6cae6b0bf4f0",
+                      "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
                       "title": "DDD",
-                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+                      "source": "placeholder",
                       "choices": [
                         {
                           "member": 0,
                           "graph": {
-                            "key": "9dde549b-a185-4168-a11d-937afeb293f8",
+                            "key": "0d52787d-f17f-42c7-bbbf-06d277670ac5",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "79ab15f3-7e20-4982-ad85-530331be9787-7",
+                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-7",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-6\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                                     "title": "snippets-in-tab5.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nCCCoo\n",
-                                    "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-6\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-7\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                                    "group": "abea886f-acf0-5473-91b4-6cae6b0bf4f0",
+                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -435,42 +390,35 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "79ab15f3-7e20-4982-ad85-530331be9787-8",
+                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-8",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-6\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                                     "title": "snippets-in-tab5.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nCCCoo\n",
-                                    "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-6\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-7\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-8\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n\n---\nvalidate: true\nid: 79ab15f3-7e20-4982-ad85-530331be9787-7\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                                    "group": "abea886f-acf0-5473-91b4-6cae6b0bf4f0",
+                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-7\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -479,42 +427,35 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "79ab15f3-7e20-4982-ad85-530331be9787-9",
+                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-9",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-6\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                                     "title": "snippets-in-tab5.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nCCCoo\n",
-                                    "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-6\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-7\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-8\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-9\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n\n---\nvalidate: true\nid: 79ab15f3-7e20-4982-ad85-530331be9787-7\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: 79ab15f3-7e20-4982-ad85-530331be9787-8\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                                    "group": "abea886f-acf0-5473-91b4-6cae6b0bf4f0",
+                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-7\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-8\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -526,48 +467,41 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "33d99d0d-e29f-4512-bc18-25e46ce0683f",
+                            "key": "09f4b01d-ca8f-4b65-a3fb-ee63f12a503e",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "79ab15f3-7e20-4982-ad85-530331be9787-10",
+                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-10",
                                 "nesting": [
                                   {
                                     "kind": "Import",
-                                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-6\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                                     "title": "snippets-in-tab5.md",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "imports:\n\n*   importd.md\n\nCCCoo\n",
-                                    "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
-                                    "groupDetail": {
-                                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-6\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                                    }
+                                    "groupDetail": {}
                                   },
                                   {
                                     "kind": "Import",
-                                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-7\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-8\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-9\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-10\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                                    "key": "test/inputs/snippets/importd.md",
                                     "title": "DDD",
-                                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                                    "filepath": "test/inputs/snippets/importd.md"
                                   },
                                   {
                                     "kind": "Choice",
-                                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                                    "group": "abea886f-acf0-5473-91b4-6cae6b0bf4f0",
+                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
                                     "title": "SubTab2",
                                     "member": 1,
                                     "groupDetail": {
-                                      "title": "DDD",
-                                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-7\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-8\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-9\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                                      "title": "DDD"
                                     }
                                   }
                                 ]
@@ -580,7 +514,7 @@
                     }
                   ]
                 },
-                "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 79ab15f3-7e20-4982-ad85-530331be9787-7\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                "source": "placeholder"
               }
             ]
           },
@@ -595,20 +529,20 @@
       "content": [
         {
           "title": "Tab1",
-          "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+          "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
           "member": 0,
           "isFirstChoice": false,
           "description": "imports:\n"
         },
         {
           "title": "Tab2",
-          "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+          "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
           "member": 1,
           "isFirstChoice": false
         },
         {
           "title": "Tab3",
-          "group": "ee7d3f9c-8e45-560e-8740-908038ae4f59",
+          "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
           "member": 2,
           "isFirstChoice": false,
           "description": "imports:\n"

--- a/test/inputs/6/wizard.json
+++ b/test/inputs/6/wizard.json
@@ -1,37 +1,34 @@
 [
   {
     "graph": {
-      "group": "4e757663-6b4c-55b7-92d3-a2de63929f66",
+      "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
       "title": "DDD",
-      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "50fd7805-7113-458b-98ab-c29f7863fc56",
+            "key": "7ee36470-d107-468a-99ca-681ea7dd3620",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "9ebe1279-474e-433a-9aa0-ea38866fb360-0",
+                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-0",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "4e757663-6b4c-55b7-92d3-a2de63929f66",
+                    "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -40,24 +37,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "9ebe1279-474e-433a-9aa0-ea38866fb360-1",
+                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-1",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: 9ebe1279-474e-433a-9aa0-ea38866fb360-0\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "4e757663-6b4c-55b7-92d3-a2de63929f66",
+                    "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -66,24 +60,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "9ebe1279-474e-433a-9aa0-ea38866fb360-2",
+                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-2",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-2\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: 9ebe1279-474e-433a-9aa0-ea38866fb360-0\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: 9ebe1279-474e-433a-9aa0-ea38866fb360-1\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "4e757663-6b4c-55b7-92d3-a2de63929f66",
+                    "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -95,30 +86,27 @@
         {
           "member": 1,
           "graph": {
-            "key": "f47dcc6a-7743-4837-a1ad-662b39844be4",
+            "key": "b919be8b-bce6-40e5-b0d6-01ae47de40cd",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "9ebe1279-474e-433a-9aa0-ea38866fb360-3",
+                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-3",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-2\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-3\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                    "group": "4e757663-6b4c-55b7-92d3-a2de63929f66",
+                    "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-2\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -135,13 +123,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "4e757663-6b4c-55b7-92d3-a2de63929f66",
+          "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "4e757663-6b4c-55b7-92d3-a2de63929f66",
+          "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
           "member": 1,
           "isFirstChoice": true
         }
@@ -150,84 +138,78 @@
   },
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "key": "test/inputs/snippets/importa.md",
       "title": "importa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "fea299c8-7762-48ad-8cea-25e2bd7104c3",
+        "key": "524cd27b-afe7-44c0-b75a-0d58fc0f1af0",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "9ebe1279-474e-433a-9aa0-ea38866fb360-4",
+            "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-4",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                "key": "test/inputs/snippets/snippets-in-tab5.md",
                 "title": "snippets-in-tab5.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                "filepath": "test/inputs/snippets/snippets-in-tab5.md"
               },
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+                "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md"
+                "filepath": "test/inputs/snippets/importa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "f109017d-3890-5747-a7a3-e02c95f8bcd5",
+      "group": "aa9fc542-480b-5bc9-b953-de6231c0b28f",
       "title": "EEE",
-      "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    echo EEE\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "2819343a-8803-447e-b9fa-7f5c4baad166",
+            "key": "4dbbce87-cab2-4ec5-97c5-1999b0c31c9b",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "9ebe1279-474e-433a-9aa0-ea38866fb360-5",
+                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-5",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                     "title": "snippets-in-tab5.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    \n    ---\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-5\n    \n    ---\n    echo EEE\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importe.md",
+                    "key": "test/inputs/snippets/importe.md",
                     "title": "EEE",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importe.md"
+                    "filepath": "test/inputs/snippets/importe.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "EEE1Content\n\n```bash\necho EEE\n```\n",
-                    "group": "f109017d-3890-5747-a7a3-e02c95f8bcd5",
+                    "group": "aa9fc542-480b-5bc9-b953-de6231c0b28f",
                     "title": "TabE1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "EEE",
-                      "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    echo EEE\n    ```\n    \n"
+                      "title": "EEE"
                     }
                   }
                 ]
@@ -244,7 +226,7 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "f109017d-3890-5747-a7a3-e02c95f8bcd5",
+          "group": "aa9fc542-480b-5bc9-b953-de6231c0b28f",
           "member": 0,
           "isFirstChoice": false
         }
@@ -253,36 +235,32 @@
   },
   {
     "graph": {
-      "group": "a12bc6ba-2e1f-55c1-8a46-2cd84ff41fbe",
+      "group": "9bf6d174-1f1d-5757-bbc9-f4b5a34020b9",
       "title": "snippets-in-tab5.md",
-      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "5c36001c-fd63-4b42-bb2e-e52fa318af25",
+            "key": "2c5c6359-a89b-4888-85f4-d395fee65fb1",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "9ebe1279-474e-433a-9aa0-ea38866fb360-10",
+                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-10",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: 9ebe1279-474e-433a-9aa0-ea38866fb360-10\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                     "title": "snippets-in-tab5.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "BBBoo\n\n```bash\necho XXX\n```\n",
-                    "group": "a12bc6ba-2e1f-55c1-8a46-2cd84ff41fbe",
+                    "group": "9bf6d174-1f1d-5757-bbc9-f4b5a34020b9",
                     "title": "Tab2",
                     "member": 1,
-                    "groupDetail": {
-                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                    }
+                    "groupDetail": {}
                   }
                 ]
               }
@@ -298,7 +276,7 @@
       "content": [
         {
           "title": "Tab2",
-          "group": "a12bc6ba-2e1f-55c1-8a46-2cd84ff41fbe",
+          "group": "9bf6d174-1f1d-5757-bbc9-f4b5a34020b9",
           "member": 1,
           "isFirstChoice": false
         }

--- a/test/inputs/7/wizard.json
+++ b/test/inputs/7/wizard.json
@@ -1,37 +1,34 @@
 [
   {
     "graph": {
-      "group": "32a107c6-9716-5d36-98a8-c214e5925efc",
+      "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
       "title": "DDD",
-      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "466355f6-2c77-4233-b2fd-34c9f65c7890",
+            "key": "fe75aff5-6edd-4334-8c61-12941cb81e5b",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-0",
+                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-0",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "32a107c6-9716-5d36-98a8-c214e5925efc",
+                    "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -40,24 +37,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-1",
+                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-1",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-0\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "32a107c6-9716-5d36-98a8-c214e5925efc",
+                    "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -66,24 +60,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-2",
+                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-2",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-2\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-0\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-1\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "32a107c6-9716-5d36-98a8-c214e5925efc",
+                    "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -95,30 +86,27 @@
         {
           "member": 1,
           "graph": {
-            "key": "72e97fb8-81cd-4b0c-8eb5-435a8b7cc0aa",
+            "key": "2c72e3b1-ecc3-43e9-bafc-6d3727dc6955",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-3",
+                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-3",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-2\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-3\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                    "group": "32a107c6-9716-5d36-98a8-c214e5925efc",
+                    "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-2\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -135,13 +123,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "32a107c6-9716-5d36-98a8-c214e5925efc",
+          "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "32a107c6-9716-5d36-98a8-c214e5925efc",
+          "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
           "member": 1,
           "isFirstChoice": true
         }
@@ -150,84 +138,78 @@
   },
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "key": "test/inputs/snippets/importa.md",
       "title": "importa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "b21940c8-03bc-4566-9469-b7e1c7163e67",
+        "key": "01554b00-19b0-4df7-b693-87e8c2550604",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-4",
+            "id": "71406f5f-4794-40f8-9d61-19fb384978a9-4",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                "key": "test/inputs/snippets/snippets-in-tab5.md",
                 "title": "snippets-in-tab5.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                "filepath": "test/inputs/snippets/snippets-in-tab5.md"
               },
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+                "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md"
+                "filepath": "test/inputs/snippets/importa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "dba285d4-9368-589a-9536-f0f760a079a0",
+      "group": "ab57d1e0-6ec9-515b-af70-6884738a3dc5",
       "title": "EEE",
-      "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    echo EEE\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "f4a86dcc-0ee1-4909-8110-8f9d5754c565",
+            "key": "7c1eaa4e-83bb-4987-89c9-afdca6f96782",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-5",
+                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-5",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                     "title": "snippets-in-tab5.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                   },
                   {
                     "kind": "Import",
-                    "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    \n    ---\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-5\n    \n    ---\n    echo EEE\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importe.md",
+                    "key": "test/inputs/snippets/importe.md",
                     "title": "EEE",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importe.md"
+                    "filepath": "test/inputs/snippets/importe.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "EEE1Content\n\n```bash\necho EEE\n```\n",
-                    "group": "dba285d4-9368-589a-9536-f0f760a079a0",
+                    "group": "ab57d1e0-6ec9-515b-af70-6884738a3dc5",
                     "title": "TabE1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "EEE",
-                      "source": "# EEE\n\n=== \"TabE1\"\n\n    EEE1Content\n    \n    ```bash\n    echo EEE\n    ```\n    \n"
+                      "title": "EEE"
                     }
                   }
                 ]
@@ -244,7 +226,7 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "dba285d4-9368-589a-9536-f0f760a079a0",
+          "group": "ab57d1e0-6ec9-515b-af70-6884738a3dc5",
           "member": 0,
           "isFirstChoice": false
         }
@@ -253,36 +235,32 @@
   },
   {
     "graph": {
-      "group": "c9d4e73e-f68b-5b3b-a7fd-dd95bb5f379d",
+      "group": "a527fcf9-fc02-5303-8423-fcce0c9c76a0",
       "title": "snippets-in-tab5.md",
-      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "8922cce2-38e6-446b-bd13-b3ddb68ab307",
+            "key": "f06b0afb-89df-4159-82ba-ee8bc55a6f7c",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-10",
+                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-10",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "\n\n# AAA\n\n=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    \n    ---\n    id: f5af1c6e-fb56-4f20-b73a-62b122fc1cb6-10\n    \n    ---\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n\n\nDDD\n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md",
+                    "key": "test/inputs/snippets/snippets-in-tab5.md",
                     "title": "snippets-in-tab5.md",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab5.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "BBBoo\n\n```bash\necho XXX\n```\n",
-                    "group": "c9d4e73e-f68b-5b3b-a7fd-dd95bb5f379d",
+                    "group": "a527fcf9-fc02-5303-8423-fcce0c9c76a0",
                     "title": "Tab2",
                     "member": 1,
-                    "groupDetail": {
-                      "source": "=== \"Tab1\"\n\n    imports:\n    \n    *   importd.md\n    \n    BBBoo\n    \n\n=== \"Tab2\"\n\n    BBBoo\n    \n    ```bash\n    echo XXX\n    ```\n    \n\n=== \"Tab3\"\n\n    imports:\n    \n    *   importd.md\n    \n    CCCoo\n    \n"
-                    }
+                    "groupDetail": {}
                   }
                 ]
               }
@@ -298,7 +276,7 @@
       "content": [
         {
           "title": "Tab2",
-          "group": "c9d4e73e-f68b-5b3b-a7fd-dd95bb5f379d",
+          "group": "a527fcf9-fc02-5303-8423-fcce0c9c76a0",
           "member": 1,
           "isFirstChoice": false
         }

--- a/test/inputs/8/wizard.json
+++ b/test/inputs/8/wizard.json
@@ -1,55 +1,49 @@
 [
   {
     "graph": {
-      "group": "31face60-7f1a-5749-9d5d-c345043ff278",
+      "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
       "title": "DDD",
-      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "937a5872-40fc-46aa-8021-c0d4f8b0a026",
+            "key": "52e6c9a3-8ecc-41ae-bdb9-16fd9e6a1dc2",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "f4b17d6a-5e5c-4101-9a20-1a56706a77a2-0",
+                "id": "56505fc9-b3a1-49f2-bdc4-943604ef543a-0",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# Chooser\n\n=== \"Tab1\"\n\n    \n\n=== \"Tab2\"\n\n    \n\n=== \"Tab3\"\n\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab6.md",
+                    "key": "test/inputs/snippets/snippets-in-tab6.md",
                     "title": "Chooser",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab6.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab6.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "",
-                    "group": "3fdc28c8-a618-5d26-baac-38bcbea80022",
+                    "group": "17be6164-ab89-59bc-97c5-19e920f88dd2",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "Chooser",
-                      "source": "# Chooser\n\n=== \"Tab1\"\n\n    \n\n=== \"Tab2\"\n\n    \n\n=== \"Tab3\"\n\n    \n"
+                      "title": "Chooser"
                     }
                   },
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "31face60-7f1a-5749-9d5d-c345043ff278",
+                    "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -58,42 +52,36 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "f4b17d6a-5e5c-4101-9a20-1a56706a77a2-1",
+                "id": "56505fc9-b3a1-49f2-bdc4-943604ef543a-1",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# Chooser\n\n=== \"Tab1\"\n\n    \n\n=== \"Tab2\"\n\n    \n\n=== \"Tab3\"\n\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab6.md",
+                    "key": "test/inputs/snippets/snippets-in-tab6.md",
                     "title": "Chooser",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab6.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab6.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "",
-                    "group": "3fdc28c8-a618-5d26-baac-38bcbea80022",
+                    "group": "17be6164-ab89-59bc-97c5-19e920f88dd2",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "Chooser",
-                      "source": "# Chooser\n\n=== \"Tab1\"\n\n    \n\n=== \"Tab2\"\n\n    \n\n=== \"Tab3\"\n\n    \n"
+                      "title": "Chooser"
                     }
                   },
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-0\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "31face60-7f1a-5749-9d5d-c345043ff278",
+                    "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -102,42 +90,36 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "f4b17d6a-5e5c-4101-9a20-1a56706a77a2-2",
+                "id": "56505fc9-b3a1-49f2-bdc4-943604ef543a-2",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# Chooser\n\n=== \"Tab1\"\n\n    \n\n=== \"Tab2\"\n\n    \n\n=== \"Tab3\"\n\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab6.md",
+                    "key": "test/inputs/snippets/snippets-in-tab6.md",
                     "title": "Chooser",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab6.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab6.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "",
-                    "group": "3fdc28c8-a618-5d26-baac-38bcbea80022",
+                    "group": "17be6164-ab89-59bc-97c5-19e920f88dd2",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "Chooser",
-                      "source": "# Chooser\n\n=== \"Tab1\"\n\n    \n\n=== \"Tab2\"\n\n    \n\n=== \"Tab3\"\n\n    \n"
+                      "title": "Chooser"
                     }
                   },
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-2\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-0\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-1\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "31face60-7f1a-5749-9d5d-c345043ff278",
+                    "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -149,48 +131,42 @@
         {
           "member": 1,
           "graph": {
-            "key": "543f058a-3484-45c2-b2dd-e2fcf9d98dd7",
+            "key": "376b001e-1a11-430c-9fa2-5053a627e977",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "f4b17d6a-5e5c-4101-9a20-1a56706a77a2-3",
+                "id": "56505fc9-b3a1-49f2-bdc4-943604ef543a-3",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# Chooser\n\n=== \"Tab1\"\n\n    \n\n=== \"Tab2\"\n\n    \n\n=== \"Tab3\"\n\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab6.md",
+                    "key": "test/inputs/snippets/snippets-in-tab6.md",
                     "title": "Chooser",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/snippets-in-tab6.md"
+                    "filepath": "test/inputs/snippets/snippets-in-tab6.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "",
-                    "group": "3fdc28c8-a618-5d26-baac-38bcbea80022",
+                    "group": "17be6164-ab89-59bc-97c5-19e920f88dd2",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "Chooser",
-                      "source": "# Chooser\n\n=== \"Tab1\"\n\n    \n\n=== \"Tab2\"\n\n    \n\n=== \"Tab3\"\n\n    \n"
+                      "title": "Chooser"
                     }
                   },
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-2\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-3\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                    "group": "31face60-7f1a-5749-9d5d-c345043ff278",
+                    "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n<!-- ____KUI_NESTED_TABS____ -->\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-0\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-1\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: f4b17d6a-5e5c-4101-9a20-1a56706a77a2-2\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -207,13 +183,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "31face60-7f1a-5749-9d5d-c345043ff278",
+          "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "31face60-7f1a-5749-9d5d-c345043ff278",
+          "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/9/wizard-darwin.json
+++ b/test/inputs/9/wizard-darwin.json
@@ -1,114 +1,106 @@
 [
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md",
+      "key": "test/inputs/snippets/importg.md",
       "title": "importg.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md",
+      "filepath": "test/inputs/snippets/importg.md",
       "graph": {
-        "key": "993705b5-80c8-4312-9f88-b3f32971445b",
+        "key": "d9b0bb55-2d44-44ef-9562-95b92c0e9e09",
         "sequence": [
           {
             "body": "echo MMM",
             "language": "bash",
-            "id": "7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-0",
+            "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-0",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md",
+                "key": "test/inputs/snippets/importg.md",
                 "title": "importg.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md"
+                "filepath": "test/inputs/snippets/importg.md"
               },
               {
                 "kind": "Choice",
-                "source": "```bash\necho MMM\n```\n",
                 "group": "org.kubernetes-sigs.kui/choice/platform",
                 "title": "Darwin",
                 "member": 0,
-                "groupDetail": {
-                  "source": "=== \"Darwin\"\n\n    ```bash\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
-                }
+                "groupDetail": {}
               }
             ]
           }
         ]
       },
-      "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importg.md",
       "description": "",
-      "content": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "key": "test/inputs/snippets/importa.md",
       "title": "importa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "f08e4884-c08c-47b6-9cdf-702b4e69227f",
+        "key": "da3a518c-5196-4d0c-ad51-0a1c0316303e",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-3",
+            "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-3",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+                "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md"
+                "filepath": "test/inputs/snippets/importa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "e3ad244c-dd51-544d-8f36-24d662513aed",
+      "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
       "title": "DDD",
-      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "52a3a31d-b588-44ad-9fd2-bde4131ffb1a",
+            "key": "e4cced3b-e116-43b3-a741-c3d5f479808d",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-4",
+                "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-4",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "e3ad244c-dd51-544d-8f36-24d662513aed",
+                    "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -117,24 +109,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-5",
+                "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-5",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-4\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "e3ad244c-dd51-544d-8f36-24d662513aed",
+                    "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -143,24 +132,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-6",
+                "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-6",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-4\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-5\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "e3ad244c-dd51-544d-8f36-24d662513aed",
+                    "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -172,30 +158,27 @@
         {
           "member": 1,
           "graph": {
-            "key": "404620d8-c674-4d25-a6a6-9562b83c4f5e",
+            "key": "91ee3c51-cad2-43b7-b6e6-79d375dabfd2",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-7",
+                "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-7",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-7\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                    "group": "e3ad244c-dd51-544d-8f36-24d662513aed",
+                    "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: 7374c4b5-d5bf-4aca-909d-82a6c5c97f9b-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -212,13 +195,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "e3ad244c-dd51-544d-8f36-24d662513aed",
+          "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "e3ad244c-dd51-544d-8f36-24d662513aed",
+          "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/9/wizard-linux.json
+++ b/test/inputs/9/wizard-linux.json
@@ -1,114 +1,106 @@
 [
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md",
+      "key": "test/inputs/snippets/importg.md",
       "title": "importg.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md",
+      "filepath": "test/inputs/snippets/importg.md",
       "graph": {
-        "key": "bbf437e6-70ed-4b12-84e6-6a177d803ab6",
+        "key": "39b1c78f-6ed0-4149-8295-ef64de5377f1",
         "sequence": [
           {
             "body": "echo LLL",
             "language": "bash",
-            "id": "e07b5262-0011-41a8-b914-672d80f98669-1",
+            "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-1",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: e07b5262-0011-41a8-b914-672d80f98669-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    \n    ---\n    id: e07b5262-0011-41a8-b914-672d80f98669-1\n    \n    ---\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md",
+                "key": "test/inputs/snippets/importg.md",
                 "title": "importg.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md"
+                "filepath": "test/inputs/snippets/importg.md"
               },
               {
                 "kind": "Choice",
-                "source": "```bash\necho LLL\n```\n",
                 "group": "org.kubernetes-sigs.kui/choice/platform",
                 "title": "Linux",
                 "member": 1,
-                "groupDetail": {
-                  "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: e07b5262-0011-41a8-b914-672d80f98669-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
-                }
+                "groupDetail": {}
               }
             ]
           }
         ]
       },
-      "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: e07b5262-0011-41a8-b914-672d80f98669-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importg.md",
       "description": "",
-      "content": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: e07b5262-0011-41a8-b914-672d80f98669-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "key": "test/inputs/snippets/importa.md",
       "title": "importa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "b00a65c7-9ae1-4309-bf78-2ff5964ff604",
+        "key": "90b58445-afcf-492d-bc44-4c9146c776be",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "e07b5262-0011-41a8-b914-672d80f98669-3",
+            "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-3",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+                "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md"
+                "filepath": "test/inputs/snippets/importa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "6000f823-83e2-5365-927d-ebcea757cd67",
+      "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
       "title": "DDD",
-      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "2158d25a-e675-4190-afaf-1ee6884b0563",
+            "key": "c18823f1-fe15-4707-b63a-e54619b909a3",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "e07b5262-0011-41a8-b914-672d80f98669-4",
+                "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-4",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "6000f823-83e2-5365-927d-ebcea757cd67",
+                    "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -117,24 +109,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "e07b5262-0011-41a8-b914-672d80f98669-5",
+                "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-5",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: e07b5262-0011-41a8-b914-672d80f98669-4\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "6000f823-83e2-5365-927d-ebcea757cd67",
+                    "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -143,24 +132,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "e07b5262-0011-41a8-b914-672d80f98669-6",
+                "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-6",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: e07b5262-0011-41a8-b914-672d80f98669-4\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: e07b5262-0011-41a8-b914-672d80f98669-5\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "6000f823-83e2-5365-927d-ebcea757cd67",
+                    "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -172,30 +158,27 @@
         {
           "member": 1,
           "graph": {
-            "key": "9c497bf7-fc98-4c31-8861-333bc820ebae",
+            "key": "b46ba6cf-4c5f-4022-8318-58284b7b9f18",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "e07b5262-0011-41a8-b914-672d80f98669-7",
+                "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-7",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: e07b5262-0011-41a8-b914-672d80f98669-7\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                    "group": "6000f823-83e2-5365-927d-ebcea757cd67",
+                    "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: e07b5262-0011-41a8-b914-672d80f98669-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -212,13 +195,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "6000f823-83e2-5365-927d-ebcea757cd67",
+          "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "6000f823-83e2-5365-927d-ebcea757cd67",
+          "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/9/wizard-win32.json
+++ b/test/inputs/9/wizard-win32.json
@@ -1,114 +1,106 @@
 [
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md",
+      "key": "test/inputs/snippets/importg.md",
       "title": "importg.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md",
+      "filepath": "test/inputs/snippets/importg.md",
       "graph": {
-        "key": "2eb6bd45-dc40-4e0e-a3fb-696b9f345e0c",
+        "key": "9d9d1ab7-51d1-4a2f-bd11-4c628ed07f83",
         "sequence": [
           {
             "body": "echo WWW",
             "language": "bash",
-            "id": "d1217113-32e9-40f3-98c1-2a025d9fe8f0-2",
+            "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-2",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    \n    ---\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-1\n    \n    ---\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    \n    ---\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-2\n    \n    ---\n    echo WWW\n    ```\n    \n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md",
+                "key": "test/inputs/snippets/importg.md",
                 "title": "importg.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importg.md"
+                "filepath": "test/inputs/snippets/importg.md"
               },
               {
                 "kind": "Choice",
-                "source": "```bash\necho WWW\n```\n",
                 "group": "org.kubernetes-sigs.kui/choice/platform",
                 "title": "Win32",
                 "member": 2,
-                "groupDetail": {
-                  "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    \n    ---\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-1\n    \n    ---\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
-                }
+                "groupDetail": {}
               }
             ]
           }
         ]
       },
-      "source": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importg.md",
       "description": "",
-      "content": "=== \"Darwin\"\n\n    ```bash\n    \n    ---\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-0\n    \n    ---\n    echo MMM\n    ```\n    \n\n=== \"Linux\"\n\n    ```bash\n    echo LLL\n    ```\n    \n\n=== \"Win32\"\n\n    ```bash\n    echo WWW\n    ```\n    \n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "key": "test/inputs/snippets/importa.md",
       "title": "importa.md",
       "description": "",
-      "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+      "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "db485b01-4ee1-4dec-8bf6-52b60cb5d43d",
+        "key": "e778754f-e5f9-4750-b253-961c6a34aa3b",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "d1217113-32e9-40f3-98c1-2a025d9fe8f0-3",
+            "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-3",
             "nesting": [
               {
                 "kind": "Import",
-                "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md",
+                "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
-                "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importa.md"
+                "filepath": "test/inputs/snippets/importa.md"
               }
             ]
           }
         ]
       },
-      "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "source": "placeholder"
     },
     "step": {
       "name": "importa.md",
       "description": "",
-      "content": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n"
+      "content": ""
     }
   },
   {
     "graph": {
-      "group": "07a563c6-9591-5321-83dd-b1d23739cc73",
+      "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
       "title": "DDD",
-      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
+      "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "16308fdb-ff48-4761-9f27-ace7c09ee42b",
+            "key": "a66b8870-8847-4477-a5fa-d9d8aa37652b",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "d1217113-32e9-40f3-98c1-2a025d9fe8f0-4",
+                "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-4",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "07a563c6-9591-5321-83dd-b1d23739cc73",
+                    "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -117,24 +109,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "d1217113-32e9-40f3-98c1-2a025d9fe8f0-5",
+                "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-5",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: d1217113-32e9-40f3-98c1-2a025d9fe8f0-4\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "07a563c6-9591-5321-83dd-b1d23739cc73",
+                    "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -143,24 +132,21 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "d1217113-32e9-40f3-98c1-2a025d9fe8f0-6",
+                "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-6",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n\n---\nvalidate: true\nid: d1217113-32e9-40f3-98c1-2a025d9fe8f0-4\n\n---\necho AAA\n```\n\n```bash\n\n---\nvalidate: true\nid: d1217113-32e9-40f3-98c1-2a025d9fe8f0-5\n\n---\necho AAA\n```\n\n```bash\n---\nvalidate: true\n---\necho AAA\n```\n",
-                    "group": "07a563c6-9591-5321-83dd-b1d23739cc73",
+                    "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    ---\n    validate: true\n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -172,30 +158,27 @@
         {
           "member": 1,
           "graph": {
-            "key": "ea759c69-c65f-4170-9e8f-708673b30f7b",
+            "key": "8a7025a6-da41-4150-b2d4-4eb8be9dd616",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "d1217113-32e9-40f3-98c1-2a025d9fe8f0-7",
+                "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-7",
                 "nesting": [
                   {
                     "kind": "Import",
-                    "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    \n    ---\n    validate: false\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-7\n    \n    ---\n    echo BBB\n    ```\n    \n",
-                    "key": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md",
+                    "key": "test/inputs/snippets/importd.md",
                     "title": "DDD",
-                    "filepath": "/Users/nickm/git/guidebooks/madwizard/test/inputs/snippets/importd.md"
+                    "filepath": "test/inputs/snippets/importd.md"
                   },
                   {
                     "kind": "Choice",
-                    "source": "```bash\n---\nvalidate: false\n---\necho BBB\n```\n",
-                    "group": "07a563c6-9591-5321-83dd-b1d23739cc73",
+                    "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
-                      "title": "DDD",
-                      "source": "# DDD\n\n=== \"SubTab1\"\n\n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-4\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-5\n    \n    ---\n    echo AAA\n    ```\n    \n    ```bash\n    \n    ---\n    validate: true\n    id: d1217113-32e9-40f3-98c1-2a025d9fe8f0-6\n    \n    ---\n    echo AAA\n    ```\n    \n\n=== \"SubTab2\"\n\n    ```bash\n    ---\n    validate: false\n    ---\n    echo BBB\n    ```\n    \n"
+                      "title": "DDD"
                     }
                   }
                 ]
@@ -212,13 +195,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "07a563c6-9591-5321-83dd-b1d23739cc73",
+          "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "07a563c6-9591-5321-83dd-b1d23739cc73",
+          "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -33,6 +33,8 @@ function munge(wizard: Awaited<ReturnType<typeof main>>["wizard"]) {
     JSON.stringify(wizard, (key, value) => {
       if (key === "group" || key === "id" || key === "key" || key === "filepath") {
         return "fakeit"
+      } else if (key === "source" && (typeof value === "function" || typeof value === "undefined")) {
+        return "placeholder"
       } else if (key === "source" || (key === "content" && typeof value === "string")) {
         return value.replace(/(id): [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(-\d+)?/g, "$1: fakeid")
       } else {


### PR DESCRIPTION
These are very expensive, and not needed for most guide use case?