### PR TITLE
fix: use consistent group id for choices

### DIFF
--- a/src/parser/markdown/rehype-tabbed/populate.ts
+++ b/src/parser/markdown/rehype-tabbed/populate.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { v5 } from "uuid"
 import { Node } from "hast"
 
+import { getTabTitle } from "."
 import { isParent } from "../util/isElement"
 import { isImports } from "../remark-import"
 
@@ -25,24 +25,21 @@ const RE_TAB = /^===\s+"([^"]+)"/
 
 import { START_OF_TAB, END_OF_TAB, PUSH_TABS } from "."
 
-export default function populateTabs(
-  uuid: string,
-  tree: Node,
-  recursiveDepth = 0
-): { tree: Node; tabgroupIdx: number } {
+export default function populateTabs(uuid: string, tree: Node): { tree: Node; tabgroupIdx: number } {
   let tabgroupIdx = -1
 
   const tabStack = []
   let currentTabs = []
   const _flushTabs = (children) => {
     if (currentTabs.length > 0) {
+      tabgroupIdx++
       children.push({
         type: "element",
         tagName: "div",
         children: currentTabs,
         properties: {
           depth: tabStack.length,
-          "data-kui-choice-group": v5((++tabgroupIdx).toString() + "." + recursiveDepth.toString(), uuid),
+          "data-kui-choice-group": currentTabs.map(getTabTitle).join("####"),
           "data-kui-choice-nesting-depth": tabStack.length,
         },
       })
@@ -90,7 +87,7 @@ export default function populateTabs(
         }
       } else if (child.type === "element" && child.tagName === "div") {
         if (currentTabs.length > 0 && isImports(child.properties)) {
-          const sub = populateTabs(uuid, child, recursiveDepth + 1).tree
+          const sub = populateTabs(uuid, child).tree
           return addToTab(sub)
         } else {
           child.children = process(child.children)


### PR DESCRIPTION
We were using a uuid (v5) for tab group identification. This would not allow for asking the same choice twice. For example: how do you wish to install, ...., how do you wish to uninstall.

The first question is likely to have the same set of choices as the second question. And the same answer...

This changes the tab identifier to be derived in a repeatible fashion from the names of the tabs. It does not yet change any other logic.