### PR TITLE
fix: add -S option to /usr/bin/env in bin/madwizard.js

### DIFF
--- a/bin/madwizard.js
+++ b/bin/madwizard.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-specifier-resolution=node --no-warnings
+#!/usr/bin/env -S node --experimental-specifier-resolution=node --no-warnings
 
 /* eslint-env node */
 /* ^^^ rather than add env: node globally in package.json */


### PR DESCRIPTION
Apparently macOS didn't need this, but linux does.