### PR TITLE
fix: choices in guide command may be missing description

### DIFF
--- a/src/parser/markdown/frontmatter/index.ts
+++ b/src/parser/markdown/frontmatter/index.ts
@@ -15,12 +15,13 @@
  */
 
 import Debug from "debug"
+import { Root } from "hast"
 import { load } from "js-yaml"
 import { u } from "unist-builder"
 import { visit } from "unist-util-visit"
-import { Literal, Node, Root, Text } from "hast"
 import { visitParents } from "unist-util-visit-parents"
 
+import { isLiteral, isText } from "../util/isElement"
 import { isOnAnImportChain, visitImportContainers } from "../remark-import"
 import KuiFrontmatter, { hasWizardSteps, isNormalSplit, isValidPosition, isValidPositionObj } from "./KuiFrontmatter"
 import { preprocessCodeBlocksInContent, preprocessCodeBlocksInImports } from "../remark-codeblocks-topmatter"
@@ -34,14 +35,6 @@ export function splitTarget(node) {
       return match[1]
     }
   }
-}
-
-function isLiteral(node: Node): node is Literal {
-  return typeof (node as Literal).value === "string"
-}
-
-function isText(node: Node): node is Text {
-  return node.type === "text" && typeof (node as Text).value === "string"
 }
 
 /** Parse out the frontmatter at the top of a markdown file */

--- a/src/parser/markdown/rehype-code-indexer/index.ts
+++ b/src/parser/markdown/rehype-code-indexer/index.ts
@@ -25,7 +25,12 @@ import dump from "./dump"
 import { isTab } from "../rehype-tabbed"
 import { isExecutable } from "../../../codeblock/isCodeBlock"
 import { getTipTitle, isTipWithFullTitle } from "../rehype-tip"
