### PR TITLE
fix: tree may wrap undesirably

### DIFF
--- a/src/fe/tree/pretty-print.ts
+++ b/src/fe/tree/pretty-print.ts
@@ -76,7 +76,7 @@ export function prettyPrintUITree(
     const name = node.name || node.title
 
     if (narrow) {
-      write(elide(name, prefix.length) + EOL)
+      write(elide(name, indent.length + prefix.length) + EOL)
     } else {
       write(name.replace(new RegExp(EOL, "g"), EOL + indent + prefix + nextPrefix) + EOL)
     }


### PR DESCRIPTION
the `elide()` call in `pretty-print.ts` ignores the width of the optional `indent` parameter