### PR TITLE
feat: tree model should include optional blocks

### DIFF
--- a/src/fe/tree/index.ts
+++ b/src/fe/tree/index.ts
@@ -256,7 +256,8 @@ export class Treeifier<Content> {
               .map((_) => _.replace(/#.*/, ""))
               .filter(Boolean)[0]
               .trim()
-              .slice(0, 30)
+              .slice(0, 30),
+            graph.optional
           ),
         },
       ]
@@ -290,7 +291,7 @@ export class Treeifier<Content> {
         return this.treeModelForChoice(graph, idPrefix, depth)
       } else if (isSubTask(graph)) {
         return this.treeModelForSubTask(graph, depth, metFirstChoice)
-      } else if (!graph.optional) {
+      } else {
         return this.treeModelForLeafNode(graph)
       }
     } finally {

--- a/src/fe/tree/ui.ts
+++ b/src/fe/tree/ui.ts
@@ -21,7 +21,7 @@ export type Decoration = Modifiers | Color
 
 export interface UI<Content> {
   span(body: string, ...decorations: Decoration[]): Content
-  code(body: string): Content
+  code(body: string, optional?: boolean): Content
   icon(cls: string): Content
   statusToIcon(status: Status): Content
   title(title: Content | string | (Content | string)[], status?: Status): Content
@@ -59,8 +59,12 @@ export class AnsiUI implements UI<string> {
     }
   }
 
-  public code(body: string) {
-    return chalk.magenta(body)
+  public code(body: string, optional = false) {
+    if (optional) {
+      return chalk.magenta.dim(body + " [OPTIONAL]")
+    } else {
+      return chalk.magenta(body)
+    }
   }
 
   public icon(cls: string) {


### PR DESCRIPTION
They are currently completely excluded from the tree model. This should be a UI decision, of if and how to display optional code blocks.