### PR TITLE
feat: allow fetching from non-raw github urls

### DIFF
--- a/src/parser/markdown/index.ts
+++ b/src/parser/markdown/index.ts
@@ -37,6 +37,7 @@ import { hackMarkdownSource } from "./hack"
 import remarkDirective from "remark-directive"
 
 import inlineSnippets from "./snippets"
+import { toRawGithubUserContent } from "./snippets/urls"
 
 import frontmatter from "remark-frontmatter"
 
@@ -150,6 +151,9 @@ export async function blockify(
   reader = read,
   madwizardOptions?: MadWizardOptions
 ) {
-  const file = typeof input === "string" ? await reader(new VFile({ path: expandHomeDir(input) })) : new VFile(input)
+  const file =
+    typeof input === "string"
+      ? await reader(new VFile({ path: toRawGithubUserContent(expandHomeDir(input)) }))
+      : new VFile(input)
   return parse(file, choices, uuid, reader, madwizardOptions)
 }

--- a/src/parser/markdown/snippets/urls.ts
+++ b/src/parser/markdown/snippets/urls.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function isUrl(a: string) {
+  return /^https?:/.test(a)
+}
+
+/**
+ * For example, transform A to B:
+ * A: https://github.com/org/repo/blob/branch/path
+ * B: https://raw.githubusercontent.com/org/repo/branch/path
+ */
+export function toRawGithubUserContent(uri: string) {
+  const re = /^https:\/\/github.com\/([^/]+)\/([^/]+)\/blob\/([^/]+)\/(.+)$/
+  const match = uri.match(re)
+
+  if (!match) {
+    return uri
+  } else {
+    const [org, repo, branch, path] = match.slice(1)
+    return `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${path}`
+  }
+}


### PR DESCRIPTION
it is often convenient to copy and paste a "normal" github url, rather than having to click a few more times to get the "raw" github url. we can easily do the transformation for the user.