-import isElementWithProperties, { hasContentChildren } from "../util/isElement"
+import isElementWithProperties, {
+  hasContentChildren,
+  isParagraph,
+  isText,
+  isNonEmptyTextOrParagraph,
+} from "../util/isElement"
 import toMarkdownStringDelayed, { toMarkdownString, Node } from "../util/toMarkdownString"
 
 import {
@@ -55,11 +60,15 @@ function isImplicitlyOptional(_: Parent): _ is Element {
 /** @return the first child, if it is a paragraph  */
 function extractFirstParagraph(parent: Parent, after?: Node) {
   const startIdx = !after ? 0 : parent.children.findIndex((_) => _ === after) + 1
-  const pIdx = parent.children.findIndex((_, idx) => idx >= startIdx && isElementWithProperties(_) && _.tagName === "p")
+  const pIdx = parent.children.findIndex((_, idx) => idx >= startIdx && isNonEmptyTextOrParagraph(_))
   if (pIdx >= 0) {
     const firstChild = parent.children[pIdx]
-    if (firstChild && isElementWithProperties(firstChild) && firstChild.tagName === "p") {
-      return toMarkdownString(firstChild)
+    if (firstChild) {
+      if (isText(firstChild)) {
+        return firstChild.value
+      } else if (isParagraph(firstChild)) {
+        return toMarkdownString(firstChild)
+      }
     }
   }
   /*const firstChild = parent.children[startIdx]

--- a/src/parser/markdown/util/isElement.ts
+++ b/src/parser/markdown/util/isElement.ts
@@ -15,7 +15,23 @@
  */
 
 import { Node, Parent } from "unist"
-import { Element, ElementContent, Root } from "hast"
+import { Element, ElementContent, Literal, Root, Text } from "hast"
+
+export function isLiteral(node: Node): node is Literal {
+  return typeof (node as Literal).value === "string"
+}
+
+export function isText(node: Node): node is Text {
+  return node.type === "text" && typeof (node as Text).value === "string"
+}
+
+export function isParagraph(node: Node): node is Element & { tagName: "p" } {
+  return isElementWithProperties(node) && node.tagName === "p"
+}
+
+export function isNonEmptyTextOrParagraph(node: Node): node is Text | Element {
+  return (isText(node) && !!node.value.trim()) || isParagraph(node)
+}
 
 export function isParent(node: Node): node is Parent {
   return Array.isArray((node as Parent).children)

--- a/test/inputs/1/wizard.json
+++ b/test/inputs/1/wizard.json
@@ -1,23 +1,24 @@
 [
   {
     "graph": {
-      "group": "ee83f65c-3702-5660-8e39-f0f1cbe96f2c",
+      "group": "Tab1Title####Tab2Title",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "f4a043b4-b86e-4eec-ae45-358d982a21d9",
+            "key": "ac10930f-9226-4788-a846-7b96269dc5b2",
             "sequence": [
               {
                 "body": "echo 111",
                 "language": "bash",
-                "id": "0971c4d9-903c-4347-bc45-3b3fef87c77e-0",
+                "id": "6be74561-6b95-460c-8dae-71a84ad2eada-0",
                 "nesting": [
                   {
                     "kind": "Choice",
-                    "group": "ee83f65c-3702-5660-8e39-f0f1cbe96f2c",
+                    "group": "Tab1Title####Tab2Title",
                     "title": "Tab1Title",
+                    "description": "\nTab1Content",
                     "member": 0,
                     "groupDetail": {}
                   }
@@ -25,22 +26,24 @@
               }
             ]
           },
-          "title": "Tab1Title"
+          "title": "Tab1Title",
+          "description": "\nTab1Content"
         },
         {
           "member": 1,
           "graph": {
-            "key": "a9c8bd76-513d-49bc-98db-876e820e5a08",
+            "key": "92ab53e2-49c4-449d-a7ba-65d0b4a867f1",
             "sequence": [
               {
                 "body": "echo 222",
                 "language": "bash",
-                "id": "0971c4d9-903c-4347-bc45-3b3fef87c77e-1",
+                "id": "6be74561-6b95-460c-8dae-71a84ad2eada-1",
                 "nesting": [
                   {
                     "kind": "Choice",
-                    "group": "ee83f65c-3702-5660-8e39-f0f1cbe96f2c",
+                    "group": "Tab1Title####Tab2Title",
                     "title": "Tab2Title",
+                    "description": "\nTab2Content",
                     "member": 1,
                     "groupDetail": {}
                   }
@@ -48,7 +51,8 @@
               }
             ]
           },
-          "title": "Tab2Title"
+          "title": "Tab2Title",
+          "description": "\nTab2Content"
         }
       ]
     },
@@ -57,15 +61,17 @@
       "content": [
         {
           "title": "Tab1Title",
-          "group": "ee83f65c-3702-5660-8e39-f0f1cbe96f2c",
+          "group": "Tab1Title####Tab2Title",
           "member": 0,
-          "isFirstChoice": true
+          "isFirstChoice": true,
+          "description": "\nTab1Content"
         },
         {
           "title": "Tab2Title",
-          "group": "ee83f65c-3702-5660-8e39-f0f1cbe96f2c",
+          "group": "Tab1Title####Tab2Title",
           "member": 1,
-          "isFirstChoice": true
+          "isFirstChoice": true,
+          "description": "\nTab2Content"
         }
       ]
     }

--- a/test/inputs/3/wizard.json
+++ b/test/inputs/3/wizard.json
@@ -5,13 +5,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "07ef077b-29bd-47c1-80da-af4b4fa43b5b",
+        "key": "d3faf64c-8fe4-4cdf-98bd-141370b0d631",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "01afb094-0382-48d7-8fcd-ebd1df121cb5-0",
+            "id": "0d654c72-03a1-495d-8972-de79262cc091-0",
             "nesting": [
               {
                 "kind": "Import",
@@ -38,19 +38,19 @@
   },
   {
     "graph": {
-      "group": "d15f06c0-29dd-5487-a9be-0a17c9815994",
+      "group": "TabE1",
       "title": "EEE",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "5bc84e50-0d1d-48c4-8190-8df3466a73fd",
+            "key": "76a73fa0-32e5-451c-8d07-971f4f04ed36",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "01afb094-0382-48d7-8fcd-ebd1df121cb5-1",
+                "id": "0d654c72-03a1-495d-8972-de79262cc091-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -66,8 +66,9 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "d15f06c0-29dd-5487-a9be-0a17c9815994",
+                    "group": "TabE1",
                     "title": "TabE1",
+                    "description": "\nEEE1Content",
                     "member": 0,
                     "groupDetail": {
                       "child": {
@@ -91,7 +92,8 @@
               }
             ]
           },
-          "title": "TabE1"
+          "title": "TabE1",
+          "description": "\nEEE1Content"
         }
       ]
     },
@@ -101,29 +103,30 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "d15f06c0-29dd-5487-a9be-0a17c9815994",
+          "group": "TabE1",
           "member": 0,
-          "isFirstChoice": true
+          "isFirstChoice": true,
+          "description": "\nEEE1Content"
         }
       ]
     }
   },
   {
     "graph": {
-      "group": "f7ee3bc8-82d8-5529-b555-4cb5c36db8e9",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "b5fa3453-e216-4b2c-94af-01eada23c6b5",
+            "key": "42242325-bb7c-445f-a418-e3880e930dd5",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "01afb094-0382-48d7-8fcd-ebd1df121cb5-2",
+                "id": "0d654c72-03a1-495d-8972-de79262cc091-2",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -145,7 +148,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "f7ee3bc8-82d8-5529-b555-4cb5c36db8e9",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -172,7 +175,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "01afb094-0382-48d7-8fcd-ebd1df121cb5-3",
+                "id": "0d654c72-03a1-495d-8972-de79262cc091-3",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -194,7 +197,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "f7ee3bc8-82d8-5529-b555-4cb5c36db8e9",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -221,7 +224,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "01afb094-0382-48d7-8fcd-ebd1df121cb5-4",
+                "id": "0d654c72-03a1-495d-8972-de79262cc091-4",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -243,7 +246,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "f7ee3bc8-82d8-5529-b555-4cb5c36db8e9",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -273,13 +276,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "d4c8a6f6-1bcf-4722-9b8b-2ce3941b10f4",
+            "key": "ebeb3be9-c849-4ab1-9c54-8a6ad39d0294",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "01afb094-0382-48d7-8fcd-ebd1df121cb5-5",
+                "id": "0d654c72-03a1-495d-8972-de79262cc091-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -301,7 +304,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "f7ee3bc8-82d8-5529-b555-4cb5c36db8e9",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
@@ -336,13 +339,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "f7ee3bc8-82d8-5529-b555-4cb5c36db8e9",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": false
         },
         {
           "title": "SubTab2",
-          "group": "f7ee3bc8-82d8-5529-b555-4cb5c36db8e9",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": false
         }
@@ -351,27 +354,27 @@
   },
   {
     "graph": {
-      "group": "7b1882b0-675d-54b2-95c8-d8168a64acc0",
+      "group": "Tab1####Tab2",
       "title": "Main Tasks",
       "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "f5294460-e3a6-44a1-ac50-4f72c41a7ad1",
+            "key": "f74f9ca7-3675-46e5-a8cb-032e782db5a8",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importc.md",
                 "title": "importc.md",
                 "filepath": "test/inputs/snippets/importc.md",
                 "graph": {
-                  "key": "e8c84cf4-2fcf-4453-8de0-20b51725e500",
+                  "key": "c713716e-8043-4d54-bc33-7c221470c616",
                   "sequence": [
                     {
                       "body": "echo CCC",
                       "language": "bash",
                       "validate": true,
-                      "id": "01afb094-0382-48d7-8fcd-ebd1df121cb5-10",
+                      "id": "0d654c72-03a1-495d-8972-de79262cc091-10",
                       "nesting": [
                         {
                           "kind": "Import",
@@ -381,7 +384,7 @@
                         },
                         {
                           "kind": "Choice",
-                          "group": "7b1882b0-675d-54b2-95c8-d8168a64acc0",
+                          "group": "Tab1####Tab2",
                           "title": "Tab2",
                           "description": "imports:\n",
                           "member": 1,
@@ -412,7 +415,7 @@
       "content": [
         {
           "title": "Tab2",
-          "group": "7b1882b0-675d-54b2-95c8-d8168a64acc0",
+          "group": "Tab1####Tab2",
           "member": 1,
           "isFirstChoice": false,
           "description": "imports:\n"

--- a/test/inputs/4/wizard.json
+++ b/test/inputs/4/wizard.json
@@ -5,13 +5,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "3394a32e-3eae-40a1-8c0e-eb9be23550bf",
+        "key": "404a7173-6631-4447-8b2d-ec7e79c117f7",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "76f374e2-d8ff-4e4c-a343-3aa555121bf7-0",
+            "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-0",
             "nesting": [
               {
                 "kind": "Import",
@@ -38,19 +38,19 @@
   },
   {
     "graph": {
-      "group": "de95690a-0135-53fe-b94b-303619ee10c0",
+      "group": "TabE1",
       "title": "EEE",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "96b5ce4d-fb5f-475a-9d27-dd87054236a0",
+            "key": "0a828d36-d55f-42e3-a4a3-36a0fc56c963",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "76f374e2-d8ff-4e4c-a343-3aa555121bf7-1",
+                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -66,8 +66,9 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "de95690a-0135-53fe-b94b-303619ee10c0",
+                    "group": "TabE1",
                     "title": "TabE1",
+                    "description": "\nEEE1Content",
                     "member": 0,
                     "groupDetail": {
                       "child": {
@@ -91,7 +92,8 @@
               }
             ]
           },
-          "title": "TabE1"
+          "title": "TabE1",
+          "description": "\nEEE1Content"
         }
       ]
     },
@@ -101,46 +103,47 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "de95690a-0135-53fe-b94b-303619ee10c0",
+          "group": "TabE1",
           "member": 0,
-          "isFirstChoice": true
+          "isFirstChoice": true,
+          "description": "\nEEE1Content"
         }
       ]
     }
   },
   {
     "graph": {
-      "group": "00c1dc0b-3b37-5e73-8fec-b57bc8cb17d3",
+      "group": "Tab1####Tab2",
       "title": "Main Tasks",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "4ed7e24a-b294-4343-9dd3-333d90656968",
+            "key": "cea683cf-3920-426b-b0a3-f4bb448c3622",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "4ecbc806-761e-44ab-889e-d3d2838df42f",
+                  "key": "58cc085b-00cb-4a35-807e-fa653865ecb4",
                   "sequence": [
                     {
-                      "group": "8ad6b8c4-c774-5836-900c-06df8d0ddfcf",
+                      "group": "SubTab1####SubTab2",
                       "title": "DDD",
                       "source": "placeholder",
                       "choices": [
                         {
                           "member": 0,
                           "graph": {
-                            "key": "1648c241-7f8c-414a-8083-75d29c8e5d92",
+                            "key": "00e9031c-521c-4976-9831-3dfc09c5c75c",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "76f374e2-d8ff-4e4c-a343-3aa555121bf7-2",
+                                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-2",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -150,7 +153,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "00c1dc0b-3b37-5e73-8fec-b57bc8cb17d3",
+                                    "group": "Tab1####Tab2",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -164,7 +167,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "8ad6b8c4-c774-5836-900c-06df8d0ddfcf",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
@@ -191,7 +194,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "76f374e2-d8ff-4e4c-a343-3aa555121bf7-3",
+                                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-3",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -201,7 +204,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "00c1dc0b-3b37-5e73-8fec-b57bc8cb17d3",
+                                    "group": "Tab1####Tab2",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -215,7 +218,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "8ad6b8c4-c774-5836-900c-06df8d0ddfcf",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
@@ -242,7 +245,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "76f374e2-d8ff-4e4c-a343-3aa555121bf7-4",
+                                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-4",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -252,7 +255,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "00c1dc0b-3b37-5e73-8fec-b57bc8cb17d3",
+                                    "group": "Tab1####Tab2",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -266,7 +269,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "8ad6b8c4-c774-5836-900c-06df8d0ddfcf",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
@@ -296,13 +299,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "62869523-c9ac-4f38-b10e-d6d38fedbb69",
+                            "key": "8fa8768e-d470-4803-961d-03d1d0532f93",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "76f374e2-d8ff-4e4c-a343-3aa555121bf7-5",
+                                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-5",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -312,7 +315,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "00c1dc0b-3b37-5e73-8fec-b57bc8cb17d3",
+                                    "group": "Tab1####Tab2",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -326,7 +329,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "8ad6b8c4-c774-5836-900c-06df8d0ddfcf",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab2",
                                     "member": 1,
                                     "groupDetail": {
@@ -367,12 +370,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "e9fa5d23-2318-4759-ae07-b5850eb755aa",
+            "key": "ffe8f02a-9b3a-4278-96c8-aab063217d88",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "76f374e2-d8ff-4e4c-a343-3aa555121bf7-6",
+                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-6",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -382,8 +385,9 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "00c1dc0b-3b37-5e73-8fec-b57bc8cb17d3",
+                    "group": "Tab1####Tab2",
                     "title": "Tab2",
+                    "description": "\nBBBoo",
                     "member": 1,
                     "groupDetail": {}
                   }
@@ -391,7 +395,8 @@
               }
             ]
           },
-          "title": "Tab2"
+          "title": "Tab2",
+          "description": "\nBBBoo"
         }
       ]
     },
@@ -401,16 +406,17 @@
       "content": [
         {
           "title": "Tab1",
-          "group": "00c1dc0b-3b37-5e73-8fec-b57bc8cb17d3",
+          "group": "Tab1####Tab2",
           "member": 0,
           "isFirstChoice": false,
           "description": "imports:\n"
         },
         {
           "title": "Tab2",
-          "group": "00c1dc0b-3b37-5e73-8fec-b57bc8cb17d3",
+          "group": "Tab1####Tab2",
           "member": 1,
-          "isFirstChoice": false
+          "isFirstChoice": false,
+          "description": "\nBBBoo"
         }
       ]
     }

--- a/test/inputs/5/wizard.json
+++ b/test/inputs/5/wizard.json
@@ -5,13 +5,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "6b9ff724-4e4c-4b4c-8553-f41dab34d68a",
+        "key": "2b63583a-712e-4ddd-a056-c8b90085c07f",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "26c04ced-8171-4b04-b715-34d980968042-0",
+            "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-0",
             "nesting": [
               {
                 "kind": "Import",
@@ -38,19 +38,19 @@
   },
   {
     "graph": {
-      "group": "622cbfcb-8e4d-572f-8230-fe864f72601f",
+      "group": "TabE1",
       "title": "EEE",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "199e83bd-1393-48a9-908a-83c925064f85",
+            "key": "59777299-8825-47db-8908-be99040b2ab4",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "26c04ced-8171-4b04-b715-34d980968042-1",
+                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -66,8 +66,9 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "622cbfcb-8e4d-572f-8230-fe864f72601f",
+                    "group": "TabE1",
                     "title": "TabE1",
+                    "description": "\nEEE1Content",
                     "member": 0,
                     "groupDetail": {
                       "child": {
@@ -91,7 +92,8 @@
               }
             ]
           },
-          "title": "TabE1"
+          "title": "TabE1",
+          "description": "\nEEE1Content"
         }
       ]
     },
@@ -101,46 +103,47 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "622cbfcb-8e4d-572f-8230-fe864f72601f",
+          "group": "TabE1",
           "member": 0,
-          "isFirstChoice": true
+          "isFirstChoice": true,
+          "description": "\nEEE1Content"
         }
       ]
     }
   },
   {
     "graph": {
-      "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+      "group": "Tab1####Tab2####Tab3",
       "title": "Main Tasks",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "53ca6c55-5925-4e00-b2b4-9755b20c6e09",
+            "key": "6a0df852-5637-42b2-b849-837916961a21",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "9ec1e9eb-57fe-4ff2-9b6f-ff002f5fe831",
+                  "key": "ed1f01a5-5a3a-4741-b1d6-6a68d24b40f3",
                   "sequence": [
                     {
-                      "group": "86d28ed8-11b9-5dae-b18b-124115591d34",
+                      "group": "SubTab1####SubTab2",
                       "title": "DDD",
                       "source": "placeholder",
                       "choices": [
                         {
                           "member": 0,
                           "graph": {
-                            "key": "c4791018-7324-4605-b134-33734756080e",
+                            "key": "f64dbdf6-9651-468d-ab3b-5b462ec41562",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "26c04ced-8171-4b04-b715-34d980968042-2",
+                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-2",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -150,7 +153,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+                                    "group": "Tab1####Tab2####Tab3",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -164,7 +167,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "86d28ed8-11b9-5dae-b18b-124115591d34",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
@@ -191,7 +194,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "26c04ced-8171-4b04-b715-34d980968042-3",
+                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-3",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -201,7 +204,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+                                    "group": "Tab1####Tab2####Tab3",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -215,7 +218,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "86d28ed8-11b9-5dae-b18b-124115591d34",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
@@ -242,7 +245,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "26c04ced-8171-4b04-b715-34d980968042-4",
+                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-4",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -252,7 +255,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+                                    "group": "Tab1####Tab2####Tab3",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -266,7 +269,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "86d28ed8-11b9-5dae-b18b-124115591d34",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
@@ -296,13 +299,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "053f56d9-8f52-425b-842a-d3867091d618",
+                            "key": "6b221e82-4a24-4f67-9737-94994b31a432",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "26c04ced-8171-4b04-b715-34d980968042-5",
+                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-5",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -312,7 +315,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+                                    "group": "Tab1####Tab2####Tab3",
                                     "title": "Tab1",
                                     "description": "imports:\n",
                                     "member": 0,
@@ -326,7 +329,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "86d28ed8-11b9-5dae-b18b-124115591d34",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab2",
                                     "member": 1,
                                     "groupDetail": {
@@ -367,12 +370,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "39bff9d1-146b-4398-9025-b74298bc108e",
+            "key": "1d0c6585-d92c-4029-b7d1-c514c25ab56d",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "26c04ced-8171-4b04-b715-34d980968042-6",
+                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-6",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -382,8 +385,9 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+                    "group": "Tab1####Tab2####Tab3",
                     "title": "Tab2",
+                    "description": "\nBBBoo",
                     "member": 1,
                     "groupDetail": {}
                   }
@@ -391,35 +395,36 @@
               }
             ]
           },
-          "title": "Tab2"
+          "title": "Tab2",
+          "description": "\nBBBoo"
         },
         {
           "member": 2,
           "graph": {
-            "key": "0d68af74-6122-4048-b5b9-36219dcc665a",
+            "key": "f5017c9d-b9e0-446a-b353-eee632af2e4f",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "1c83796a-caba-4bf4-a37a-38f72814359d",
+                  "key": "94e2d3ee-a96b-4f76-accd-788871688717",
                   "sequence": [
                     {
-                      "group": "86d28ed8-11b9-5dae-b18b-124115591d34",
+                      "group": "SubTab1####SubTab2",
                       "title": "DDD",
                       "source": "placeholder",
                       "choices": [
                         {
                           "member": 0,
                           "graph": {
-                            "key": "6cae2b25-0078-461e-913e-67d78eaa7a3c",
+                            "key": "ecc243d5-da1e-430e-990d-fdaf8e2d0964",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "26c04ced-8171-4b04-b715-34d980968042-7",
+                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-7",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -429,7 +434,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+                                    "group": "Tab1####Tab2####Tab3",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
@@ -443,7 +448,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "86d28ed8-11b9-5dae-b18b-124115591d34",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
@@ -470,7 +475,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "26c04ced-8171-4b04-b715-34d980968042-8",
+                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-8",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -480,7 +485,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+                                    "group": "Tab1####Tab2####Tab3",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
@@ -494,7 +499,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "86d28ed8-11b9-5dae-b18b-124115591d34",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
@@ -521,7 +526,7 @@
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "26c04ced-8171-4b04-b715-34d980968042-9",
+                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-9",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -531,7 +536,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+                                    "group": "Tab1####Tab2####Tab3",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
@@ -545,7 +550,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "86d28ed8-11b9-5dae-b18b-124115591d34",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab1",
                                     "member": 0,
                                     "groupDetail": {
@@ -575,13 +580,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "65fd50ba-b829-4177-ad09-d7a527057c00",
+                            "key": "c4db5c46-cccf-4b2a-a9a9-9d4ba4c553c5",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "26c04ced-8171-4b04-b715-34d980968042-10",
+                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-10",
                                 "nesting": [
                                   {
                                     "kind": "Import",
@@ -591,7 +596,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+                                    "group": "Tab1####Tab2####Tab3",
                                     "title": "Tab3",
                                     "description": "imports:\n",
                                     "member": 2,
@@ -605,7 +610,7 @@
                                   },
                                   {
                                     "kind": "Choice",
-                                    "group": "86d28ed8-11b9-5dae-b18b-124115591d34",
+                                    "group": "SubTab1####SubTab2",
                                     "title": "SubTab2",
                                     "member": 1,
                                     "groupDetail": {
@@ -651,20 +656,21 @@
       "content": [
         {
           "title": "Tab1",
-          "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+          "group": "Tab1####Tab2####Tab3",
           "member": 0,
           "isFirstChoice": false,
           "description": "imports:\n"
         },
         {
           "title": "Tab2",
-          "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+          "group": "Tab1####Tab2####Tab3",
           "member": 1,
-          "isFirstChoice": false
+          "isFirstChoice": false,
+          "description": "\nBBBoo"
         },
         {
           "title": "Tab3",
-          "group": "5f442d36-19c6-5f73-a3b7-3d0b99e5a6c2",
+          "group": "Tab1####Tab2####Tab3",
           "member": 2,
           "isFirstChoice": false,
           "description": "imports:\n"

--- a/test/inputs/6/wizard.json
+++ b/test/inputs/6/wizard.json
@@ -1,20 +1,20 @@
 [
   {
     "graph": {
-      "group": "4a4f6237-7753-58e1-8461-539d54396ae8",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "067ddb2b-8508-4075-a68f-03fb32d93517",
+            "key": "622dfde3-eabd-4189-969d-ad1c58327a83",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "e801caff-4932-4464-ad72-dcf031d55db0-0",
+                "id": "0c6f9eab-4128-4c24-b394-648906b45572-0",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -24,7 +24,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "4a4f6237-7753-58e1-8461-539d54396ae8",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -51,7 +51,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "e801caff-4932-4464-ad72-dcf031d55db0-1",
+                "id": "0c6f9eab-4128-4c24-b394-648906b45572-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -61,7 +61,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "4a4f6237-7753-58e1-8461-539d54396ae8",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -88,7 +88,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "e801caff-4932-4464-ad72-dcf031d55db0-2",
+                "id": "0c6f9eab-4128-4c24-b394-648906b45572-2",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -98,7 +98,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "4a4f6237-7753-58e1-8461-539d54396ae8",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -128,13 +128,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "282cfe72-748f-46bd-8130-11b45c0c464c",
+            "key": "31bdd4d7-9156-4c1c-b6ed-a92d0430fab1",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "e801caff-4932-4464-ad72-dcf031d55db0-3",
+                "id": "0c6f9eab-4128-4c24-b394-648906b45572-3",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -144,7 +144,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "4a4f6237-7753-58e1-8461-539d54396ae8",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
@@ -179,13 +179,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "4a4f6237-7753-58e1-8461-539d54396ae8",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "4a4f6237-7753-58e1-8461-539d54396ae8",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": true
         }
@@ -198,13 +198,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "1b9f9312-c710-4da9-8514-eeb53dc9e868",
+        "key": "2ee07653-d358-46fe-afd8-f08fc67ba86f",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "e801caff-4932-4464-ad72-dcf031d55db0-4",
+            "id": "0c6f9eab-4128-4c24-b394-648906b45572-4",
             "nesting": [
               {
                 "kind": "Import",
@@ -231,19 +231,19 @@
   },
   {
     "graph": {
-      "group": "ef0d4974-f17b-559c-a252-c8e7fadc40ea",
+      "group": "TabE1",
       "title": "EEE",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "43df39a5-b702-4f69-9bcf-c13de9226cee",
+            "key": "7e022526-3eea-4a14-8961-b9d648dd856f",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "e801caff-4932-4464-ad72-dcf031d55db0-5",
+                "id": "0c6f9eab-4128-4c24-b394-648906b45572-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -259,8 +259,9 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "ef0d4974-f17b-559c-a252-c8e7fadc40ea",
+                    "group": "TabE1",
                     "title": "TabE1",
+                    "description": "\nEEE1Content",
                     "member": 0,
                     "groupDetail": {
                       "child": {
@@ -284,7 +285,8 @@
               }
             ]
           },
-          "title": "TabE1"
+          "title": "TabE1",
+          "description": "\nEEE1Content"
         }
       ]
     },
@@ -294,28 +296,29 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "ef0d4974-f17b-559c-a252-c8e7fadc40ea",
+          "group": "TabE1",
           "member": 0,
-          "isFirstChoice": false
+          "isFirstChoice": false,
+          "description": "\nEEE1Content"
         }
       ]
     }
   },
   {
     "graph": {
-      "group": "66e55a6c-4243-5c8b-be5a-2eb80c64d97a",
+      "group": "Tab1####Tab2####Tab3",
       "title": "snippets-in-tab5.md",
       "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "608b5043-5c02-4f09-949d-7934f429b723",
+            "key": "7bd8e9bc-69c8-44d6-8477-4a59682aab1d",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "e801caff-4932-4464-ad72-dcf031d55db0-10",
+                "id": "0c6f9eab-4128-4c24-b394-648906b45572-10",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -325,8 +328,9 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "66e55a6c-4243-5c8b-be5a-2eb80c64d97a",
+                    "group": "Tab1####Tab2####Tab3",
                     "title": "Tab2",
+                    "description": "\nBBBoo",
                     "member": 1,
                     "groupDetail": {}
                   }
@@ -334,7 +338,8 @@
               }
             ]
           },
-          "title": "Tab2"
+          "title": "Tab2",
+          "description": "\nBBBoo"
         }
       ]
     },
@@ -344,9 +349,10 @@
       "content": [
         {
           "title": "Tab2",
-          "group": "66e55a6c-4243-5c8b-be5a-2eb80c64d97a",
+          "group": "Tab1####Tab2####Tab3",
           "member": 1,
-          "isFirstChoice": false
+          "isFirstChoice": false,
+          "description": "\nBBBoo"
         }
       ]
     }

--- a/test/inputs/7/wizard.json
+++ b/test/inputs/7/wizard.json
@@ -1,20 +1,20 @@
 [
   {
     "graph": {
-      "group": "c17ab9a1-20c8-59bd-be71-d8c25b5b9d9b",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "9c39f3ad-f525-48ae-a224-5859e5af5ebf",
+            "key": "2a45ea57-5695-44fa-a588-1b1525ec8121",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "c51fb0f3-923a-4a37-99f1-675f1746707b-0",
+                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-0",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -24,7 +24,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "c17ab9a1-20c8-59bd-be71-d8c25b5b9d9b",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -51,7 +51,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "c51fb0f3-923a-4a37-99f1-675f1746707b-1",
+                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -61,7 +61,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "c17ab9a1-20c8-59bd-be71-d8c25b5b9d9b",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -88,7 +88,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "c51fb0f3-923a-4a37-99f1-675f1746707b-2",
+                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-2",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -98,7 +98,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "c17ab9a1-20c8-59bd-be71-d8c25b5b9d9b",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -128,13 +128,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "4298dba2-0080-4ef8-823e-eaffb2b0a56c",
+            "key": "f80f9286-c302-4dfb-ae84-aee2a1d489a8",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "c51fb0f3-923a-4a37-99f1-675f1746707b-3",
+                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-3",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -144,7 +144,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "c17ab9a1-20c8-59bd-be71-d8c25b5b9d9b",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
@@ -179,13 +179,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "c17ab9a1-20c8-59bd-be71-d8c25b5b9d9b",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "c17ab9a1-20c8-59bd-be71-d8c25b5b9d9b",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": true
         }
@@ -198,13 +198,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "3f191a8a-7b10-4d00-9036-e2d4c8ab6116",
+        "key": "dda041da-af71-4c89-ac1d-c16c0325cc2c",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "c51fb0f3-923a-4a37-99f1-675f1746707b-4",
+            "id": "d32658b7-423b-464d-8186-b807c2ae7f72-4",
             "nesting": [
               {
                 "kind": "Import",
@@ -231,19 +231,19 @@
   },
   {
     "graph": {
-      "group": "dc89c018-4729-58a1-bec2-4fa5af33055e",
+      "group": "TabE1",
       "title": "EEE",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "1c76b86a-4e6e-4229-a81d-e4307e0f1403",
+            "key": "7aa2075a-cb05-4011-9d0c-713832440828",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "c51fb0f3-923a-4a37-99f1-675f1746707b-5",
+                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-5",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -259,8 +259,9 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "dc89c018-4729-58a1-bec2-4fa5af33055e",
+                    "group": "TabE1",
                     "title": "TabE1",
+                    "description": "\nEEE1Content",
                     "member": 0,
                     "groupDetail": {
                       "child": {
@@ -284,7 +285,8 @@
               }
             ]
           },
-          "title": "TabE1"
+          "title": "TabE1",
+          "description": "\nEEE1Content"
         }
       ]
     },
@@ -294,28 +296,29 @@
       "content": [
         {
           "title": "TabE1",
-          "group": "dc89c018-4729-58a1-bec2-4fa5af33055e",
+          "group": "TabE1",
           "member": 0,
-          "isFirstChoice": false
+          "isFirstChoice": false,
+          "description": "\nEEE1Content"
         }
       ]
     }
   },
   {
     "graph": {
-      "group": "40a0463b-e741-5735-b45f-6d7099863c9e",
+      "group": "Tab1####Tab2####Tab3",
       "title": "snippets-in-tab5.md",
       "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "f70ab651-18b1-4ffd-9b1f-98bcd5fa460f",
+            "key": "a5e6e911-5b38-49da-a7f6-02cb268e2989",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "c51fb0f3-923a-4a37-99f1-675f1746707b-10",
+                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-10",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -325,8 +328,9 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "40a0463b-e741-5735-b45f-6d7099863c9e",
+                    "group": "Tab1####Tab2####Tab3",
                     "title": "Tab2",
+                    "description": "\nBBBoo",
                     "member": 1,
                     "groupDetail": {}
                   }
@@ -334,7 +338,8 @@
               }
             ]
           },
-          "title": "Tab2"
+          "title": "Tab2",
+          "description": "\nBBBoo"
         }
       ]
     },
@@ -344,9 +349,10 @@
       "content": [
         {
           "title": "Tab2",
-          "group": "40a0463b-e741-5735-b45f-6d7099863c9e",
+          "group": "Tab1####Tab2####Tab3",
           "member": 1,
-          "isFirstChoice": false
+          "isFirstChoice": false,
+          "description": "\nBBBoo"
         }
       ]
     }

