### PR TITLE
fix: add --no-warnings to bin/madwizard.js

### DIFF
--- a/bin/madwizard.js
+++ b/bin/madwizard.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-specifier-resolution=node
+#!/usr/bin/env node --experimental-specifier-resolution=node --no-warnings
 
 /* eslint-env node */
 /* ^^^ rather than add env: node globally in package.json */


### PR DESCRIPTION
Since we are using an experimental option, we should probably suppress the inevitable `ExperimentalWarning`.