### PR TITLE
feat: support for --mkdocs flag

### DIFF
--- a/src/fe/MadWizardOptions.ts
+++ b/src/fe/MadWizardOptions.ts
@@ -14,19 +14,6 @@
  * limitations under the License.
  */
 
-// CLI
-export * from "./fe/cli"
-
-// UI support
-export * from "./fe/tree"
-
-// An entrypoint useful for tests
-export * from "./fe/main"
-
-// APIs
-export * from "./graph"
-export * from "./parser"
-export * from "./choices"
-export * from "./wizard"
-
-export * from "./fe/MadWizardOptions"
+export interface MadWizardOptions {
+  mkdocs?: string
+}

--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -46,9 +46,13 @@ function usage(argv: string[], msg?: string) {
   process.exit(1)
 }
 
-export async function cli<Writer extends (msg: string) => boolean>(argv: string[], write?: Writer) {
+export async function cli<Writer extends (msg: string) => boolean>(_argv: string[], write?: Writer) {
+  const argv = _argv.filter((_, idx) => !/^-/.test(_) && (idx === 0 || !/^--/.test(_argv[idx - 1])))
   const task = argv[1]
   const input = argv[2]
+
+  const mkdocsIdx = _argv.findIndex((_) => _ === "--mkdocs")
+  const mkdocs = mkdocsIdx < 0 ? undefined : _argv[mkdocsIdx + 1]
 
   if (!task || !input) {
     return usage(argv)
@@ -62,7 +66,7 @@ export async function cli<Writer extends (msg: string) => boolean>(argv: string[
     Debug.enable("madwizard/timing/*")
   }
 
-  const { blocks, choices } = await parse(input)
+  const { blocks, choices } = await parse(input, undefined, undefined, undefined, { mkdocs })
 
   try {
     switch (task) {

--- a/src/fe/tree/xform.ts
+++ b/src/fe/tree/xform.ts
@@ -89,7 +89,7 @@ export default class TreeTransformer<Content> {
    */
   public foldNestedSubTask(graph: UITree<Content>[number]) {
     const origin1 = graph["data-origin"]
-    if (origin1 && isSubTask(origin1)) {
+    if (origin1 && isSubTask(origin1) && origin1.title !== "Prerequisites") {
       if (graph.children.length === 1) {
         const singleChild = graph.children[0]
         const origin2 = singleChild["data-origin"]

--- a/src/graph/hoistSubTasks.ts
+++ b/src/graph/hoistSubTasks.ts
@@ -25,6 +25,7 @@ import {
   hasTitle,
   hasTitleProperty,
   isSubTask,
+  isSubTaskWithFilepath,
   isChoice,
   isSequence,
   isParallel,
@@ -239,14 +240,14 @@ function findAndHoistChoiceFrontier(graph: void | Graph, inheritedSubTasks: SubT
 
 function extractTopLevelSubTasks(graph: Graph): { toplevelSubTasks: SubTask[]; residual: Graph } {
   if (isSequence(graph)) {
-    const toplevelSubTasks = graph.sequence.filter(isSubTask)
-    const residual = sequence(graph.sequence.filter((_) => !isSubTask(_)))
+    const toplevelSubTasks = graph.sequence.filter(isSubTaskWithFilepath)
+    const residual = sequence(graph.sequence.filter((_) => !isSubTaskWithFilepath(_)))
     return { toplevelSubTasks, residual }
   } else if (isParallel(graph)) {
     const toplevelSubTasks = graph.parallel.filter(isSubTask)
     const residual = parallel(graph.parallel.filter((_) => !isSubTask(_)))
     return { toplevelSubTasks, residual }
-  } else if (isSubTask(graph)) {
+  } else if (isSubTaskWithFilepath(graph)) {
     return { toplevelSubTasks: [graph], residual: emptySequence() }
   } else {
     return { toplevelSubTasks: [], residual: graph }

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -247,6 +247,10 @@ export function isSubTask<T extends Unordered | Ordered = Unordered>(graph: Grap
   return subtask && typeof subtask.key === "string" && typeof subtask.filepath === "string"
 }
 
+export function isSubTaskWithFilepath<T extends Unordered | Ordered = Unordered>(graph: Graph<T>): graph is SubTask<T> {
+  return isSubTask(graph) && !!graph.filepath
+}
+
 function sameCodeBlock(a: CodeBlockProps, b: CodeBlockProps) {
   return (
     a.id === b.id &&

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -18,7 +18,7 @@ import { read } from "to-vfile"
 import { VFileCompatible } from "vfile"
 import { extname as pathExtname } from "path"
 
-import { ChoiceState } from "../choices"
+import { ChoiceState, MadWizardOptions } from "../../"
 
 export * from "./markdown"
 
@@ -36,10 +36,16 @@ function extname(input: VFileCompatible) {
 }
 
 /** Parse the given `input` into a `Graph` syntax tree. */
-export async function parse(input: VFileCompatible, choices?: ChoiceState, uuid?: string, reader?: typeof read) {
+export async function parse(
+  input: VFileCompatible,
+  choices?: ChoiceState,
+  uuid?: string,
+  reader?: typeof read,
+  madwizardOptions?: MadWizardOptions
+) {
   const ext = extname(input)
   if (ext === ".md") {
-    return await import("./markdown").then((_) => _.blockify(input, choices, uuid, reader))
+    return await import("./markdown").then((_) => _.blockify(input, choices, uuid, reader, madwizardOptions))
   } else {
     throw new Error(`Unsupported file type: ${String(input)}`)
   }

--- a/src/parser/markdown/index.ts
+++ b/src/parser/markdown/index.ts
@@ -25,6 +25,8 @@ import remarkParse from "remark-parse"
 import remarkRehype from "remark-rehype"
 import { unified, PluggableList } from "unified"
 
+import { MadWizardOptions } from "../../"
+
 import { CodeBlockProps } from "../../codeblock"
 import { ChoiceState, newChoiceState } from "../../choices"
 
@@ -91,7 +93,13 @@ async function read(file: VFile): Promise<VFile> {
 }
 
 /** Parse the given `input` into a `Graph` syntax tree. */
-async function parse(input: VFile, choices: ChoiceState = newChoiceState(), uuid = v4(), reader = read) {
+async function parse(
+  input: VFile,
+  choices: ChoiceState = newChoiceState(),
+  uuid = v4(),
+  reader = read,
+  madwizardOptions: MadWizardOptions = {}
+) {
   const debug = Debug("madwizard/timing/parser:markdown")
   debug("start")
 
@@ -108,7 +116,7 @@ async function parse(input: VFile, choices: ChoiceState = newChoiceState(), uuid
 
     debug("fetch start")
     const sourcePriorToInlining = input.value.toString()
-    const source = await inlineSnippets({ fetcher })(sourcePriorToInlining, input.path)
+    const source = await inlineSnippets({ fetcher, madwizardOptions })(sourcePriorToInlining, input.path)
     debug("fetch complete")
 
     debug("parse start")
@@ -130,7 +138,13 @@ async function parse(input: VFile, choices: ChoiceState = newChoiceState(), uuid
 }
 
 /** Parse the given `input` into a `Graph` syntax tree. */
-export async function blockify(input: VFileCompatible, choices?: ChoiceState, uuid?: string, reader = read) {
+export async function blockify(
+  input: VFileCompatible,
+  choices?: ChoiceState,
+  uuid?: string,
+  reader = read,
+  madwizardOptions?: MadWizardOptions
+) {
   const file = typeof input === "string" ? await reader(new VFile({ path: expandHomeDir(input) })) : new VFile(input)
-  return parse(file, choices, uuid, reader)
+  return parse(file, choices, uuid, reader, madwizardOptions)
 }

--- a/src/parser/markdown/rehype-code-indexer/index.ts
+++ b/src/parser/markdown/rehype-code-indexer/index.ts
@@ -41,7 +41,7 @@ import {
 } from "../rehype-wizard"
 
 import { tryFrontmatter } from "../frontmatter"
-import { isImports, getImportKey, getImportFilepath, getImportTitle } from "../remark-import"
+import { isOnAnImportChain, isImports, getImportKey, getImportFilepath, getImportTitle } from "../remark-import"
 import { CodeBlockProps, addNesting as addCodeBlockNesting } from "../../../codeblock/CodeBlockProps"
 
 /**
@@ -259,7 +259,10 @@ export function rehypeCodeIndexer(uuid: string, codeblocks?: CodeBlockProps[]) {
                   attributes.nesting = attributes.nesting.reverse()
                   reserialize()
 
-                  if (!attributes.nesting.find((_) => _.kind === "WizardStep" || (_.kind === "Import" && _.filepath))) {
+                  if (
+                    !isOnAnImportChain(ancestors) &&
+                    !attributes.nesting.find((_) => _.kind === "WizardStep" || (_.kind === "Import" && _.filepath))
+                  ) {
                     // try looking for an h1
                     const grandparent = ancestors[0]
                     if (grandparent) {

--- a/test/inputs/8/tree.txt
+++ b/test/inputs/8/tree.txt
@@ -1,7 +1,8 @@
-DDD
-├── Option 1: SubTab1
-│   ├── echo AAA
-│   ├── echo AAA
-│   └── echo AAA
-└── Option 2: SubTab2
-    └── echo BBB
+Prerequisites
+└── DDD
+    ├── Option 1: SubTab1
+    │   ├── echo AAA
+    │   ├── echo AAA
+    │   └── echo AAA
+    └── Option 2: SubTab2
+        └── echo BBB


### PR DESCRIPTION
This will allow us a bit more flexibility in consuming mkdocs content. In general, we will need to snarf up the base path from the mkdocs.yml config, because all of the content will be written w.r.t. that base.

This PR also fixes a few issues with the graph and tree formation for "fake" subtasks, i.e. not from imports, but just a way to name a subtask.