--- a/test/inputs/8/wizard.json
+++ b/test/inputs/8/wizard.json
@@ -1,20 +1,20 @@
 [
   {
     "graph": {
-      "group": "cb7be6cd-029b-5d71-8314-5b89718fe630",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "6ef5437d-dc06-4e0f-974d-fe6feb3e209b",
+            "key": "d31fb27f-02ab-4c2b-809c-caf8d3a71ea6",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "07bfc324-9634-4272-b8c4-7f715dee2294-0",
+                "id": "4f47be51-375e-4be9-8a90-5409539a9bec-0",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -24,7 +24,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "c75d9e12-67f2-5ddf-9fde-b97ed33c7047",
+                    "group": "Tab1####Tab2####Tab3",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
@@ -53,7 +53,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "cb7be6cd-029b-5d71-8314-5b89718fe630",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -80,7 +80,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "07bfc324-9634-4272-b8c4-7f715dee2294-1",
+                "id": "4f47be51-375e-4be9-8a90-5409539a9bec-1",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -90,7 +90,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "c75d9e12-67f2-5ddf-9fde-b97ed33c7047",
+                    "group": "Tab1####Tab2####Tab3",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
@@ -119,7 +119,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "cb7be6cd-029b-5d71-8314-5b89718fe630",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -146,7 +146,7 @@
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "07bfc324-9634-4272-b8c4-7f715dee2294-2",
+                "id": "4f47be51-375e-4be9-8a90-5409539a9bec-2",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -156,7 +156,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "c75d9e12-67f2-5ddf-9fde-b97ed33c7047",
+                    "group": "Tab1####Tab2####Tab3",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
@@ -185,7 +185,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "cb7be6cd-029b-5d71-8314-5b89718fe630",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab1",
                     "member": 0,
                     "groupDetail": {
@@ -215,13 +215,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "7fbcd1c6-a06f-4375-9b87-f99a24c2d218",
+            "key": "e4ad1147-046e-497f-ab7d-8d4b7f424211",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "07bfc324-9634-4272-b8c4-7f715dee2294-3",
+                "id": "4f47be51-375e-4be9-8a90-5409539a9bec-3",
                 "nesting": [
                   {
                     "kind": "Import",
@@ -231,7 +231,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "c75d9e12-67f2-5ddf-9fde-b97ed33c7047",
+                    "group": "Tab1####Tab2####Tab3",
                     "title": "Tab1",
                     "member": 0,
                     "groupDetail": {
@@ -260,7 +260,7 @@
                   },
                   {
                     "kind": "Choice",
-                    "group": "cb7be6cd-029b-5d71-8314-5b89718fe630",
+                    "group": "SubTab1####SubTab2",
                     "title": "SubTab2",
                     "member": 1,
                     "groupDetail": {
@@ -295,13 +295,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "cb7be6cd-029b-5d71-8314-5b89718fe630",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "cb7be6cd-029b-5d71-8314-5b89718fe630",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": true
         }


### PR DESCRIPTION
When we are scanning for a "first paragraph", we have been ignoring text nodes; we were only looking for paragraph nodes. Text nodes come from cases where there is no newline after a tab title or section header line, for example.