### PR TITLE
fix: avoid starting up ora spinners when revalidating, if not needed

### DIFF
--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -233,7 +233,7 @@ export class Guide {
         name: "execution",
         message: chalk.yellow("How do you wish to execute this guidebook?"),
         choices: [
-          { value: "dryr", name: "Check prerequisites 👀" },
+          { value: "dryr", name: "Dry run 👀" },
           { value: "auto", name: "Run this guidebook" },
           new inquirer.Separator(),
           { value: "plan", name: "Show me the full plan" },

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -206,7 +206,10 @@ export function asSubTask(step: TitledStep): SubTask {
 
 function sameSubTask(A: SubTask, B: SubTask) {
   return (
-    A.key === B.key && A.title === B.title && A.filepath === B.filepath && sameGraph(A.graph, B.graph) // eslint-disable-line @typescript-eslint/no-use-before-define
+    /* A.key === B.key &&*/ A.title === B.title &&
+    A.description === B.description &&
+    A.filepath === B.filepath &&
+    sameGraph(A.graph, B.graph) // eslint-disable-line @typescript-eslint/no-use-before-define
   )
 }
 


### PR DESCRIPTION
We don't need to start up a spinner, just to immediately detect that we aren't going to re-validate.