### PR TITLE
chore: remove unnecessary `@types/figures` dependence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@parcel/packager-ts": "^2.5.0",
         "@parcel/transformer-typescript-types": "^2.5.0",
         "@types/debug": "^4.1.7",
-        "@types/figures": "^3.0.1",
         "@types/hast": "^2.3.4",
         "@types/inquirer": "^8.2.1",
         "@types/js-yaml": "^4.0.5",
@@ -1740,16 +1739,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
       "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
-    },
-    "node_modules/@types/figures": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/figures/-/figures-3.0.1.tgz",
-      "integrity": "sha512-2OXodKWdNhYl+S+wCvlafqJbfMIVDfQZYX2wRyUOcRiEQpeJ9zU6cT7d+RbMpjS+/vmQ2cAUUL8gyGy1YxtLPw==",
-      "deprecated": "This is a stub types definition. figures provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "figures": "*"
-      }
     },
     "node_modules/@types/hast": {
       "version": "2.3.4",
@@ -8592,15 +8581,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
       "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
-    },
-    "@types/figures": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/figures/-/figures-3.0.1.tgz",
-      "integrity": "sha512-2OXodKWdNhYl+S+wCvlafqJbfMIVDfQZYX2wRyUOcRiEQpeJ9zU6cT7d+RbMpjS+/vmQ2cAUUL8gyGy1YxtLPw==",
-      "dev": true,
-      "requires": {
-        "figures": "*"
-      }
     },
     "@types/hast": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@parcel/packager-ts": "^2.5.0",
     "@parcel/transformer-typescript-types": "^2.5.0",
     "@types/debug": "^4.1.7",
-    "@types/figures": "^3.0.1",
     "@types/hast": "^2.3.4",
     "@types/inquirer": "^8.2.1",
     "@types/js-yaml": "^4.0.5",


### PR DESCRIPTION
> npm WARN deprecated @types/figures@3.0.1: This is a stub types definition. figures provides its own type definitions, so you do not need this installed.