### PR TITLE
fix: when collapsing choices, make sure to preserve titles

### DIFF
--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -99,7 +99,19 @@ export async function cli<Writer extends (msg: string) => boolean>(
         const graph = compile(blocks, choices)
         const wizard = wizardify(graph)
         console.log(
-          JSON.stringify(wizard, (key, value) => (key === "source" || key === "position" ? "placeholder" : value), 2)
+          JSON.stringify(
+            wizard,
+            (key, value) => {
+              if (key === "source" || key === "position") {
+                return "placeholder"
+              } else if (key === "description" && !value) {
+                return undefined
+              } else {
+                return value
+              }
+            },
+            2
+          )
         )
         break
       }

--- a/src/graph/collapseMadeChoices.ts
+++ b/src/graph/collapseMadeChoices.ts
@@ -15,7 +15,19 @@
  */
 
 import { ChoiceState } from "../choices"
-import { Graph, isChoice, isSequence, isParallel, isSubTask, isTitledSteps, emptySequence } from "."
+import {
+  Graph,
+  emptySequence,
+  hasKey,
+  hasTitle,
+  isChoice,
+  isSequence,
+  isParallel,
+  isSubTask,
+  isTitledSteps,
+  sequence,
+  subtask,
+} from "."
 
 function collapse(graph: Graph, choices: ChoiceState): Graph {
   if (isChoice(graph)) {
@@ -31,7 +43,20 @@ function collapse(graph: Graph, choices: ChoiceState): Graph {
             ? chosenSubtree.graph.sequence[0]
             : chosenSubtree.graph
 
-        return collapse(chosenSubgraph, choices)
+        const collapsed = collapse(chosenSubgraph, choices)
+        if (!hasTitle(collapsed) && hasTitle(graph)) {
+          // TODO with graph.source
+          return subtask(
+            hasKey(collapsed) ? collapsed.key : graph.group,
+            graph.title,
+            "",
+            "",
+            sequence([collapsed]),
+            graph.source
+          )
+        } else {
+          return collapsed
+        }
       }
     }
 

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -41,6 +41,8 @@ function munge(wizard: Awaited<ReturnType<typeof main>>["wizard"]) {
         return "fakeit"
       } else if (key === "source" || key === "position") {
         return "placeholder"
+      } else if (key === "description" && !value) {
+        return undefined
       } else if (key === "source" || (key === "content" && typeof value === "string")) {
         return value.replace(/(id): [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(-\d+)?/g, "$1: fakeid")
       } else {


### PR DESCRIPTION
We may collapse away a meaningful title, e.g. if the resulting (collapsed) subgraph is just a code block, and the title was coming from the choice...