### PR TITLE
fix: improve handling of markdown content that does not use wizards

### DIFF
--- a/src/codeblock/CodeBlockProps.ts
+++ b/src/codeblock/CodeBlockProps.ts
@@ -108,9 +108,14 @@ export interface CodeBlockProps {
   nesting?: CodeBlockNestingParent[]
 }
 
-export function addNesting(props: CodeBlockProps, nesting: CodeBlockNestingParent) {
+export function addNesting(props: CodeBlockProps, nesting: CodeBlockNestingParent, insertIdx?: number) {
   if (!props.nesting) {
     props.nesting = []
   }
-  props.nesting.push(nesting)
+
+  if (typeof insertIdx === "number") {
+    props.nesting.splice(insertIdx, 0, nesting)
+  } else {
+    props.nesting.push(nesting)
+  }
 }

--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -84,7 +84,9 @@ export async function cli<Writer extends (msg: string) => boolean>(argv: string[
       case "json": {
         const graph = compile(blocks, choices)
         const wizard = wizardify(graph)
-        console.log(JSON.stringify(wizard, (key, value) => (key === "source" ? "placeholder" : value), 2))
+        console.log(
+          JSON.stringify(wizard, (key, value) => (key === "source" || key === "position" ? "placeholder" : value), 2)
+        )
         break
       }
 

--- a/src/parser/markdown/rehype-tip/index.ts
+++ b/src/parser/markdown/rehype-tip/index.ts
@@ -36,7 +36,7 @@ export function getTipTitle(elt: Element) {
 }
 
 export function isTipWithFullTitle(node: Node): node is Element {
-  return isTip(node) && !!node.properties.fullTitle
+  return isTip(node) && !!node.properties.hasFullTitle
 }
 
 export function isTipWithoutFullTitle(node: Node): node is Element {

--- a/src/parser/markdown/rehype-wizard.ts
+++ b/src/parser/markdown/rehype-wizard.ts
@@ -87,8 +87,14 @@ function removedHeading() {
   return u("raw", REMOVED_HEADING_PLACEHOLDER_TEXT)
 }
 
-export function isHeading(node: Content) {
+export function isHeading(node: Content): node is Element {
   return isElementWithProperties(node) && /^h\d+$/.test(node.tagName)
+}
+
+export function getHeadingLevel(node: Content): number {
+  if (isHeading(node)) {
+    return parseInt(node.tagName.slice(1), 10)
+  }
 }
 
 export function isHeadingOrRemovedHeading(node: Content) {

--- a/src/parser/markdown/util/isElement.ts
+++ b/src/parser/markdown/util/isElement.ts
@@ -15,15 +15,23 @@
  */
 
 import { Node, Parent } from "unist"
-import { Element, ElementContent } from "hast"
+import { Element, ElementContent, Root } from "hast"
 
 export function isParent(node: Node): node is Parent {
   return Array.isArray((node as Parent).children)
 }
 
+export function isRoot(node: Node): node is Root {
+  return (node as Root).type === "root"
+}
+
 export function isElement(_: Node | Parent | ElementContent): _ is Element {
   const elt = _ as Element
   return elt && typeof elt.tagName === "string"
+}
+
+export function hasContentChildren(node: Node): node is Element | Root {
+  return isElement(node) || isRoot(node)
 }
 
 export default function isElementWithProperties(_: Element | ElementContent | Parent | Node): _ is Element {

--- a/test/inputs/1/wizard.json
+++ b/test/inputs/1/wizard.json
@@ -1,22 +1,22 @@
 [
   {
     "graph": {
-      "group": "aff787ef-5b66-5fd9-a6a4-93eb35b8fee9",
+      "group": "18f9d4dc-7aab-5906-869a-ede097e1932e",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "5eb6201e-7240-495f-9ce3-c83829423e86",
+            "key": "8c39a6fb-6f9c-40d1-8b1d-2f4218d0bd6b",
             "sequence": [
               {
                 "body": "echo 111",
                 "language": "bash",
-                "id": "4ee8d971-d984-49a7-b3eb-675d9df86ae5-0",
+                "id": "917f44fe-e50e-4520-ae17-c0f7871bd11d-0",
                 "nesting": [
                   {
                     "kind": "Choice",
-                    "group": "aff787ef-5b66-5fd9-a6a4-93eb35b8fee9",
+                    "group": "18f9d4dc-7aab-5906-869a-ede097e1932e",
                     "title": "Tab1Title",
                     "member": 0,
                     "groupDetail": {}
@@ -30,16 +30,16 @@
         {
           "member": 1,
           "graph": {
-            "key": "2f703e00-bcd9-4561-9324-a9b64e088021",
+            "key": "badd00bb-fb81-4421-b0de-e41c560ac123",
             "sequence": [
               {
                 "body": "echo 222",
                 "language": "bash",
-                "id": "4ee8d971-d984-49a7-b3eb-675d9df86ae5-1",
+                "id": "917f44fe-e50e-4520-ae17-c0f7871bd11d-1",
                 "nesting": [
                   {
                     "kind": "Choice",
-                    "group": "aff787ef-5b66-5fd9-a6a4-93eb35b8fee9",
+                    "group": "18f9d4dc-7aab-5906-869a-ede097e1932e",
                     "title": "Tab2Title",
                     "member": 1,
                     "groupDetail": {}
@@ -57,13 +57,13 @@
       "content": [
         {
           "title": "Tab1Title",
-          "group": "aff787ef-5b66-5fd9-a6a4-93eb35b8fee9",
+          "group": "18f9d4dc-7aab-5906-869a-ede097e1932e",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "Tab2Title",
-          "group": "aff787ef-5b66-5fd9-a6a4-93eb35b8fee9",
+          "group": "18f9d4dc-7aab-5906-869a-ede097e1932e",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/10/wizard-darwin.json
+++ b/test/inputs/10/wizard-darwin.json
@@ -6,12 +6,12 @@
       "description": "",
       "filepath": "test/inputs/snippets/importgg.md",
       "graph": {
-        "key": "75cf7462-f800-4368-b40f-8dfd021fea47",
+        "key": "34f56098-95c1-4a07-b2c5-f97464423e73",
         "sequence": [
           {
             "body": "echo MMM",
             "language": "bash",
-            "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-0",
+            "id": "450d496d-3657-4abc-8956-26d17749e886-0",
             "nesting": [
               {
                 "kind": "Import",
@@ -45,13 +45,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "c640c065-e606-4908-9bcf-ea9b78a56a12",
+        "key": "d11bd1c5-1720-4bbf-b5d3-5060dab2fc6e",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-3",
+            "id": "450d496d-3657-4abc-8956-26d17749e886-3",
             "nesting": [
               {
                 "kind": "Import",
@@ -73,20 +73,20 @@
   },
   {
     "graph": {
-      "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
+      "group": "adfc59b1-d31b-5cd2-97a5-d000427e3528",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "3539d3c2-b3e2-4159-af76-882f8572df29",
+            "key": "422e9114-5411-45cc-946a-b68a49eef39b",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-4",
+                "id": "450d496d-3657-4abc-8956-26d17749e886-4",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -96,10 +96,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
+                    "group": "adfc59b1-d31b-5cd2-97a5-d000427e3528",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1352
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1355
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1350
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1355
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -109,7 +145,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-5",
+                "id": "450d496d-3657-4abc-8956-26d17749e886-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -119,10 +155,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
+                    "group": "adfc59b1-d31b-5cd2-97a5-d000427e3528",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1352
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1355
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1350
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1355
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -132,7 +204,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-6",
+                "id": "450d496d-3657-4abc-8956-26d17749e886-6",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -142,10 +214,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
+                    "group": "adfc59b1-d31b-5cd2-97a5-d000427e3528",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1352
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1355
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1350
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1355
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -158,13 +266,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "9aa33492-3eae-4e37-83d3-3720ef34d5b9",
+            "key": "8d2fe153-229d-44c1-bb87-5235fe95633b",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "aef6cecb-01ec-44a6-8848-70f2a0b09584-7",
+                "id": "450d496d-3657-4abc-8956-26d17749e886-7",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -174,10 +282,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
+                    "group": "adfc59b1-d31b-5cd2-97a5-d000427e3528",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1352
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1355
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1350
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1355
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -195,13 +339,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
+          "group": "adfc59b1-d31b-5cd2-97a5-d000427e3528",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "151cd64a-d80a-5187-bd18-eeb50c4bc423",
+          "group": "adfc59b1-d31b-5cd2-97a5-d000427e3528",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/10/wizard-linux.json
+++ b/test/inputs/10/wizard-linux.json
@@ -6,12 +6,12 @@
       "description": "",
       "filepath": "test/inputs/snippets/importgg.md",
       "graph": {
-        "key": "d82af8d0-fcfb-413e-bb86-61f2a30ac802",
+        "key": "2aca0714-e6f7-42a6-b796-216fb734cda5",
         "sequence": [
           {
             "body": "echo LLL",
             "language": "bash",
-            "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-1",
+            "id": "4509c2fe-43aa-4dbc-a0e7-db6dd8cec6fb-1",
             "nesting": [
               {
                 "kind": "Import",
@@ -45,13 +45,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "34178019-5aa2-4ead-830f-11cd0bcd1f96",
+        "key": "f9e764ac-975d-44e1-bd5d-d327bd8835cf",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-3",
+            "id": "4509c2fe-43aa-4dbc-a0e7-db6dd8cec6fb-3",
             "nesting": [
               {
                 "kind": "Import",
@@ -73,20 +73,20 @@
   },
   {
     "graph": {
-      "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
+      "group": "56a36329-9780-591f-a98f-34e6d7344ad4",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "58b69b96-ac48-4e0a-b5e4-c5d2bf37d860",
+            "key": "2dc93765-e061-440c-9608-3d18a0b31d5a",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-4",
+                "id": "4509c2fe-43aa-4dbc-a0e7-db6dd8cec6fb-4",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -96,10 +96,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
+                    "group": "56a36329-9780-591f-a98f-34e6d7344ad4",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1352
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1355
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1350
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1355
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -109,7 +145,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-5",
+                "id": "4509c2fe-43aa-4dbc-a0e7-db6dd8cec6fb-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -119,10 +155,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
+                    "group": "56a36329-9780-591f-a98f-34e6d7344ad4",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1352
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1355
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1350
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1355
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -132,7 +204,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-6",
+                "id": "4509c2fe-43aa-4dbc-a0e7-db6dd8cec6fb-6",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -142,10 +214,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
+                    "group": "56a36329-9780-591f-a98f-34e6d7344ad4",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1352
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1355
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1350
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1355
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -158,13 +266,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "503ef61b-31c0-4668-87cb-734b7f93c784",
+            "key": "ae18b5ba-4bc4-4153-af46-b77db55e8420",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "5eeecd25-5387-4c1e-8712-0cb4874457e8-7",
+                "id": "4509c2fe-43aa-4dbc-a0e7-db6dd8cec6fb-7",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -174,10 +282,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
+                    "group": "56a36329-9780-591f-a98f-34e6d7344ad4",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1352
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1355
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1350
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1355
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -195,13 +339,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
+          "group": "56a36329-9780-591f-a98f-34e6d7344ad4",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "181b6342-91f7-5e96-aad4-ffdeafb20cd5",
+          "group": "56a36329-9780-591f-a98f-34e6d7344ad4",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/10/wizard-win32.json
+++ b/test/inputs/10/wizard-win32.json
@@ -6,12 +6,12 @@
       "description": "",
       "filepath": "test/inputs/snippets/importgg.md",
       "graph": {
-        "key": "d3b4de93-62c6-4cf8-bcd5-8165786b8906",
+        "key": "f49dabec-0810-42de-8257-5518a618198c",
         "sequence": [
           {
-            "body": "echo WWW",
+            "body": "echo MMM",
             "language": "bash",
-            "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-2",
+            "id": "ab514305-1039-455c-96bc-d13f5a3ea130-0",
             "nesting": [
               {
                 "kind": "Import",
@@ -22,8 +22,8 @@
               {
                 "kind": "Choice",
                 "group": "org.kubernetes-sigs.kui/choice/platform",
-                "title": "Win32",
-                "member": 2,
+                "title": "Darwin",
+                "member": 0,
                 "groupDetail": {}
               }
             ]
@@ -45,13 +45,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "8429616b-907b-4ab1-badf-dbc5bd5818f7",
+        "key": "bd9f14b4-8349-4d62-bcf3-91398c682726",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-3",
+            "id": "ab514305-1039-455c-96bc-d13f5a3ea130-3",
             "nesting": [
               {
                 "kind": "Import",
@@ -73,20 +73,20 @@
   },
   {
     "graph": {
-      "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
+      "group": "31542e56-6247-5c42-9c9c-b10069f15e41",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "2cfd922c-fb20-4fd9-8798-97318030fccf",
+            "key": "83f97d3d-caec-4f45-baba-2fefe19c32e7",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-4",
+                "id": "ab514305-1039-455c-96bc-d13f5a3ea130-4",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -96,10 +96,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
+                    "group": "31542e56-6247-5c42-9c9c-b10069f15e41",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -109,7 +123,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-5",
+                "id": "ab514305-1039-455c-96bc-d13f5a3ea130-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -119,10 +133,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
+                    "group": "31542e56-6247-5c42-9c9c-b10069f15e41",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -132,7 +160,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-6",
+                "id": "ab514305-1039-455c-96bc-d13f5a3ea130-6",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -142,10 +170,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
+                    "group": "31542e56-6247-5c42-9c9c-b10069f15e41",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -158,13 +200,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "a1eda799-10f4-4120-8538-f3256efe5ff1",
+            "key": "a2b91d71-b36f-4ae1-b6cf-953cc909a461",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "87bc3123-e656-4272-91eb-cc4e29ec02b2-7",
+                "id": "ab514305-1039-455c-96bc-d13f5a3ea130-7",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -174,10 +216,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
+                    "group": "31542e56-6247-5c42-9c9c-b10069f15e41",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -195,13 +251,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
+          "group": "31542e56-6247-5c42-9c9c-b10069f15e41",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "13dea497-2a9c-5ec6-96ba-03e3a82d1fb4",
+          "group": "31542e56-6247-5c42-9c9c-b10069f15e41",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/3/wizard.json
+++ b/test/inputs/3/wizard.json
@@ -6,13 +6,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "983ba647-3f46-4e1e-8e03-0a89abf02ac7",
+        "key": "c72b9cee-5f67-4e66-88e5-5e78a244cc31",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-0",
+            "id": "9618639d-9c5c-4a21-bd32-a0e66e230f73-0",
             "nesting": [
               {
                 "kind": "Import",
@@ -40,19 +40,19 @@
   },
   {
     "graph": {
-      "group": "665ed6b2-d77f-52ca-9bf4-c45e96a9e612",
+      "group": "c1e9157a-eae5-530f-a439-8219170a59be",
       "title": "EEE",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "f93f6091-08dd-4b6c-903c-2fd9f623610d",
+            "key": "a67e79f5-1e90-426b-bbc0-df67249c257b",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-1",
+                "id": "9618639d-9c5c-4a21-bd32-a0e66e230f73-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -68,10 +68,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "665ed6b2-d77f-52ca-9bf4-c45e96a9e612",
+                    "group": "c1e9157a-eae5-530f-a439-8219170a59be",
                     "title": "TabE1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "EEE",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "EEE"
                     }
                   }
@@ -89,7 +103,7 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "665ed6b2-d77f-52ca-9bf4-c45e96a9e612",
+          "group": "c1e9157a-eae5-530f-a439-8219170a59be",
           "member": 0,
           "isFirstChoice": true
         }
@@ -98,20 +112,20 @@
   },
   {
     "graph": {
-      "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
+      "group": "b4512cb0-da4f-5f3e-8752-47599534d0a9",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "1542e2d9-a39e-4001-8064-4a5ca5aff15c",
+            "key": "dc41b3b6-cdb4-4f30-b6e2-3c10c8a32516",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-2",
+                "id": "9618639d-9c5c-4a21-bd32-a0e66e230f73-2",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -133,10 +147,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
+                    "group": "b4512cb0-da4f-5f3e-8752-47599534d0a9",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -146,7 +174,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-3",
+                "id": "9618639d-9c5c-4a21-bd32-a0e66e230f73-3",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -168,10 +196,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
+                    "group": "b4512cb0-da4f-5f3e-8752-47599534d0a9",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -181,7 +223,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-4",
+                "id": "9618639d-9c5c-4a21-bd32-a0e66e230f73-4",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -203,10 +245,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
+                    "group": "b4512cb0-da4f-5f3e-8752-47599534d0a9",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -219,13 +275,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "c812ae1e-2bd3-4ac5-8a69-acec46e16e90",
+            "key": "f8f429d2-278d-4d57-8188-f08efcf5e4fd",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-5",
+                "id": "9618639d-9c5c-4a21-bd32-a0e66e230f73-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -247,10 +303,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
+                    "group": "b4512cb0-da4f-5f3e-8752-47599534d0a9",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -268,13 +338,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
+          "group": "b4512cb0-da4f-5f3e-8752-47599534d0a9",
           "member": 0,
           "isFirstChoice": false
         },
         {
           "title": "SubTab2",
-          "group": "b929475a-cd0a-5954-921c-cbade11fcb90",
+          "group": "b4512cb0-da4f-5f3e-8752-47599534d0a9",
           "member": 1,
           "isFirstChoice": false
         }
@@ -283,14 +353,14 @@
   },
   {
     "graph": {
-      "group": "dc8ba323-49e8-5421-8189-21303fbc4a22",
+      "group": "67463669-9837-5d30-bcc8-9b5fb506b021",
       "title": "Main Tasks",
       "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "b54bf381-89fa-49c0-b155-dbf7989daf59",
+            "key": "19bd3aee-30a2-4eab-82a4-540992cae9c1",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importc.md",
@@ -298,13 +368,13 @@
                 "description": "",
                 "filepath": "test/inputs/snippets/importc.md",
                 "graph": {
-                  "key": "6e365160-d306-463c-be9d-24ef2c95bc96",
+                  "key": "1b30e51a-c94a-48f1-9819-467b39c279cf",
                   "sequence": [
                     {
                       "body": "echo CCC",
                       "language": "bash",
                       "validate": true,
-                      "id": "2fbc14dd-3cc6-4c2d-bd48-41fe92263faa-10",
+                      "id": "9618639d-9c5c-4a21-bd32-a0e66e230f73-10",
                       "nesting": [
                         {
                           "kind": "Import",
@@ -314,7 +384,7 @@
                         },
                         {
                           "kind": "Choice",
-                          "group": "dc8ba323-49e8-5421-8189-21303fbc4a22",
+                          "group": "67463669-9837-5d30-bcc8-9b5fb506b021",
                           "title": "Tab2",
                           "description": "imports:\n",
                           "member": 1,
@@ -345,7 +415,7 @@
       "content": [
         {
           "title": "Tab2",
-          "group": "dc8ba323-49e8-5421-8189-21303fbc4a22",
+          "group": "67463669-9837-5d30-bcc8-9b5fb506b021",
           "member": 1,
           "isFirstChoice": false,
           "description": "imports:\n"

--- a/test/inputs/4/wizard.json
+++ b/test/inputs/4/wizard.json
@@ -6,13 +6,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "988305c0-7d19-4b31-aa0f-8168795da502",
+        "key": "f349b794-84db-4d2e-bfc0-af9e20380fe4",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-0",
+            "id": "20496a1b-e1b9-4f3f-9b7b-ea90332203d5-0",
             "nesting": [
               {
                 "kind": "Import",
@@ -40,19 +40,19 @@
   },
   {
     "graph": {
-      "group": "c8839442-2f89-53df-9b9a-09266fa2f943",
+      "group": "bcbfaafe-1dbf-5b4a-b900-e8804911fce8",
       "title": "EEE",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "9eca0bd4-c456-44ca-b2f5-b9e3b626cf1d",
+            "key": "208c92bc-9068-49d3-a998-cebde51da889",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-1",
+                "id": "20496a1b-e1b9-4f3f-9b7b-ea90332203d5-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -68,10 +68,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "c8839442-2f89-53df-9b9a-09266fa2f943",
+                    "group": "bcbfaafe-1dbf-5b4a-b900-e8804911fce8",
                     "title": "TabE1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "EEE",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "EEE"
                     }
                   }
@@ -89,7 +103,7 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "c8839442-2f89-53df-9b9a-09266fa2f943",
+          "group": "bcbfaafe-1dbf-5b4a-b900-e8804911fce8",
           "member": 0,
           "isFirstChoice": true
         }
@@ -98,14 +112,14 @@
   },
   {
     "graph": {
-      "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
+      "group": "ea37e5db-3d05-52ef-a7fc-c921c9755593",
       "title": "Main Tasks",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "68a5f282-2f9d-4cb5-953e-3d45d0780b80",
+            "key": "0dc04ee4-b5cb-428c-ab73-febb7a03103b",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
@@ -113,23 +127,23 @@
                 "description": "",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "a5e42ef1-37a1-4352-8cfe-2b7c72a3ab07",
+                  "key": "3aa68724-8c2e-4d6c-9797-f2e29a734f38",
                   "sequence": [
                     {
-                      "group": "3e96a744-4524-51bb-bef6-9d212184c9cd",
+                      "group": "b7371bd8-1a61-558e-a766-4f6dd3dc09f6",
                       "title": "DDD",
                       "source": "placeholder",
                       "choices": [
                         {
                           "member": 0,
                           "graph": {
-                            "key": "f35601b7-4e68-4895-871f-91dd0861b552",
+                            "key": "d2185d20-4d53-459b-813c-b9e302ce6181",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-2",
+                                "id": "20496a1b-e1b9-4f3f-9b7b-ea90332203d5-2",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -139,7 +153,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
+                                    "group": "ea37e5db-3d05-52ef-a7fc-c921c9755593",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -153,10 +167,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "3e96a744-4524-51bb-bef6-9d212184c9cd",
+                                    "group": "b7371bd8-1a61-558e-a766-4f6dd3dc09f6",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -166,7 +194,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-3",
+                                "id": "20496a1b-e1b9-4f3f-9b7b-ea90332203d5-3",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -176,7 +204,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
+                                    "group": "ea37e5db-3d05-52ef-a7fc-c921c9755593",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -190,10 +218,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "3e96a744-4524-51bb-bef6-9d212184c9cd",
+                                    "group": "b7371bd8-1a61-558e-a766-4f6dd3dc09f6",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -203,7 +245,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-4",
+                                "id": "20496a1b-e1b9-4f3f-9b7b-ea90332203d5-4",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -213,7 +255,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
+                                    "group": "ea37e5db-3d05-52ef-a7fc-c921c9755593",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -227,10 +269,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "3e96a744-4524-51bb-bef6-9d212184c9cd",
+                                    "group": "b7371bd8-1a61-558e-a766-4f6dd3dc09f6",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -243,13 +299,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "6bbe8ecb-edc2-4230-a747-b06dbc23209a",
+                            "key": "0c54c132-d125-4a01-9f74-b1d156f9eedb",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-5",
+                                "id": "20496a1b-e1b9-4f3f-9b7b-ea90332203d5-5",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -259,7 +315,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
+                                    "group": "ea37e5db-3d05-52ef-a7fc-c921c9755593",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -273,10 +329,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "3e96a744-4524-51bb-bef6-9d212184c9cd",
+                                    "group": "b7371bd8-1a61-558e-a766-4f6dd3dc09f6",
                                     "title": "SubTab2",
                                     "member": 1,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -300,12 +370,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "18fcbfc6-48d2-4502-bacd-7d686eb4e499",
+            "key": "04dfa5fd-e9fd-4c01-a5ff-7f647d5e3bfa",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "5883d249-64f8-4c59-bec1-863dbc4beac7-6",
+                "id": "20496a1b-e1b9-4f3f-9b7b-ea90332203d5-6",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -315,7 +385,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
+                    "group": "ea37e5db-3d05-52ef-a7fc-c921c9755593",
                     "title": "Tab2",
                     "member": 1,
                     "groupDetail": {}
@@ -334,14 +404,14 @@
       "content": [
         {
           "title": "Tab1",
-          "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
+          "group": "ea37e5db-3d05-52ef-a7fc-c921c9755593",
           "member": 0,
           "isFirstChoice": false,
           "description": "imports:\n"
         },
         {
           "title": "Tab2",
-          "group": "295fe9e9-d6b6-5eb0-9722-b3f964652912",
+          "group": "ea37e5db-3d05-52ef-a7fc-c921c9755593",
           "member": 1,
           "isFirstChoice": false
         }

--- a/test/inputs/5/wizard.json
+++ b/test/inputs/5/wizard.json
@@ -6,13 +6,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "af0807ea-7bf8-4e85-b6c5-125dd588bf60",
+        "key": "780410be-38c0-48c6-90cb-402ace3f21cb",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-0",
+            "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-0",
             "nesting": [
               {
                 "kind": "Import",
@@ -40,19 +40,19 @@
   },
   {
     "graph": {
-      "group": "6eddc154-5e0e-5d0b-b277-f16fe216dc41",
+      "group": "0ee195cc-e0fe-5cc8-9483-495a2fcc20b8",
       "title": "EEE",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "6155934c-9bc8-4d0e-8b60-872abff78262",
+            "key": "7639ffc7-5263-4d96-b548-20bbc0e76e03",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-1",
+                "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -68,10 +68,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "6eddc154-5e0e-5d0b-b277-f16fe216dc41",
+                    "group": "0ee195cc-e0fe-5cc8-9483-495a2fcc20b8",
                     "title": "TabE1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "EEE",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "EEE"
                     }
                   }
@@ -89,7 +103,7 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "6eddc154-5e0e-5d0b-b277-f16fe216dc41",
+          "group": "0ee195cc-e0fe-5cc8-9483-495a2fcc20b8",
           "member": 0,
           "isFirstChoice": true
         }
@@ -98,14 +112,14 @@
   },
   {
     "graph": {
-      "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+      "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
       "title": "Main Tasks",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "b8a87711-e5bb-4491-96e4-708fa80c7548",
+            "key": "5fe4084d-b4ba-4dcb-9383-4c9f71f75245",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
@@ -113,23 +127,23 @@
                 "description": "",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "69d520c1-d795-41be-87a0-5de2e31e722a",
+                  "key": "02e90edc-1d3d-41d3-938a-3a56d26c5984",
                   "sequence": [
                     {
-                      "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
+                      "group": "e921750d-c2f7-500a-bc42-5d5ccc1c8009",
                       "title": "DDD",
                       "source": "placeholder",
                       "choices": [
                         {
                           "member": 0,
                           "graph": {
-                            "key": "04ceaf97-63c3-41dd-9879-efb4581d084a",
+                            "key": "c05255cb-21db-4dae-851b-f31a68b79412",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-2",
+                                "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-2",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -139,7 +153,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+                                    "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -153,10 +167,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
+                                    "group": "e921750d-c2f7-500a-bc42-5d5ccc1c8009",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -166,7 +194,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-3",
+                                "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-3",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -176,7 +204,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+                                    "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -190,10 +218,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
+                                    "group": "e921750d-c2f7-500a-bc42-5d5ccc1c8009",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -203,7 +245,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-4",
+                                "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-4",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -213,7 +255,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+                                    "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -227,10 +269,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
+                                    "group": "e921750d-c2f7-500a-bc42-5d5ccc1c8009",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -243,13 +299,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "8e3e4992-86e0-4ee9-a5f0-f39e9e2cd0c8",
+                            "key": "7b7dafeb-a088-4c78-9b94-9e1051b95ad6",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-5",
+                                "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-5",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -259,7 +315,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+                                    "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -273,10 +329,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
+                                    "group": "e921750d-c2f7-500a-bc42-5d5ccc1c8009",
                                     "title": "SubTab2",
                                     "member": 1,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -300,12 +370,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "ee406cbb-4209-45a4-92b8-998840eafc9b",
+            "key": "f284e8ca-23ea-4640-8662-b7210918f2f9",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-6",
+                "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-6",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -315,7 +385,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+                    "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
                     "title": "Tab2",
                     "member": 1,
                     "groupDetail": {}
@@ -329,7 +399,7 @@
         {
           "member": 2,
           "graph": {
-            "key": "b38d61ce-e2ba-4256-9a22-1d9b9aa5b254",
+            "key": "42af569e-c24a-4dc4-b3a7-890a5640a167",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
@@ -337,23 +407,23 @@
                 "description": "",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "f9a4f7a4-bbbb-45d9-9c88-35390fd59a18",
+                  "key": "52383e0c-7e42-4e44-baea-aedf2aa69380",
                   "sequence": [
                     {
-                      "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
+                      "group": "e921750d-c2f7-500a-bc42-5d5ccc1c8009",
                       "title": "DDD",
                       "source": "placeholder",
                       "choices": [
                         {
                           "member": 0,
                           "graph": {
-                            "key": "0d52787d-f17f-42c7-bbbf-06d277670ac5",
+                            "key": "f0fb390f-ead8-4ce5-a3cd-9f97fc5fa68d",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-7",
+                                "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-7",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -363,7 +433,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+                                    "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
@@ -377,10 +447,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
+                                    "group": "e921750d-c2f7-500a-bc42-5d5ccc1c8009",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -390,7 +474,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-8",
+                                "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-8",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -400,7 +484,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+                                    "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
@@ -414,10 +498,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
+                                    "group": "e921750d-c2f7-500a-bc42-5d5ccc1c8009",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -427,7 +525,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-9",
+                                "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-9",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -437,7 +535,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+                                    "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
@@ -451,10 +549,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
+                                    "group": "e921750d-c2f7-500a-bc42-5d5ccc1c8009",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -467,13 +579,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "09f4b01d-ca8f-4b65-a3fb-ee63f12a503e",
+                            "key": "60369157-e716-4044-aa94-fe45adf0b570",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "b17fc334-168f-4279-8c87-42ce0366b5a3-10",
+                                "id": "1220fd37-a625-47c2-88d0-bc92b615ca20-10",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -483,7 +595,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+                                    "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
@@ -497,10 +609,24 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "1b96212d-8630-5d2c-8ecf-8b35be27a030",
+                                    "group": "e921750d-c2f7-500a-bc42-5d5ccc1c8009",
                                     "title": "SubTab2",
                                     "member": 1,
                                     "groupDetail": {
+                                      "child": {
+                                        "type": "element",
+                                        "tagName": "h1",
+                                        "properties": {},
+                                        "children": [
+                                          {
+                                            "type": "text",
+                                            "value": "DDD",
+                                            "position": "placeholder"
+                                          }
+                                        ],
+                                        "position": "placeholder"
+                                      },
+                                      "level": 1,
                                       "title": "DDD"
                                     }
                                   }
@@ -529,20 +655,20 @@
       "content": [
         {
           "title": "Tab1",
-          "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+          "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
           "member": 0,
           "isFirstChoice": false,
           "description": "imports:\n"
         },
         {
           "title": "Tab2",
-          "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+          "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
           "member": 1,
           "isFirstChoice": false
         },
         {
           "title": "Tab3",
-          "group": "d8020344-d4d4-5c06-834a-e51386aae29c",
+          "group": "4e6738e4-253d-5dd3-a9b0-a2a1a7e22cc6",
           "member": 2,
           "isFirstChoice": false,
           "description": "imports:\n"

--- a/test/inputs/6/wizard.json
+++ b/test/inputs/6/wizard.json
@@ -1,20 +1,20 @@
 [
   {
     "graph": {
-      "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
+      "group": "fe100d1f-1fbf-5ebe-86b7-4d11b437e15b",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "7ee36470-d107-468a-99ca-681ea7dd3620",
+            "key": "dc072ba9-0a03-4268-95b2-0c0205850bc4",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-0",
+                "id": "7b95d5db-a40f-4af0-8daa-2978c4e5818f-0",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -24,10 +24,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
+                    "group": "fe100d1f-1fbf-5ebe-86b7-4d11b437e15b",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -37,7 +51,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-1",
+                "id": "7b95d5db-a40f-4af0-8daa-2978c4e5818f-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -47,10 +61,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
+                    "group": "fe100d1f-1fbf-5ebe-86b7-4d11b437e15b",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -60,7 +88,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-2",
+                "id": "7b95d5db-a40f-4af0-8daa-2978c4e5818f-2",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -70,10 +98,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
+                    "group": "fe100d1f-1fbf-5ebe-86b7-4d11b437e15b",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -86,13 +128,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "b919be8b-bce6-40e5-b0d6-01ae47de40cd",
+            "key": "7c62dcfc-75c0-4393-b58b-991f0ebabf5e",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-3",
+                "id": "7b95d5db-a40f-4af0-8daa-2978c4e5818f-3",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -102,10 +144,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
+                    "group": "fe100d1f-1fbf-5ebe-86b7-4d11b437e15b",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -123,13 +179,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
+          "group": "fe100d1f-1fbf-5ebe-86b7-4d11b437e15b",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "f0c903c6-7e95-51ce-9215-04a0491f302c",
+          "group": "fe100d1f-1fbf-5ebe-86b7-4d11b437e15b",
           "member": 1,
           "isFirstChoice": true
         }
@@ -143,13 +199,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "524cd27b-afe7-44c0-b75a-0d58fc0f1af0",
+        "key": "54f8523e-201e-4c00-9d75-71c02495e699",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-4",
+            "id": "7b95d5db-a40f-4af0-8daa-2978c4e5818f-4",
             "nesting": [
               {
                 "kind": "Import",
@@ -177,19 +233,19 @@
   },
   {
     "graph": {
-      "group": "aa9fc542-480b-5bc9-b953-de6231c0b28f",
+      "group": "395ce7d5-fc0e-5d67-b897-50e3b03a5432",
       "title": "EEE",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "4dbbce87-cab2-4ec5-97c5-1999b0c31c9b",
+            "key": "891d990b-e3d7-4662-a5b2-f72d443d69fb",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-5",
+                "id": "7b95d5db-a40f-4af0-8daa-2978c4e5818f-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -205,10 +261,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "aa9fc542-480b-5bc9-b953-de6231c0b28f",
+                    "group": "395ce7d5-fc0e-5d67-b897-50e3b03a5432",
                     "title": "TabE1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "EEE",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "EEE"
                     }
                   }
@@ -226,7 +296,7 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "aa9fc542-480b-5bc9-b953-de6231c0b28f",
+          "group": "395ce7d5-fc0e-5d67-b897-50e3b03a5432",
           "member": 0,
           "isFirstChoice": false
         }
@@ -235,19 +305,19 @@
   },
   {
     "graph": {
-      "group": "9bf6d174-1f1d-5757-bbc9-f4b5a34020b9",
+      "group": "a0162344-f03d-5f34-9a32-ac8bf82a9796",
       "title": "snippets-in-tab5.md",
       "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "2c5c6359-a89b-4888-85f4-d395fee65fb1",
+            "key": "ed77711f-259f-4f96-a84b-8547f803de41",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "1c144c1e-c61d-490c-ac97-eee3bb85f0b3-10",
+                "id": "7b95d5db-a40f-4af0-8daa-2978c4e5818f-10",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -257,7 +327,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "9bf6d174-1f1d-5757-bbc9-f4b5a34020b9",
+                    "group": "a0162344-f03d-5f34-9a32-ac8bf82a9796",
                     "title": "Tab2",
                     "member": 1,
                     "groupDetail": {}
@@ -276,7 +346,7 @@
       "content": [
         {
           "title": "Tab2",
-          "group": "9bf6d174-1f1d-5757-bbc9-f4b5a34020b9",
+          "group": "a0162344-f03d-5f34-9a32-ac8bf82a9796",
           "member": 1,
           "isFirstChoice": false
         }

--- a/test/inputs/7/wizard.json
+++ b/test/inputs/7/wizard.json
@@ -1,20 +1,20 @@
 [
   {
     "graph": {
-      "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
+      "group": "519da8a9-1d45-5722-9b23-b0a7e6002460",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "fe75aff5-6edd-4334-8c61-12941cb81e5b",
+            "key": "85d9bc7d-8ddd-4620-957a-d4da190209cf",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-0",
+                "id": "4f136d55-2675-4b16-8b40-1e343f6f2e56-0",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -24,10 +24,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
+                    "group": "519da8a9-1d45-5722-9b23-b0a7e6002460",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -37,7 +51,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-1",
+                "id": "4f136d55-2675-4b16-8b40-1e343f6f2e56-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -47,10 +61,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
+                    "group": "519da8a9-1d45-5722-9b23-b0a7e6002460",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -60,7 +88,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-2",
+                "id": "4f136d55-2675-4b16-8b40-1e343f6f2e56-2",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -70,10 +98,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
+                    "group": "519da8a9-1d45-5722-9b23-b0a7e6002460",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -86,13 +128,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "2c72e3b1-ecc3-43e9-bafc-6d3727dc6955",
+            "key": "d2b95b2a-86f5-459b-aca3-eb9dc7f424ed",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-3",
+                "id": "4f136d55-2675-4b16-8b40-1e343f6f2e56-3",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -102,10 +144,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
+                    "group": "519da8a9-1d45-5722-9b23-b0a7e6002460",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -123,13 +179,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
+          "group": "519da8a9-1d45-5722-9b23-b0a7e6002460",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "caea6780-334f-51dd-8e2a-2803b5e67178",
+          "group": "519da8a9-1d45-5722-9b23-b0a7e6002460",
           "member": 1,
           "isFirstChoice": true
         }
@@ -143,13 +199,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "01554b00-19b0-4df7-b693-87e8c2550604",
+        "key": "c9628b4f-bf3b-492d-925a-beb81fc3cd26",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "71406f5f-4794-40f8-9d61-19fb384978a9-4",
+            "id": "4f136d55-2675-4b16-8b40-1e343f6f2e56-4",
             "nesting": [
               {
                 "kind": "Import",
@@ -177,19 +233,19 @@
   },
   {
     "graph": {
-      "group": "ab57d1e0-6ec9-515b-af70-6884738a3dc5",
+      "group": "7ed3a32c-61a5-5fd3-be21-58edb7a48771",
       "title": "EEE",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "7c1eaa4e-83bb-4987-89c9-afdca6f96782",
+            "key": "977da844-6811-45f8-ae56-24b43c6dc676",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-5",
+                "id": "4f136d55-2675-4b16-8b40-1e343f6f2e56-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -205,10 +261,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "ab57d1e0-6ec9-515b-af70-6884738a3dc5",
+                    "group": "7ed3a32c-61a5-5fd3-be21-58edb7a48771",
                     "title": "TabE1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "EEE",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "EEE"
                     }
                   }
@@ -226,7 +296,7 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "ab57d1e0-6ec9-515b-af70-6884738a3dc5",
+          "group": "7ed3a32c-61a5-5fd3-be21-58edb7a48771",
           "member": 0,
           "isFirstChoice": false
         }
@@ -235,19 +305,19 @@
   },
   {
     "graph": {
-      "group": "a527fcf9-fc02-5303-8423-fcce0c9c76a0",
+      "group": "b2fc079c-b22f-52b7-a955-c54d9bd0e610",
       "title": "snippets-in-tab5.md",
       "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "f06b0afb-89df-4159-82ba-ee8bc55a6f7c",
+            "key": "666b96c5-3d36-4333-aee1-a12334432665",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "71406f5f-4794-40f8-9d61-19fb384978a9-10",
+                "id": "4f136d55-2675-4b16-8b40-1e343f6f2e56-10",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -257,7 +327,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "a527fcf9-fc02-5303-8423-fcce0c9c76a0",
+                    "group": "b2fc079c-b22f-52b7-a955-c54d9bd0e610",
                     "title": "Tab2",
                     "member": 1,
                     "groupDetail": {}
@@ -276,7 +346,7 @@
       "content": [
         {
           "title": "Tab2",
-          "group": "a527fcf9-fc02-5303-8423-fcce0c9c76a0",
+          "group": "b2fc079c-b22f-52b7-a955-c54d9bd0e610",
           "member": 1,
           "isFirstChoice": false
         }

--- a/test/inputs/8/wizard.json
+++ b/test/inputs/8/wizard.json
@@ -1,20 +1,20 @@
 [
   {
     "graph": {
-      "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
+      "group": "a03e3ec6-a66f-5e4e-9f61-b48c4c0accbd",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "52e6c9a3-8ecc-41ae-bdb9-16fd9e6a1dc2",
+            "key": "4d46200f-9abd-480c-b7b3-8848d18d6683",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "56505fc9-b3a1-49f2-bdc4-943604ef543a-0",
+                "id": "168a2fa7-87b2-4e60-aea6-db4bbd29da12-0",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -24,10 +24,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "17be6164-ab89-59bc-97c5-19e920f88dd2",
+                    "group": "26cdae5b-02b0-554a-898a-8a2e6ffd5980",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "Chooser",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "Chooser"
                     }
                   },
@@ -39,10 +53,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
+                    "group": "a03e3ec6-a66f-5e4e-9f61-b48c4c0accbd",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -52,7 +80,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "56505fc9-b3a1-49f2-bdc4-943604ef543a-1",
+                "id": "168a2fa7-87b2-4e60-aea6-db4bbd29da12-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -62,10 +90,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "17be6164-ab89-59bc-97c5-19e920f88dd2",
+                    "group": "26cdae5b-02b0-554a-898a-8a2e6ffd5980",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "Chooser",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "Chooser"
                     }
                   },
@@ -77,10 +119,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
+                    "group": "a03e3ec6-a66f-5e4e-9f61-b48c4c0accbd",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -90,7 +146,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "56505fc9-b3a1-49f2-bdc4-943604ef543a-2",
+                "id": "168a2fa7-87b2-4e60-aea6-db4bbd29da12-2",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -100,10 +156,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "17be6164-ab89-59bc-97c5-19e920f88dd2",
+                    "group": "26cdae5b-02b0-554a-898a-8a2e6ffd5980",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "Chooser",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "Chooser"
                     }
                   },
@@ -115,10 +185,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
+                    "group": "a03e3ec6-a66f-5e4e-9f61-b48c4c0accbd",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -131,13 +215,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "376b001e-1a11-430c-9fa2-5053a627e977",
+            "key": "7b080b15-fc79-43c3-a0bb-afb23e2a411e",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "56505fc9-b3a1-49f2-bdc4-943604ef543a-3",
+                "id": "168a2fa7-87b2-4e60-aea6-db4bbd29da12-3",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -147,10 +231,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "17be6164-ab89-59bc-97c5-19e920f88dd2",
+                    "group": "26cdae5b-02b0-554a-898a-8a2e6ffd5980",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "Chooser",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "Chooser"
                     }
                   },
@@ -162,10 +260,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
+                    "group": "a03e3ec6-a66f-5e4e-9f61-b48c4c0accbd",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -183,13 +295,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
+          "group": "a03e3ec6-a66f-5e4e-9f61-b48c4c0accbd",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "0c5ab6ce-b289-53cf-87b5-150163915a5c",
+          "group": "a03e3ec6-a66f-5e4e-9f61-b48c4c0accbd",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/9/wizard-darwin.json
+++ b/test/inputs/9/wizard-darwin.json
@@ -6,12 +6,12 @@
       "description": "",
       "filepath": "test/inputs/snippets/importg.md",
       "graph": {
-        "key": "d9b0bb55-2d44-44ef-9562-95b92c0e9e09",
+        "key": "97bc1a34-4ea5-49ca-84d7-39ae6b56d989",
         "sequence": [
           {
             "body": "echo MMM",
             "language": "bash",
-            "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-0",
+            "id": "0531465c-80e2-46d4-9c90-e8164b42b507-0",
             "nesting": [
               {
                 "kind": "Import",
@@ -45,13 +45,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "da3a518c-5196-4d0c-ad51-0a1c0316303e",
+        "key": "551c5b53-875b-4403-a108-c2760c58563b",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-3",
+            "id": "0531465c-80e2-46d4-9c90-e8164b42b507-3",
             "nesting": [
               {
                 "kind": "Import",
@@ -73,20 +73,20 @@
   },
   {
     "graph": {
-      "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
+      "group": "3d0673d2-e9a9-54ae-95fc-81c9b35e1d09",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "e4cced3b-e116-43b3-a741-c3d5f479808d",
+            "key": "e1bd82f1-ca0c-4e02-9105-3dfcfd52b0f8",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-4",
+                "id": "0531465c-80e2-46d4-9c90-e8164b42b507-4",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -96,10 +96,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
+                    "group": "3d0673d2-e9a9-54ae-95fc-81c9b35e1d09",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1340
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1343
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1338
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1343
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -109,7 +145,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-5",
+                "id": "0531465c-80e2-46d4-9c90-e8164b42b507-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -119,10 +155,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
+                    "group": "3d0673d2-e9a9-54ae-95fc-81c9b35e1d09",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1340
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1343
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1338
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1343
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -132,7 +204,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-6",
+                "id": "0531465c-80e2-46d4-9c90-e8164b42b507-6",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -142,10 +214,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
+                    "group": "3d0673d2-e9a9-54ae-95fc-81c9b35e1d09",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1340
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1343
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1338
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1343
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -158,13 +266,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "91ee3c51-cad2-43b7-b6e6-79d375dabfd2",
+            "key": "446a64f5-044d-4f84-b2e8-016b7bb5f9f6",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "4f33f6aa-44d3-4ed9-9309-a6f6282a9b05-7",
+                "id": "0531465c-80e2-46d4-9c90-e8164b42b507-7",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -174,10 +282,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
+                    "group": "3d0673d2-e9a9-54ae-95fc-81c9b35e1d09",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1340
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1343
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1338
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1343
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -195,13 +339,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
+          "group": "3d0673d2-e9a9-54ae-95fc-81c9b35e1d09",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "edb2ce3b-10a3-54e6-9026-fda8cce16915",
+          "group": "3d0673d2-e9a9-54ae-95fc-81c9b35e1d09",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/9/wizard-linux.json
+++ b/test/inputs/9/wizard-linux.json
@@ -6,12 +6,12 @@
       "description": "",
       "filepath": "test/inputs/snippets/importg.md",
       "graph": {
-        "key": "39b1c78f-6ed0-4149-8295-ef64de5377f1",
+        "key": "48d8a29a-db4a-4380-ae8c-c29c3eca38ca",
         "sequence": [
           {
             "body": "echo LLL",
             "language": "bash",
-            "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-1",
+            "id": "592c76fe-ed28-49de-bbae-06b7d2694648-1",
             "nesting": [
               {
                 "kind": "Import",
@@ -45,13 +45,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "90b58445-afcf-492d-bc44-4c9146c776be",
+        "key": "ff5123aa-b80f-4489-a6a8-c0f71bd606d8",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-3",
+            "id": "592c76fe-ed28-49de-bbae-06b7d2694648-3",
             "nesting": [
               {
                 "kind": "Import",
@@ -73,20 +73,20 @@
   },
   {
     "graph": {
-      "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
+      "group": "2dfb27ac-49de-5295-9150-d07a14382d70",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "c18823f1-fe15-4707-b63a-e54619b909a3",
+            "key": "2df610e6-4fc2-4316-bb92-e005dae10cbf",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-4",
+                "id": "592c76fe-ed28-49de-bbae-06b7d2694648-4",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -96,10 +96,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
+                    "group": "2dfb27ac-49de-5295-9150-d07a14382d70",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1340
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1343
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1338
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1343
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -109,7 +145,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-5",
+                "id": "592c76fe-ed28-49de-bbae-06b7d2694648-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -119,10 +155,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
+                    "group": "2dfb27ac-49de-5295-9150-d07a14382d70",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1340
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1343
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1338
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1343
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -132,7 +204,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-6",
+                "id": "592c76fe-ed28-49de-bbae-06b7d2694648-6",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -142,10 +214,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
+                    "group": "2dfb27ac-49de-5295-9150-d07a14382d70",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1340
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1343
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1338
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1343
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -158,13 +266,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "b46ba6cf-4c5f-4022-8318-58284b7b9f18",
+            "key": "92d0114f-b350-40af-9a46-26806128b476",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "912adb3b-bced-4114-98c1-14a05c9c9e0f-7",
+                "id": "592c76fe-ed28-49de-bbae-06b7d2694648-7",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -174,10 +282,46 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
+                    "group": "2dfb27ac-49de-5295-9150-d07a14382d70",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": {
+                              "start": {
+                                "line": 58,
+                                "column": 3,
+                                "offset": 1340
+                              },
+                              "end": {
+                                "line": 58,
+                                "column": 6,
+                                "offset": 1343
+                              }
+                            }
+                          }
+                        ],
+                        "position": {
+                          "start": {
+                            "line": 58,
+                            "column": 1,
+                            "offset": 1338
+                          },
+                          "end": {
+                            "line": 58,
+                            "column": 6,
+                            "offset": 1343
+                          }
+                        }
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -195,13 +339,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
+          "group": "2dfb27ac-49de-5295-9150-d07a14382d70",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "0df8d4e1-13b2-57d5-be7e-4c1100eb5e17",
+          "group": "2dfb27ac-49de-5295-9150-d07a14382d70",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/9/wizard-win32.json
+++ b/test/inputs/9/wizard-win32.json
@@ -6,12 +6,12 @@
       "description": "",
       "filepath": "test/inputs/snippets/importg.md",
       "graph": {
-        "key": "9d9d1ab7-51d1-4a2f-bd11-4c628ed07f83",
+        "key": "2767c6d7-b82e-4d1e-9bfe-2d0d0ab9a648",
         "sequence": [
           {
-            "body": "echo WWW",
+            "body": "echo MMM",
             "language": "bash",
-            "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-2",
+            "id": "31e2d716-37b7-4fca-946a-05c39d320542-0",
             "nesting": [
               {
                 "kind": "Import",
@@ -22,8 +22,8 @@
               {
                 "kind": "Choice",
                 "group": "org.kubernetes-sigs.kui/choice/platform",
-                "title": "Win32",
-                "member": 2,
+                "title": "Darwin",
+                "member": 0,
                 "groupDetail": {}
               }
             ]
@@ -45,13 +45,13 @@
       "description": "",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "e778754f-e5f9-4750-b253-961c6a34aa3b",
+        "key": "95fe8fc2-f073-47fe-af40-4c381a5ca873",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-3",
+            "id": "31e2d716-37b7-4fca-946a-05c39d320542-3",
             "nesting": [
               {
                 "kind": "Import",
@@ -73,20 +73,20 @@
   },
   {
     "graph": {
-      "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
+      "group": "0595efe2-36c6-5708-afc6-279285f6a327",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "a66b8870-8847-4477-a5fa-d9d8aa37652b",
+            "key": "b508a921-3ebe-4273-9f24-159a9173402d",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-4",
+                "id": "31e2d716-37b7-4fca-946a-05c39d320542-4",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -96,10 +96,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
+                    "group": "0595efe2-36c6-5708-afc6-279285f6a327",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -109,7 +123,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-5",
+                "id": "31e2d716-37b7-4fca-946a-05c39d320542-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -119,10 +133,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
+                    "group": "0595efe2-36c6-5708-afc6-279285f6a327",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -132,7 +160,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-6",
+                "id": "31e2d716-37b7-4fca-946a-05c39d320542-6",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -142,10 +170,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
+                    "group": "0595efe2-36c6-5708-afc6-279285f6a327",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -158,13 +200,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "8a7025a6-da41-4150-b2d4-4eb8be9dd616",
+            "key": "8553a69d-1c7a-416e-b2aa-3d216f54c7b6",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "0e43c529-7b15-4570-8fb3-623ecddcc712-7",
+                "id": "31e2d716-37b7-4fca-946a-05c39d320542-7",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -174,10 +216,24 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
+                    "group": "0595efe2-36c6-5708-afc6-279285f6a327",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
+                      "child": {
+                        "type": "element",
+                        "tagName": "h1",
+                        "properties": {},
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "DDD",
+                            "position": "placeholder"
+                          }
+                        ],
+                        "position": "placeholder"
+                      },
+                      "level": 1,
                       "title": "DDD"
                     }
                   }
@@ -195,13 +251,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
+          "group": "0595efe2-36c6-5708-afc6-279285f6a327",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "1ed55043-b1f5-5396-baad-d7f8b8cd1800",
+          "group": "0595efe2-36c6-5708-afc6-279285f6a327",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -33,7 +33,7 @@ function munge(wizard: Awaited<ReturnType<typeof main>>["wizard"]) {
     JSON.stringify(wizard, (key, value) => {
       if (key === "group" || key === "id" || key === "key" || key === "filepath") {
         return "fakeit"
-      } else if (key === "source" && (typeof value === "function" || typeof value === "undefined")) {
+      } else if (key === "source" || key === "position") {
         return "placeholder"
       } else if (key === "source" || (key === "content" && typeof value === "string")) {
         return value.replace(/(id): [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(-\d+)?/g, "$1: fakeid")


### PR DESCRIPTION
We have been somewhat assuming that structure comes from our home-grown Wizards. We should probably switch over to feeding off the heading structure. This PR starts us in that direction.