### PR TITLE
feat: pre-validate wizard choice steps

### DIFF
--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -115,7 +115,7 @@ export async function cli<Writer extends (msg: string) => boolean>(
 
       case "json": {
         const graph = compile(blocks, choices)
-        const wizard = wizardify(graph)
+        const wizard = await wizardify(graph)
         ;(write || process.stdout.write.bind(process.stdout))(
           JSON.stringify(
             wizard,

--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -52,9 +52,9 @@ export class Guide {
    * @param iter How many questions have we asked so far?
    * @return the list of remaining questions
    */
-  private questions(iter: number) {
+  private async questions(iter: number) {
     const graph = compile(this.blocks, this.choices)
-    const steps = wizardify(graph)
+    const steps = await wizardify(graph, { validator: shellExec })
 
     const choiceSteps = steps.filter(isChoiceStep)
     const taskSteps = steps.filter(isTaskStep)
@@ -293,6 +293,9 @@ export class Guide {
   private async resolveChoices(iter = 0) {
     const { graph, choiceSteps, taskSteps, questions } = await this.questions(iter)
 
+    // start a fresh screen before presenting the guide proper
+    console.clear()
+
     if (iter === 0) {
       this.presentGuidebookTitle(graph)
     }
@@ -308,7 +311,6 @@ export class Guide {
   }
 
   public async run() {
-    console.clear()
     const taskSteps = await this.resolveChoices()
     try {
       this.showPlan(true, true)

--- a/src/fe/guide/taskrunner.ts
+++ b/src/fe/guide/taskrunner.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import ora from "ora"
 import { EOL } from "os"
+import ora, { Ora } from "ora"
 import { mainSymbols } from "figures"
 import chalk, { ChalkInstance } from "chalk"
 
@@ -56,6 +56,13 @@ async function promiseEach<T, R>(arr: T[], fn: (t: T, idx: number) => R | Promis
   return result
 }
 
+export function skip(ora: Ora, text: string) {
+  ora.stopAndPersist({
+    text,
+    symbol: chalk.blue(mainSymbols.arrowDown),
+  })
+}
+
 class TaskWrapperImpl implements TaskWrapper {
   public constructor(
     private readonly title: string,
@@ -65,10 +72,7 @@ class TaskWrapperImpl implements TaskWrapper {
 
   public skip(parentheticalMsg = "SKIPPED", fullMsg = ` [${parentheticalMsg}]`) {
     if (this.spinner) {
-      this.spinner.stopAndPersist({
-        text: this.title + chalk.yellow(fullMsg),
-        symbol: chalk.blue(mainSymbols.arrowDown),
-      })
+      skip(this.spinner, this.title + chalk.yellow(fullMsg))
     } else {
       this.stream.write(chalk.yellow(fullMsg))
       this.stream.write(EOL)

--- a/src/graph/validate.ts
+++ b/src/graph/validate.ts
@@ -100,7 +100,7 @@ function union(A: Promise<Status[]>) {
   return A.then((A) => A.slice(1).reduce(succeedFast, A[0]))
 }
 
-type Options = { executor?: ValidationExecutor; throwErrors?: boolean }
+type Options = { validator?: ValidationExecutor; throwErrors?: boolean }
 
 /**
  * Note: this code assumes that collapseMadeChoices has already been
@@ -123,7 +123,7 @@ async function validateGraph(graph: Graph, opts: Options): Promise<Status> {
     return "success"
   } else if (graph.validate) {
     try {
-      await (opts.executor || shellExec)(graph.validate, { quiet: true })
+      await (opts.validator || shellExec)(graph.validate, { quiet: true })
       return "success"
     } catch (err) {
       if (opts.throwErrors) {


### PR DESCRIPTION
There's no sense in presenting wizard steps that are already done. We were already doing this for task execution, but not for choices. This PR adds that feature.

We will need to find a way to distinguish between choices that are ok not to repeat and choices that bear repeating. This PR assumes all valid choices do not need to be presented again.