### PR TITLE
fix: don't be clever about dots in codeblocks.match topmatter

### DIFF
--- a/src/parser/markdown/remark-codeblocks-topmatter.ts
+++ b/src/parser/markdown/remark-codeblocks-topmatter.ts
@@ -30,9 +30,7 @@ function isCode(node: Node): node is Code {
 /** Scan and process the `codeblocks` schema of the given `frontmatter` */
 export function preprocessCodeBlocksInContent(tree /*: Root */, frontmatter: KuiFrontmatter, ignoreImports = true) {
   if (hasCodeBlocks(frontmatter)) {
-    const codeblocks = frontmatter.codeblocks.map((_) =>
-      Object.assign({}, _, { match: new RegExp(_.match.replace(/\./g, "\\.")) })
-    )
+    const codeblocks = frontmatter.codeblocks.map((_) => Object.assign({}, _, { match: new RegExp(_.match) }))
 
     visitParents(tree, "code", (node, ancestors) => {
       if (isCode(node)) {


### PR DESCRIPTION
We were replacing these with `\.`. Let's just treat them like regexps without special interpretation on our part!