### PR TITLE
chore: improved debugging of aprioris detection

### DIFF
--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -26,10 +26,14 @@ import { prettyPrintUITreeFromBlocks, Treeifier, DevNullUI } from "../tree"
 
 export { Guide }
 
-type Task = "tree" | "json" | "guide" | "timing" | "fetch" | "topmatter"
+type Task = "tree" | "json" | "guide" | "timing" | "fetch" | "topmatter" | "aprioris"
 
 function validTasks(): Task[] {
-  return ["tree", "json", "guide", "timing", "fetch", "topmatter"]
+  return ["tree", "json", "guide", "timing", "fetch", "topmatter", "aprioris"]
+}
+
+function isDebugTask(task: Task) {
+  return task === "timing" || task === "fetch" || task === "topmatter" || task === "aprioris"
 }
 
 function isValidTask(task: string): task is Task {
@@ -83,7 +87,7 @@ export async function cli<Writer extends (msg: string) => boolean>(
   }
 
   try {
-    if (task === "topmatter" || task === "timing" || task === "fetch") {
+    if (isDebugTask(task)) {
       enableTracing(task)
     }
 
@@ -91,6 +95,7 @@ export async function cli<Writer extends (msg: string) => boolean>(
 
     switch (task) {
       case "topmatter":
+      case "aprioris":
         break
 
       case "timing":

--- a/src/parser/markdown/rehype-tabbed/groups/arch.ts
+++ b/src/parser/markdown/rehype-tabbed/groups/arch.ts
@@ -16,6 +16,7 @@
 
 import { Element } from "hast"
 
+import debug from "./debug"
 import { ChoiceState } from "../../../../choices"
 import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from ".."
 
@@ -59,12 +60,15 @@ class Arch {
 
   /** Set the architecture choice group to use the current host arch */
   public populateChoice(choices: ChoiceState) {
-    choices.set(this.choiceGroup, process.arch, false)
+    const choice = process.arch
+    debug("arch", "using choice " + choice)
+    choices.set(this.choiceGroup, choice, false)
   }
 
   /** Check if the given `node` is a tab group that we can inform */
   public checkAndSet(node: Element) {
     if (this.isMatchingTabGroup(node)) {
+      debug("arch", "found matching tab group")
       setTabGroup(node, this.choiceGroup)
       this.rewriteTabsToUseCanonicalNames(node)
       return true

--- a/src/parser/markdown/rehype-tabbed/groups/debug.ts
+++ b/src/parser/markdown/rehype-tabbed/groups/debug.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Debug from "debug"
+
+export default function debug(subtask: string, formatter: string, ...args: string[]) {
+  return Debug(`madwizard/aprioris/${subtask}`)(formatter, ...args)
+}

--- a/src/parser/markdown/rehype-tabbed/groups/homebrew.ts
+++ b/src/parser/markdown/rehype-tabbed/groups/homebrew.ts
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import Debug from "debug"
 import { Element } from "hast"
 import which from "which"
 
+import debug from "./debug"
 import { ChoiceState } from "../../../../choices"
 import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from ".."
-
-const debug = Debug("rehype-tabbed/groups/homebrew")
 
 class Homebrew {
   /** the value should be namespaced and unique, but the particulars don't matter */
@@ -62,16 +60,19 @@ class Homebrew {
     // .catch(err => debug('Homebrew probably not found', err))
     try {
       if (which.sync("brew")) {
-        choices.set(this.choiceGroup, this.canonicalName, false)
+        const choice = this.canonicalName
+        debug("homebrew", "using choice " + choice)
+        choices.set(this.choiceGroup, choice, false)
       }
     } catch (err) {
-      debug("Homebrew probably not found", err)
+      debug("homebrew", "probably not installed", err)
     }
   }
 
   /** Check if the given `node` is a tab group that we can inform */
   public checkAndSet(node: Element) {
     if (this.isMatchingTabGroup(node)) {
+      debug("homebrew", "found matching tab group")
       setTabGroup(node, this.choiceGroup)
       this.rewriteTabsToUseCanonicalNames(node)
       return true

--- a/src/parser/markdown/rehype-tabbed/groups/interminal.ts
+++ b/src/parser/markdown/rehype-tabbed/groups/interminal.ts
@@ -16,6 +16,7 @@
 
 import { Element } from "hast"
 
+import debug from "./debug"
 import { ChoiceState } from "../../../../choices"
 import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from ".."
 
@@ -61,12 +62,15 @@ class RunningInTerminal {
 
   /** Set the platform choice group to use the current host platform */
   public populateChoice(choices: ChoiceState) {
-    choices.set(this.choiceGroup, this.inTerminal(), false)
+    const choice = this.inTerminal()
+    debug("interminal", "using choice " + choice)
+    choices.set(this.choiceGroup, choice, false)
   }
 
   /** Check if the given `node` is a tab group that we can inform */
   public checkAndSet(node: Element) {
     if (this.isMatchingTabGroup(node)) {
+      debug("interminal", "found matching tab group")
       setTabGroup(node, this.choiceGroup)
       this.rewriteTabsToUseCanonicalNames(node)
       return true

--- a/src/parser/markdown/rehype-tabbed/groups/platform.ts
+++ b/src/parser/markdown/rehype-tabbed/groups/platform.ts
@@ -16,6 +16,7 @@
 
 import { Element } from "hast"
 
+import debug from "./debug"
 import { ChoiceState } from "../../../../choices"
 import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from ".."
 
@@ -33,6 +34,11 @@ class Platform {
     win: "win32",
     win32: "win32",
     windows: "win32",
+
+    wsl: "linux",
+    wsl2: "linux",
+    "windows subsystem for linux": "linux",
+    "windows subsystem for linux 2": "linux",
   }
 
   private readonly findPlatform = (str: string) => this.platforms[str.toLowerCase()]
@@ -60,12 +66,15 @@ class Platform {
 
   /** Set the platform choice group to use the current host platform */
   public populateChoice(choices: ChoiceState) {
-    choices.set(this.choiceGroup, process.platform, false)
+    const choice = process.platform
+    debug("platform", "using choice " + choice)
+    choices.set(this.choiceGroup, choice, false)
   }
 
   /** Check if the given `node` is a tab group that we can inform */
   public checkAndSet(node: Element) {
     if (this.isMatchingTabGroup(node)) {
+      debug("platform", "found matching tab group")
       setTabGroup(node, this.choiceGroup)
       this.rewriteTabsToUseCanonicalNames(node)
       return true


### PR DESCRIPTION
```shell
madwizard aprioris <filepath or uri>
  madwizard/aprioris/arch using choice x64 +0ms
  madwizard/aprioris/platform using choice darwin +0ms
  madwizard/aprioris/homebrew using choice Homebrew +0ms
  madwizard/aprioris/interminal using choice Text +0ms
  madwizard/aprioris/platform found matching tab group +0ms
  madwizard/aprioris/homebrew found matching tab group +0ms
  madwizard/aprioris/arch found matching tab group +0ms
  madwizard/aprioris/homebrew found matching tab group +0ms
  madwizard/aprioris/homebrew found matching tab group +0ms
```