### PR TITLE
chore: refactor tab expansion to occur on Graph model, not AST model

### DIFF
--- a/src/choices/groups/index.ts
+++ b/src/choices/groups/index.ts
@@ -21,7 +21,6 @@ import { ChoiceState, MadWizardOptions } from "../.."
 import { isTabGroup } from "../../parser/markdown/rehype-tabbed"
 export { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from "../../parser/markdown/rehype-tabbed"
 
-import expand from "./expansion"
 import aprioris from "./aprioris"
 
 /**
@@ -61,7 +60,7 @@ export async function identifyRecognizableTabGroups(
   })
 
   await Promise.all(
-    nodesToVisit.map(async (node) => {
+    nodesToVisit.map((node) => {
       if (useAprioris) {
         // re: the use of `find`
         // Assumption: a given tab group can only have one match,
@@ -72,9 +71,9 @@ export async function identifyRecognizableTabGroups(
         }
       }
 
-      if (await expand(node)) {
-        return
-      }
+      // if (await expand(node)) {
+      // return
+      // }
     })
   )
 

--- a/src/choices/index.ts
+++ b/src/choices/index.ts
@@ -18,6 +18,8 @@ import ChoiceStateImpl from "./impl"
 import { Choice as CodeBlockChoice } from "../codeblock/CodeBlockProps"
 import { ChoiceHandlerRegistration } from "./events"
 
+export { expand } from "./groups/expansion"
+
 /* map from choice group to selected choice member */
 export type ChoicesMap = Record<CodeBlockChoice["group"], CodeBlockChoice["title"]>
 

--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -102,19 +102,19 @@ export async function cli<Writer extends (msg: string) => boolean>(
       case "timing":
       case "fetch": {
         // print out timing
-        const graph = compile(blocks, choices, options)
+        const graph = await compile(blocks, choices, options)
         wizardify(graph)
         new Treeifier(new DevNullUI()).toTree(order(graph))
         break
       }
 
       case "tree": {
-        prettyPrintUITreeFromBlocks(blocks, choices, Object.assign({ write }, options))
+        await prettyPrintUITreeFromBlocks(blocks, choices, Object.assign({ write }, options))
         break
       }
 
       case "json": {
-        const graph = compile(blocks, choices)
+        const graph = await compile(blocks, choices)
         const wizard = await wizardify(graph)
         ;(write || process.stdout.write.bind(process.stdout))(
           JSON.stringify(
@@ -123,6 +123,8 @@ export async function cli<Writer extends (msg: string) => boolean>(
               if (key === "source" || key === "position") {
                 return "placeholder"
               } else if (key === "description" && !value) {
+                return undefined
+              } else if (key === "nesting" && Array.isArray(value)) {
                 return undefined
               } else if (key === "status" && value === "blank") {
                 return undefined

--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -54,7 +54,7 @@ export class Guide {
    * @return the list of remaining questions
    */
   private async questions(iter: number, previous?: Wizard) {
-    const graph = compile(this.blocks, this.choices, this.options)
+    const graph = await compile(this.blocks, this.choices, this.options)
     const wizard = await wizardify(graph, { validator: shellExec, previous })
 
     const choiceSteps = wizard.filter(isChoiceStep).filter((_) => _.status !== "success")
@@ -298,7 +298,7 @@ export class Guide {
 
     if (iter === 0) {
       // start a fresh screen before presenting the guide proper
-      console.clear()
+      // console.clear()
 
       this.presentGuidebookTitle(graph)
     }

--- a/src/fe/tree/pretty-print.ts
+++ b/src/fe/tree/pretty-print.ts
@@ -101,12 +101,12 @@ export function prettyPrintUITree(
   })
 }
 
-export function prettyPrintUITreeFromBlocks(
+export async function prettyPrintUITreeFromBlocks(
   blocks: CodeBlockProps[],
   choices: ChoiceState,
   options: PrettyPrintOptions & MadWizardOptions & { root?: string } = {}
 ) {
-  const graph = compile(blocks, choices, options)
+  const graph = await compile(blocks, choices, options)
 
   const treeifier = new Treeifier(new AnsiUI())
   const tree = treeifier.toTree(order(graph))

--- a/src/graph/validate.ts
+++ b/src/graph/validate.ts
@@ -31,13 +31,17 @@ export async function shellExec(cmdline: string, opts: ExecOptions = { quiet: fa
   const capture = typeof opts.capture === "string"
 
   return new Promise((resolve, reject) => {
-    const child = spawn(process.env.SHELL || (process.platform === "win32" ? "pwsh" : "bash"), ["-c", cmdline], {
-      stdio: opts.quiet
-        ? ["inherit", "ignore", "pipe"]
-        : capture
-        ? ["inherit", "pipe", "pipe"]
-        : ["inherit", "inherit", "inherit"],
-    })
+    const child = spawn(
+      process.env.SHELL || (process.platform === "win32" ? "pwsh" : "bash"),
+      ["-c", `set -o pipefail; ${cmdline}`],
+      {
+        stdio: opts.quiet
+          ? ["inherit", "ignore", "pipe"]
+          : capture
+          ? ["inherit", "pipe", "pipe"]
+          : ["inherit", "inherit", "inherit"],
+      }
+    )
 
     child.on("error", reject)
 

--- a/src/parser/markdown/rehype-tabbed/index.ts
+++ b/src/parser/markdown/rehype-tabbed/index.ts
@@ -58,13 +58,6 @@ export function isTabGroup(elt: Element): boolean {
   return elt.properties["data-kui-choice-group"] !== undefined
 }
 
-export function isExpansionGroup(elt: Element): string {
-  if (isTabGroup(elt)) {
-    const match = elt.properties["data-kui-choice-group"].toString().match(/expand\((.+)\)/)
-    return match && match[1]
-  }
-}
-
 export function setTabGroup(elt: Element, group: string) {
   elt.properties["data-kui-choice-group"] = group
 }
@@ -77,20 +70,9 @@ export function setTabTitle(elt: Element, title: string): string {
   return (elt.properties.title = title)
 }
 
-function setTabIndex(elt: Element, idx: number) {
+/* function setTabIndex(elt: Element, idx: number) {
   elt.properties["data-kui-tab-index"] = idx
-}
-
-export function cloneAndAddTab(elt: Element, template: Element, title: string, idx: number) {
-  if (isTabGroup(elt) && isTabWithProperties(template)) {
-    const tab = JSON.parse(JSON.stringify(template))
-    setTabTitle(tab, title)
-    setTabIndex(tab, idx)
-    elt.children.push(tab)
-
-    return tab
-  }
-}
+} */
 
 export function rehypeTabbed(uuid: string, choices: ChoiceState, madwizardOptions: MadWizardOptions) {
   return async function rehypeTabbedTransformer(tree: Parameters<Transformer>[0]): Promise<ReturnType<Transformer>> {

--- a/test/inputs/1/wizard.json
+++ b/test/inputs/1/wizard.json
@@ -7,22 +7,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "ac10930f-9226-4788-a846-7b96269dc5b2",
+            "key": "6864e759-3b93-4688-b41b-d601a1c88a9b",
             "sequence": [
               {
                 "body": "echo 111",
                 "language": "bash",
-                "id": "6be74561-6b95-460c-8dae-71a84ad2eada-0",
-                "nesting": [
-                  {
-                    "kind": "Choice",
-                    "group": "Tab1Title####Tab2Title",
-                    "title": "Tab1Title",
-                    "description": "\nTab1Content",
-                    "member": 0,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "eb1bab5e-398f-4258-b0cb-ce38cf5ca146-0"
               }
             ]
           },
@@ -32,22 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "92ab53e2-49c4-449d-a7ba-65d0b4a867f1",
+            "key": "c9a9e723-4734-4ecc-96d5-5d0bca80bc40",
             "sequence": [
               {
                 "body": "echo 222",
                 "language": "bash",
-                "id": "6be74561-6b95-460c-8dae-71a84ad2eada-1",
-                "nesting": [
-                  {
-                    "kind": "Choice",
-                    "group": "Tab1Title####Tab2Title",
-                    "title": "Tab2Title",
-                    "description": "\nTab2Content",
-                    "member": 1,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "eb1bab5e-398f-4258-b0cb-ce38cf5ca146-1"
               }
             ]
           },

--- a/test/inputs/10/wizard-darwin.json
+++ b/test/inputs/10/wizard-darwin.json
@@ -5,27 +5,12 @@
       "title": "importgg.md",
       "filepath": "test/inputs/snippets/importgg.md",
       "graph": {
-        "key": "4d47857f-e4de-450f-b245-b6f65428443c",
+        "key": "377a80e4-584e-42bc-9f74-1ca0614617ca",
         "sequence": [
           {
             "body": "echo MMM",
             "language": "bash",
-            "id": "9b179826-0b33-4041-b5c0-8ffc2873ce75-0",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importgg.md",
-                "title": "importgg.md",
-                "filepath": "test/inputs/snippets/importgg.md"
-              },
-              {
-                "kind": "Choice",
-                "group": "org.kubernetes-sigs.kui/choice/platform",
-                "title": "Darwin",
-                "member": 0,
-                "groupDetail": {}
-              }
-            ]
+            "id": "96edc684-bca2-4439-bfdf-4bb44e10f226-0"
           }
         ]
       },
@@ -42,21 +27,13 @@
       "title": "importaa.md",
       "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "8c31767a-684b-4de7-8492-1235386c6816",
+        "key": "82c25d00-17ac-4a3a-9282-8979a3527949",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "9b179826-0b33-4041-b5c0-8ffc2873ce75-3",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importaa.md",
-                "title": "importaa.md",
-                "filepath": "test/inputs/snippets/importaa.md"
-              }
-            ]
+            "id": "96edc684-bca2-4439-bfdf-4bb44e10f226-3"
           }
         ]
       },
@@ -69,125 +46,32 @@
   },
   {
     "graph": {
-      "group": "8bf07d44-562d-5904-b8ad-71e1dc471800",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "1a06fed8-fbc4-4136-b868-34b231ac3383",
+            "key": "31a24632-2f22-43a3-90f3-b32d1d23f974",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "9b179826-0b33-4041-b5c0-8ffc2873ce75-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "8bf07d44-562d-5904-b8ad-71e1dc471800",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "96edc684-bca2-4439-bfdf-4bb44e10f226-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "9b179826-0b33-4041-b5c0-8ffc2873ce75-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "8bf07d44-562d-5904-b8ad-71e1dc471800",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "96edc684-bca2-4439-bfdf-4bb44e10f226-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "9b179826-0b33-4041-b5c0-8ffc2873ce75-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "8bf07d44-562d-5904-b8ad-71e1dc471800",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "96edc684-bca2-4439-bfdf-4bb44e10f226-6"
               }
             ]
           },
@@ -196,44 +80,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "61ca8431-d073-47fd-9ad5-28258c574d43",
+            "key": "f610a47c-35e2-4a17-a8bf-648f330c9ebe",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "9b179826-0b33-4041-b5c0-8ffc2873ce75-7",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "8bf07d44-562d-5904-b8ad-71e1dc471800",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "96edc684-bca2-4439-bfdf-4bb44e10f226-7"
               }
             ]
           },
@@ -247,13 +100,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "8bf07d44-562d-5904-b8ad-71e1dc471800",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "8bf07d44-562d-5904-b8ad-71e1dc471800",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/10/wizard-linux.json
+++ b/test/inputs/10/wizard-linux.json
@@ -5,27 +5,12 @@
       "title": "importgg.md",
       "filepath": "test/inputs/snippets/importgg.md",
       "graph": {
-        "key": "2a400a44-393d-4a2a-ade3-f1205b02b5b6",
+        "key": "298f8563-8d8c-4af7-afeb-f64e2d0fdd99",
         "sequence": [
           {
             "body": "echo LLL",
             "language": "bash",
-            "id": "a4ed055a-f25b-4fb3-8208-4b5415cd8a04-1",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importgg.md",
-                "title": "importgg.md",
-                "filepath": "test/inputs/snippets/importgg.md"
-              },
-              {
-                "kind": "Choice",
-                "group": "org.kubernetes-sigs.kui/choice/platform",
-                "title": "Linux",
-                "member": 1,
-                "groupDetail": {}
-              }
-            ]
+            "id": "1ac83121-87c2-4d54-ab89-a1a409dcb244-1"
           }
         ]
       },
@@ -42,21 +27,13 @@
       "title": "importaa.md",
       "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "8eaf73ac-0db1-43aa-b022-ab97cf51b09b",
+        "key": "7415ea6c-2557-44b7-addd-5ba4ba102bd3",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "a4ed055a-f25b-4fb3-8208-4b5415cd8a04-3",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importaa.md",
-                "title": "importaa.md",
-                "filepath": "test/inputs/snippets/importaa.md"
-              }
-            ]
+            "id": "1ac83121-87c2-4d54-ab89-a1a409dcb244-3"
           }
         ]
       },
@@ -69,125 +46,32 @@
   },
   {
     "graph": {
-      "group": "bc022847-a7fc-578d-853b-63b3f2f72f3d",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "79e442af-3ae3-4ea2-becc-67e06600c29c",
+            "key": "bcb478d0-b550-403f-85cd-14aa603f7d6e",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "a4ed055a-f25b-4fb3-8208-4b5415cd8a04-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "bc022847-a7fc-578d-853b-63b3f2f72f3d",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "1ac83121-87c2-4d54-ab89-a1a409dcb244-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "a4ed055a-f25b-4fb3-8208-4b5415cd8a04-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "bc022847-a7fc-578d-853b-63b3f2f72f3d",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "1ac83121-87c2-4d54-ab89-a1a409dcb244-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "a4ed055a-f25b-4fb3-8208-4b5415cd8a04-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "bc022847-a7fc-578d-853b-63b3f2f72f3d",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "1ac83121-87c2-4d54-ab89-a1a409dcb244-6"
               }
             ]
           },
@@ -196,44 +80,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "b99353dd-ec37-4fbf-864b-7ea1d29227cc",
+            "key": "507621f5-4189-41de-9abc-7529aca72591",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "a4ed055a-f25b-4fb3-8208-4b5415cd8a04-7",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "bc022847-a7fc-578d-853b-63b3f2f72f3d",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "1ac83121-87c2-4d54-ab89-a1a409dcb244-7"
               }
             ]
           },
@@ -247,13 +100,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "bc022847-a7fc-578d-853b-63b3f2f72f3d",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "bc022847-a7fc-578d-853b-63b3f2f72f3d",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/10/wizard-noaprioris.json
+++ b/test/inputs/10/wizard-noaprioris.json
@@ -1,34 +1,19 @@
 [
   {
     "graph": {
-      "group": "bc030f17-321e-5d7f-ba11-d451fc040142",
+      "group": "MacOS####Linux####Windows",
       "title": "importgg.md",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "5ba4263f-f560-42c9-b9d4-4a5497e3add5",
+            "key": "08d99f2a-5ebe-4ead-8f70-3d5287b2021d",
             "sequence": [
               {
                 "body": "echo MMM",
                 "language": "bash",
-                "id": "db446e13-cb4f-461a-8b6f-488a5207c835-0",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importgg.md",
-                    "title": "importgg.md",
-                    "filepath": "test/inputs/snippets/importgg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "bc030f17-321e-5d7f-ba11-d451fc040142",
-                    "title": "MacOS",
-                    "member": 0,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "be41a431-bd2a-44af-b3db-72f6f47163a8-0"
               }
             ]
           },
@@ -37,27 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "fecaaf41-09e8-4a65-9438-b6b1d8806030",
+            "key": "f1a1cade-f5ce-4e62-97ce-6a27cca0aa39",
             "sequence": [
               {
                 "body": "echo LLL",
                 "language": "bash",
-                "id": "db446e13-cb4f-461a-8b6f-488a5207c835-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importgg.md",
-                    "title": "importgg.md",
-                    "filepath": "test/inputs/snippets/importgg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "bc030f17-321e-5d7f-ba11-d451fc040142",
-                    "title": "Linux",
-                    "member": 1,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "be41a431-bd2a-44af-b3db-72f6f47163a8-1"
               }
             ]
           },
@@ -66,27 +36,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "654581fe-2031-4d72-b047-0f69f7749ee1",
+            "key": "f88a8d8f-cb75-4a19-b0f1-aabe914bfb5e",
             "sequence": [
               {
                 "body": "echo WWW",
                 "language": "bash",
-                "id": "db446e13-cb4f-461a-8b6f-488a5207c835-2",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importgg.md",
-                    "title": "importgg.md",
-                    "filepath": "test/inputs/snippets/importgg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "bc030f17-321e-5d7f-ba11-d451fc040142",
-                    "title": "Windows",
-                    "member": 2,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "be41a431-bd2a-44af-b3db-72f6f47163a8-2"
               }
             ]
           },
@@ -100,19 +55,19 @@
       "content": [
         {
           "title": "MacOS",
-          "group": "bc030f17-321e-5d7f-ba11-d451fc040142",
+          "group": "MacOS####Linux####Windows",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "Linux",
-          "group": "bc030f17-321e-5d7f-ba11-d451fc040142",
+          "group": "MacOS####Linux####Windows",
           "member": 1,
           "isFirstChoice": true
         },
         {
           "title": "Windows",
-          "group": "bc030f17-321e-5d7f-ba11-d451fc040142",
+          "group": "MacOS####Linux####Windows",
           "member": 2,
           "isFirstChoice": true
         }
@@ -125,21 +80,13 @@
       "title": "importaa.md",
       "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "56964673-8eee-4d53-82c8-d41090563fb3",
+        "key": "0680c52f-9417-48ab-ba71-b813dd8ebc64",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "db446e13-cb4f-461a-8b6f-488a5207c835-3",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importaa.md",
-                "title": "importaa.md",
-                "filepath": "test/inputs/snippets/importaa.md"
-              }
-            ]
+            "id": "be41a431-bd2a-44af-b3db-72f6f47163a8-3"
           }
         ]
       },
@@ -152,125 +99,32 @@
   },
   {
     "graph": {
-      "group": "efca942d-78f6-5d2d-8d45-b315c8f7d086",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "9f57e926-1081-4399-a87a-94730a037de6",
+            "key": "ea7ac51c-0e26-401e-ba81-63e20804d2a9",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "db446e13-cb4f-461a-8b6f-488a5207c835-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "efca942d-78f6-5d2d-8d45-b315c8f7d086",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "be41a431-bd2a-44af-b3db-72f6f47163a8-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "db446e13-cb4f-461a-8b6f-488a5207c835-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "efca942d-78f6-5d2d-8d45-b315c8f7d086",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "be41a431-bd2a-44af-b3db-72f6f47163a8-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "db446e13-cb4f-461a-8b6f-488a5207c835-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "efca942d-78f6-5d2d-8d45-b315c8f7d086",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "be41a431-bd2a-44af-b3db-72f6f47163a8-6"
               }
             ]
           },
@@ -279,44 +133,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "18c49e69-9ab4-4fad-9116-5f9d4d8c6014",
+            "key": "45ab97fd-3e31-49a5-bf79-292a6b5d85eb",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "db446e13-cb4f-461a-8b6f-488a5207c835-7",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "efca942d-78f6-5d2d-8d45-b315c8f7d086",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "be41a431-bd2a-44af-b3db-72f6f47163a8-7"
               }
             ]
           },
@@ -330,13 +153,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "efca942d-78f6-5d2d-8d45-b315c8f7d086",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": false
         },
         {
           "title": "SubTab2",
-          "group": "efca942d-78f6-5d2d-8d45-b315c8f7d086",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": false
         }

--- a/test/inputs/10/wizard-noopt.json
+++ b/test/inputs/10/wizard-noopt.json
@@ -1,34 +1,19 @@
 [
   {
     "graph": {
-      "group": "23a2e4ca-6d23-5ff2-9e67-a7e0008a12eb",
+      "group": "MacOS####Linux####Windows",
       "title": "importgg.md",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "34489d45-f075-4819-8e9b-15e740cb1584",
+            "key": "1a17923d-e4b1-4f81-a5a8-212a801f982d",
             "sequence": [
               {
                 "body": "echo MMM",
                 "language": "bash",
-                "id": "d0090ade-3cc4-4bd6-834a-26c14559426b-0",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importgg.md",
-                    "title": "importgg.md",
-                    "filepath": "test/inputs/snippets/importgg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "23a2e4ca-6d23-5ff2-9e67-a7e0008a12eb",
-                    "title": "MacOS",
-                    "member": 0,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "bc2b398c-5f43-4bc6-9935-4331ca72c0dc-0"
               }
             ]
           },
@@ -37,27 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "6be58bc2-a00c-4180-bf29-1c008a6a9375",
+            "key": "1e8e0230-4b0a-4c6f-8ae7-de4a15dd4614",
             "sequence": [
               {
                 "body": "echo LLL",
                 "language": "bash",
-                "id": "d0090ade-3cc4-4bd6-834a-26c14559426b-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importgg.md",
-                    "title": "importgg.md",
-                    "filepath": "test/inputs/snippets/importgg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "23a2e4ca-6d23-5ff2-9e67-a7e0008a12eb",
-                    "title": "Linux",
-                    "member": 1,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "bc2b398c-5f43-4bc6-9935-4331ca72c0dc-1"
               }
             ]
           },
@@ -66,27 +36,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "d8cbb1db-9209-4bed-9678-e572b1a6c398",
+            "key": "00cb1a7c-318c-4b1a-a457-a4db0ead8850",
             "sequence": [
               {
                 "body": "echo WWW",
                 "language": "bash",
-                "id": "d0090ade-3cc4-4bd6-834a-26c14559426b-2",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importgg.md",
-                    "title": "importgg.md",
-                    "filepath": "test/inputs/snippets/importgg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "23a2e4ca-6d23-5ff2-9e67-a7e0008a12eb",
-                    "title": "Windows",
-                    "member": 2,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "bc2b398c-5f43-4bc6-9935-4331ca72c0dc-2"
               }
             ]
           },
@@ -100,19 +55,19 @@
       "content": [
         {
           "title": "MacOS",
-          "group": "23a2e4ca-6d23-5ff2-9e67-a7e0008a12eb",
+          "group": "MacOS####Linux####Windows",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "Linux",
-          "group": "23a2e4ca-6d23-5ff2-9e67-a7e0008a12eb",
+          "group": "MacOS####Linux####Windows",
           "member": 1,
           "isFirstChoice": true
         },
         {
           "title": "Windows",
-          "group": "23a2e4ca-6d23-5ff2-9e67-a7e0008a12eb",
+          "group": "MacOS####Linux####Windows",
           "member": 2,
           "isFirstChoice": true
         }
@@ -125,21 +80,13 @@
       "title": "importaa.md",
       "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "3f83726e-50c3-4076-bd3b-e6014dd0b61c",
+        "key": "8232aad2-7c3c-4e99-9f7f-b74ca2ea0145",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "d0090ade-3cc4-4bd6-834a-26c14559426b-3",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importaa.md",
-                "title": "importaa.md",
-                "filepath": "test/inputs/snippets/importaa.md"
-              }
-            ]
+            "id": "bc2b398c-5f43-4bc6-9935-4331ca72c0dc-3"
           }
         ]
       },
@@ -152,125 +99,32 @@
   },
   {
     "graph": {
-      "group": "17940898-7785-51a3-8dfd-cfafe78729e0",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "96878edf-b377-40c7-bd22-8e44719bfdf6",
+            "key": "023f2480-ac4b-4844-bd99-e785486df354",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "d0090ade-3cc4-4bd6-834a-26c14559426b-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "17940898-7785-51a3-8dfd-cfafe78729e0",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "bc2b398c-5f43-4bc6-9935-4331ca72c0dc-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "d0090ade-3cc4-4bd6-834a-26c14559426b-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "17940898-7785-51a3-8dfd-cfafe78729e0",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "bc2b398c-5f43-4bc6-9935-4331ca72c0dc-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "d0090ade-3cc4-4bd6-834a-26c14559426b-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "17940898-7785-51a3-8dfd-cfafe78729e0",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "bc2b398c-5f43-4bc6-9935-4331ca72c0dc-6"
               }
             ]
           },
@@ -279,44 +133,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "abf7511a-78a8-43e0-bba9-0e9ce3f6093a",
+            "key": "9c8d66df-9861-45b0-86a6-a515b98a626b",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "d0090ade-3cc4-4bd6-834a-26c14559426b-7",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "17940898-7785-51a3-8dfd-cfafe78729e0",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "bc2b398c-5f43-4bc6-9935-4331ca72c0dc-7"
               }
             ]
           },
@@ -330,13 +153,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "17940898-7785-51a3-8dfd-cfafe78729e0",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": false
         },
         {
           "title": "SubTab2",
-          "group": "17940898-7785-51a3-8dfd-cfafe78729e0",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": false
         }

--- a/test/inputs/10/wizard-win32.json
+++ b/test/inputs/10/wizard-win32.json
@@ -5,27 +5,12 @@
       "title": "importgg.md",
       "filepath": "test/inputs/snippets/importgg.md",
       "graph": {
-        "key": "34a08566-50e7-4535-ba82-8a9587b12186",
+        "key": "f16b4741-3c7d-46f0-b7d0-2b472aa717d0",
         "sequence": [
           {
-            "body": "echo LLL",
+            "body": "echo WWW",
             "language": "bash",
-            "id": "c7d824f8-52de-40d9-9d79-cf02e77f1be5-1",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importgg.md",
-                "title": "importgg.md",
-                "filepath": "test/inputs/snippets/importgg.md"
-              },
-              {
-                "kind": "Choice",
-                "group": "org.kubernetes-sigs.kui/choice/platform",
-                "title": "Linux",
-                "member": 1,
-                "groupDetail": {}
-              }
-            ]
+            "id": "23552f3e-3716-42aa-a427-ed484419a1d0-2"
           }
         ]
       },
@@ -42,21 +27,13 @@
       "title": "importaa.md",
       "filepath": "test/inputs/snippets/importaa.md",
       "graph": {
-        "key": "bdb79a52-d143-496e-ad99-6388a79f5836",
+        "key": "763f9367-801b-4500-b5d2-71f9c466d532",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "c7d824f8-52de-40d9-9d79-cf02e77f1be5-3",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importaa.md",
-                "title": "importaa.md",
-                "filepath": "test/inputs/snippets/importaa.md"
-              }
-            ]
+            "id": "23552f3e-3716-42aa-a427-ed484419a1d0-3"
           }
         ]
       },
@@ -69,125 +46,32 @@
   },
   {
     "graph": {
-      "group": "c23646c9-5d48-5b5f-80ea-18e598a84f1b",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "1df65738-4e16-42c7-946a-03dbfc610cd1",
+            "key": "246e9d55-d132-4fe6-be20-121c1276b03d",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "c7d824f8-52de-40d9-9d79-cf02e77f1be5-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "c23646c9-5d48-5b5f-80ea-18e598a84f1b",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "23552f3e-3716-42aa-a427-ed484419a1d0-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "c7d824f8-52de-40d9-9d79-cf02e77f1be5-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "c23646c9-5d48-5b5f-80ea-18e598a84f1b",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "23552f3e-3716-42aa-a427-ed484419a1d0-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "c7d824f8-52de-40d9-9d79-cf02e77f1be5-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "c23646c9-5d48-5b5f-80ea-18e598a84f1b",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "23552f3e-3716-42aa-a427-ed484419a1d0-6"
               }
             ]
           },
@@ -196,44 +80,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "5defcddb-8fb7-4588-b362-8e965c5728b6",
+            "key": "f193ffe3-863c-4d22-86a7-b87c27213448",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "c7d824f8-52de-40d9-9d79-cf02e77f1be5-7",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importdd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importdd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "c23646c9-5d48-5b5f-80ea-18e598a84f1b",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "23552f3e-3716-42aa-a427-ed484419a1d0-7"
               }
             ]
           },
@@ -247,13 +100,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "c23646c9-5d48-5b5f-80ea-18e598a84f1b",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "c23646c9-5d48-5b5f-80ea-18e598a84f1b",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/11/wizard-noaprioris.json
+++ b/test/inputs/11/wizard-noaprioris.json
@@ -1,50 +1,19 @@
 [
   {
     "graph": {
-      "group": "f964cdce-763d-5ca7-9d68-3ccbabf57cb3",
+      "group": "Text####HTML",
       "title": "Text versus HTML?",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "75dfa26a-b94d-46c5-aa69-8705e259b0f6",
+            "key": "c44c3999-661f-4a58-961e-f4819ef9abc7",
             "sequence": [
               {
                 "body": "echo text",
                 "language": "shell",
-                "id": "ff96a505-b5c1-498d-ab59-a26408c6f560-0",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "Text versus HTML?",
-                    "title": "Text versus HTML?",
-                    "filepath": ""
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "f964cdce-763d-5ca7-9d68-3ccbabf57cb3",
-                    "title": "Text",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Text versus HTML?",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Text versus HTML?"
-                    }
-                  }
-                ]
+                "id": "f7b3f028-6954-4944-85c0-2807f183f7d7-0"
               }
             ]
           },
@@ -53,43 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "608616c2-5455-45b6-9101-c66f41456842",
+            "key": "04fd58be-43fe-496e-a58b-18a52adf3128",
             "sequence": [
               {
                 "body": "echo html",
                 "language": "shell",
-                "id": "ff96a505-b5c1-498d-ab59-a26408c6f560-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "Text versus HTML?",
-                    "title": "Text versus HTML?",
-                    "filepath": ""
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "f964cdce-763d-5ca7-9d68-3ccbabf57cb3",
-                    "title": "HTML",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Text versus HTML?",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Text versus HTML?"
-                    }
-                  }
-                ]
+                "id": "f7b3f028-6954-4944-85c0-2807f183f7d7-1"
               }
             ]
           },
@@ -103,13 +41,13 @@
       "content": [
         {
           "title": "Text",
-          "group": "f964cdce-763d-5ca7-9d68-3ccbabf57cb3",
+          "group": "Text####HTML",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "HTML",
-          "group": "f964cdce-763d-5ca7-9d68-3ccbabf57cb3",
+          "group": "Text####HTML",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/11/wizard-noopt.json
+++ b/test/inputs/11/wizard-noopt.json
@@ -1,50 +1,19 @@
 [
   {
     "graph": {
-      "group": "4b0121fe-1b8e-595b-a035-56b51e80b123",
+      "group": "Text####HTML",
       "title": "Text versus HTML?",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "3e881aac-4dd2-46a9-8d69-82125ca5c047",
+            "key": "db027561-0d47-4ae9-8739-36f10e39ee66",
             "sequence": [
               {
                 "body": "echo text",
                 "language": "shell",
-                "id": "d922f1ce-319f-4f46-8118-cf27ca46a698-0",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "Text versus HTML?",
-                    "title": "Text versus HTML?",
-                    "filepath": ""
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "4b0121fe-1b8e-595b-a035-56b51e80b123",
-                    "title": "Text",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Text versus HTML?",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Text versus HTML?"
-                    }
-                  }
-                ]
+                "id": "aaf89190-229e-451a-9443-8c7dc5f50021-0"
               }
             ]
           },
@@ -53,43 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "89c44859-c983-4bd4-9e74-229ebded05f1",
+            "key": "0214c2f4-b1a8-4eaf-953d-3ec1309d0f16",
             "sequence": [
               {
                 "body": "echo html",
                 "language": "shell",
-                "id": "d922f1ce-319f-4f46-8118-cf27ca46a698-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "Text versus HTML?",
-                    "title": "Text versus HTML?",
-                    "filepath": ""
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "4b0121fe-1b8e-595b-a035-56b51e80b123",
-                    "title": "HTML",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Text versus HTML?",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Text versus HTML?"
-                    }
-                  }
-                ]
+                "id": "aaf89190-229e-451a-9443-8c7dc5f50021-1"
               }
             ]
           },
@@ -103,13 +41,13 @@
       "content": [
         {
           "title": "Text",
-          "group": "4b0121fe-1b8e-595b-a035-56b51e80b123",
+          "group": "Text####HTML",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "HTML",
-          "group": "4b0121fe-1b8e-595b-a035-56b51e80b123",
+          "group": "Text####HTML",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/11/wizard.json
+++ b/test/inputs/11/wizard.json
@@ -1,47 +1,16 @@
 [
   {
     "graph": {
-      "key": "Text versus HTML?",
+      "key": "org.kubernetes-sigs.kui/choice/in-terminal",
       "title": "Text versus HTML?",
       "filepath": "",
       "graph": {
-        "key": "6f26f994-cc4e-40a8-889e-51b42490f17b",
+        "key": "b0b1e7c1-f48e-46d7-9eea-8a2c7f71b87b",
         "sequence": [
           {
             "body": "echo text",
             "language": "shell",
-            "id": "5808cba7-fd02-4818-ae07-e7dc4d7f740a-0",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "Text versus HTML?",
-                "title": "Text versus HTML?",
-                "filepath": ""
-              },
-              {
-                "kind": "Choice",
-                "group": "org.kubernetes-sigs.kui/choice/in-terminal",
-                "title": "Text",
-                "member": 0,
-                "groupDetail": {
-                  "child": {
-                    "type": "element",
-                    "tagName": "h1",
-                    "properties": {},
-                    "children": [
-                      {
-                        "type": "text",
-                        "value": "Text versus HTML?",
-                        "position": "placeholder"
-                      }
-                    ],
-                    "position": "placeholder"
-                  },
-                  "level": 1,
-                  "title": "Text versus HTML?"
-                }
-              }
-            ]
+            "id": "09dfda3e-78c4-4b0a-8760-0a5b8673edb7-0"
           }
         ]
       },

--- a/test/inputs/12/wizard.json
+++ b/test/inputs/12/wizard.json
@@ -5,21 +5,13 @@
       "title": "Main Tasks",
       "filepath": "test/inputs/12/snippet.md",
       "graph": {
-        "key": "d095d362-bb5f-4006-bf8b-bc834ffa6ba9",
+        "key": "ae39d7a7-eeba-4675-84c8-9006749a863e",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "shell",
             "validate": "echo true",
-            "id": "1a246867-2e6e-450f-afd7-9308903d55d6-0",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/12/snippet.md",
-                "title": "Codeblocks in enclosing markdown",
-                "filepath": "test/inputs/12/snippet.md"
-              }
-            ]
+            "id": "9cff9e53-9f0c-4c29-a354-37018421bc0b-0"
           }
         ]
       },

--- a/test/inputs/13/wizard.json
+++ b/test/inputs/13/wizard.json
@@ -5,26 +5,12 @@
       "title": "H1",
       "filepath": "",
       "graph": {
-        "key": "8a4fd559-a328-41e6-a43b-aa4d31f9da3e",
+        "key": "014a8f24-180c-4ba8-9e16-d5ec3af04548",
         "sequence": [
           {
             "body": "111",
             "language": "shell",
-            "id": "af97e788-2189-46a6-a9a8-f3b26bf55eeb-0",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "H1",
-                "title": "H1",
-                "filepath": ""
-              },
-              {
-                "kind": "Import",
-                "key": "H1",
-                "title": "H1",
-                "filepath": ""
-              }
-            ]
+            "id": "546a70b5-d710-46f6-a790-11cd270bac8c-0"
           }
         ]
       },

--- a/test/inputs/14/wizard.json
+++ b/test/inputs/14/wizard.json
@@ -8,44 +8,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "8fb214b5-f0a3-422f-9e4c-2e4fa97549eb",
+            "key": "99587a47-69eb-4a6a-bcc3-9432342d7614",
             "sequence": [
               {
                 "body": "echo \"3\"",
                 "language": "shell",
-                "id": "de028df6-b9fe-4749-8ce4-93dbe7d28a42-0",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "Testing tab expansion",
-                    "title": "Testing tab expansion",
-                    "filepath": ""
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "expand(echo 3 ; echo 4 ; echo 5)",
-                    "title": "3",
-                    "description": "\nThis should emit 3 to your terminal.",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Testing tab expansion",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Testing tab expansion"
-                    }
-                  }
-                ]
+                "id": "b008f525-c4b1-4638-982c-14b96f1e044c-0"
               }
             ]
           },
@@ -55,44 +23,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "bbf301be-8333-4414-88e4-d23f7b639638",
+            "key": "99587a47-69eb-4a6a-bcc3-9432342d7614",
             "sequence": [
               {
                 "body": "echo \"4\"",
                 "language": "shell",
-                "id": "de028df6-b9fe-4749-8ce4-93dbe7d28a42-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "Testing tab expansion",
-                    "title": "Testing tab expansion",
-                    "filepath": ""
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "expand(echo 3 ; echo 4 ; echo 5)",
-                    "title": "4",
-                    "description": "\nThis should emit 4 to your terminal.",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Testing tab expansion",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Testing tab expansion"
-                    }
-                  }
-                ]
+                "id": "b008f525-c4b1-4638-982c-14b96f1e044c-0"
               }
             ]
           },
@@ -102,44 +38,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "fa345b2a-d57b-49c9-96b2-abff6a8a17db",
+            "key": "99587a47-69eb-4a6a-bcc3-9432342d7614",
             "sequence": [
               {
                 "body": "echo \"5\"",
                 "language": "shell",
-                "id": "de028df6-b9fe-4749-8ce4-93dbe7d28a42-2",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "Testing tab expansion",
-                    "title": "Testing tab expansion",
-                    "filepath": ""
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "expand(echo 3 ; echo 4 ; echo 5)",
-                    "title": "5",
-                    "description": "\nThis should emit 5 to your terminal.",
-                    "member": 2,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Testing tab expansion",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Testing tab expansion"
-                    }
-                  }
-                ]
+                "id": "b008f525-c4b1-4638-982c-14b96f1e044c-0"
               }
             ]
           },

--- a/test/inputs/15/wizard.json
+++ b/test/inputs/15/wizard.json
@@ -8,7 +8,7 @@
         {
           "member": 0,
           "graph": {
-            "key": "26c5e1cf-e723-4914-9f55-2a81e2a505a6",
+            "key": "90939f80-73ac-4e29-b0b9-087d9238fe7a",
             "sequence": [
               {
                 "group": "SubTab1####SubTab2",
@@ -18,52 +18,12 @@
                   {
                     "member": 0,
                     "graph": {
-                      "key": "fc4f87f8-2809-49f2-a61f-94451035ce96",
+                      "key": "ca7676e5-2b6a-406b-a626-93ec89f268e4",
                       "sequence": [
                         {
                           "body": "echo 111",
                           "language": "shell",
-                          "id": "811eb55d-2b29-40f2-8637-c9935605681f-0",
-                          "nesting": [
-                            {
-                              "kind": "Import",
-                              "key": "MainTitle",
-                              "title": "MainTitle",
-                              "description": "MainDescription\n",
-                              "filepath": ""
-                            },
-                            {
-                              "kind": "Choice",
-                              "group": "Tab1",
-                              "title": "Tab1",
-                              "description": "\nTab1Description",
-                              "member": 0,
-                              "groupDetail": {
-                                "child": {
-                                  "type": "element",
-                                  "tagName": "h1",
-                                  "properties": {},
-                                  "children": [
-                                    {
-                                      "type": "text",
-                                      "value": "MainTitle",
-                                      "position": "placeholder"
-                                    }
-                                  ],
-                                  "position": "placeholder"
-                                },
-                                "level": 1,
-                                "title": "MainTitle"
-                              }
-                            },
-                            {
-                              "kind": "Choice",
-                              "group": "SubTab1####SubTab2",
-                              "title": "SubTab1",
-                              "member": 0,
-                              "groupDetail": {}
-                            }
-                          ]
+                          "id": "1a1d8847-80a8-4b06-83f9-4020498ef47d-0"
                         }
                       ]
                     },
@@ -72,52 +32,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "4251848d-7d91-416a-b502-8ef54585b4bf",
+                      "key": "7a1274dc-c770-4643-a366-1e26b1ee413f",
                       "sequence": [
                         {
                           "body": "echo 222",
                           "language": "shell",
-                          "id": "811eb55d-2b29-40f2-8637-c9935605681f-1",
-                          "nesting": [
-                            {
-                              "kind": "Import",
-                              "key": "MainTitle",
-                              "title": "MainTitle",
-                              "description": "MainDescription\n",
-                              "filepath": ""
-                            },
-                            {
-                              "kind": "Choice",
-                              "group": "Tab1",
-                              "title": "Tab1",
-                              "description": "\nTab1Description",
-                              "member": 0,
-                              "groupDetail": {
-                                "child": {
-                                  "type": "element",
-                                  "tagName": "h1",
-                                  "properties": {},
-                                  "children": [
-                                    {
-                                      "type": "text",
-                                      "value": "MainTitle",
-                                      "position": "placeholder"
-                                    }
-                                  ],
-                                  "position": "placeholder"
-                                },
-                                "level": 1,
-                                "title": "MainTitle"
-                              }
-                            },
-                            {
-                              "kind": "Choice",
-                              "group": "SubTab1####SubTab2",
-                              "title": "SubTab2",
-                              "member": 1,
-                              "groupDetail": {}
-                            }
-                          ]
+                          "id": "1a1d8847-80a8-4b06-83f9-4020498ef47d-1"
                         }
                       ]
                     },

--- a/test/inputs/16/wizard.json
+++ b/test/inputs/16/wizard.json
@@ -8,7 +8,7 @@
         {
           "member": 0,
           "graph": {
-            "key": "7f7290af-d3c8-48f4-a788-2512f3b86229",
+            "key": "c771d056-0b58-470a-97be-ea299b6e5711",
             "sequence": [
               {
                 "group": "SubTab1####SubTab2",
@@ -18,52 +18,12 @@
                   {
                     "member": 0,
                     "graph": {
-                      "key": "2c140c97-5c18-4cf5-9666-5dfa90406beb",
+                      "key": "249f5fd4-1929-4e52-af65-c96366d9d92c",
                       "sequence": [
                         {
                           "body": "echo 111",
                           "language": "shell",
-                          "id": "b190cf6f-a699-4471-81a7-9caf4feb66f9-0",
-                          "nesting": [
-                            {
-                              "kind": "Import",
-                              "key": "MainTitle",
-                              "title": "MainTitle",
-                              "description": "MainDescription\n",
-                              "filepath": ""
-                            },
-                            {
-                              "kind": "Choice",
-                              "group": "Tab1",
-                              "title": "Tab1",
-                              "description": "Tab1Description\n",
-                              "member": 0,
-                              "groupDetail": {
-                                "child": {
-                                  "type": "element",
-                                  "tagName": "h1",
-                                  "properties": {},
-                                  "children": [
-                                    {
-                                      "type": "text",
-                                      "value": "MainTitle",
-                                      "position": "placeholder"
-                                    }
-                                  ],
-                                  "position": "placeholder"
-                                },
-                                "level": 1,
-                                "title": "MainTitle"
-                              }
-                            },
-                            {
-                              "kind": "Choice",
-                              "group": "SubTab1####SubTab2",
-                              "title": "SubTab1",
-                              "member": 0,
-                              "groupDetail": {}
-                            }
-                          ]
+                          "id": "78344111-588b-4131-b71c-8d0ccdb6666d-0"
                         }
                       ]
                     },
@@ -72,52 +32,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "87cb49b1-1575-4830-b397-20d06959780c",
+                      "key": "370d3b03-5ba2-4f8b-b509-30931e31c68c",
                       "sequence": [
                         {
                           "body": "echo 222",
                           "language": "shell",
-                          "id": "b190cf6f-a699-4471-81a7-9caf4feb66f9-1",
-                          "nesting": [
-                            {
-                              "kind": "Import",
-                              "key": "MainTitle",
-                              "title": "MainTitle",
-                              "description": "MainDescription\n",
-                              "filepath": ""
-                            },
-                            {
-                              "kind": "Choice",
-                              "group": "Tab1",
-                              "title": "Tab1",
-                              "description": "Tab1Description\n",
-                              "member": 0,
-                              "groupDetail": {
-                                "child": {
-                                  "type": "element",
-                                  "tagName": "h1",
-                                  "properties": {},
-                                  "children": [
-                                    {
-                                      "type": "text",
-                                      "value": "MainTitle",
-                                      "position": "placeholder"
-                                    }
-                                  ],
-                                  "position": "placeholder"
-                                },
-                                "level": 1,
-                                "title": "MainTitle"
-                              }
-                            },
-                            {
-                              "kind": "Choice",
-                              "group": "SubTab1####SubTab2",
-                              "title": "SubTab2",
-                              "member": 1,
-                              "groupDetail": {}
-                            }
-                          ]
+                          "id": "78344111-588b-4131-b71c-8d0ccdb6666d-1"
                         }
                       ]
                     },

--- a/test/inputs/3/wizard.json
+++ b/test/inputs/3/wizard.json
@@ -5,27 +5,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "d3faf64c-8fe4-4cdf-98bd-141370b0d631",
+        "key": "e0b05e94-dc68-455b-82a6-a40b71bc8b38",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "0d654c72-03a1-495d-8972-de79262cc091-0",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/snippets-in-tab3.md",
-                "title": "snippets-in-tab3.md",
-                "filepath": "test/inputs/snippets/snippets-in-tab3.md"
-              },
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importa.md",
-                "title": "importa.md",
-                "filepath": "test/inputs/snippets/importa.md"
-              }
-            ]
+            "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-0"
           }
         ]
       },
@@ -45,50 +31,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "76a73fa0-32e5-451c-8d07-971f4f04ed36",
+            "key": "66114bf3-c46f-414e-b486-ee3412f557d0",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "0d654c72-03a1-495d-8972-de79262cc091-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab3.md",
-                    "title": "snippets-in-tab3.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab3.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importe.md",
-                    "title": "EEE",
-                    "filepath": "test/inputs/snippets/importe.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "TabE1",
-                    "title": "TabE1",
-                    "description": "\nEEE1Content",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "EEE",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "EEE"
-                    }
-                  }
-                ]
+                "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-1"
               }
             ]
           },
@@ -120,154 +68,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "42242325-bb7c-445f-a418-e3880e930dd5",
+            "key": "e0e67ddb-5add-475e-b506-10b1504b8722",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0d654c72-03a1-495d-8972-de79262cc091-2",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab3.md",
-                    "title": "snippets-in-tab3.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab3.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importf.md",
-                    "title": "importf.md",
-                    "filepath": "test/inputs/snippets/importf.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-2"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0d654c72-03a1-495d-8972-de79262cc091-3",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab3.md",
-                    "title": "snippets-in-tab3.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab3.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importf.md",
-                    "title": "importf.md",
-                    "filepath": "test/inputs/snippets/importf.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-3"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0d654c72-03a1-495d-8972-de79262cc091-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab3.md",
-                    "title": "snippets-in-tab3.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab3.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importf.md",
-                    "title": "importf.md",
-                    "filepath": "test/inputs/snippets/importf.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-4"
               }
             ]
           },
@@ -276,56 +95,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "ebeb3be9-c849-4ab1-9c54-8a6ad39d0294",
+            "key": "01bc66f4-4f81-4d5a-a6bd-8e0c545b2061",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "0d654c72-03a1-495d-8972-de79262cc091-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab3.md",
-                    "title": "snippets-in-tab3.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab3.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importf.md",
-                    "title": "importf.md",
-                    "filepath": "test/inputs/snippets/importf.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-5"
               }
             ]
           },
@@ -361,42 +137,20 @@
         {
           "member": 1,
           "graph": {
-            "key": "f74f9ca7-3675-46e5-a8cb-032e782db5a8",
+            "key": "8337e722-f32e-4577-895e-932700d58275",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importc.md",
                 "title": "importc.md",
                 "filepath": "test/inputs/snippets/importc.md",
                 "graph": {
-                  "key": "c713716e-8043-4d54-bc33-7c221470c616",
+                  "key": "65349943-aa99-4fbe-8a1e-988527930c1d",
                   "sequence": [
                     {
                       "body": "echo CCC",
                       "language": "bash",
                       "validate": true,
-                      "id": "0d654c72-03a1-495d-8972-de79262cc091-10",
-                      "nesting": [
-                        {
-                          "kind": "Import",
-                          "key": "test/inputs/snippets/snippets-in-tab3.md",
-                          "title": "snippets-in-tab3.md",
-                          "filepath": "test/inputs/snippets/snippets-in-tab3.md"
-                        },
-                        {
-                          "kind": "Choice",
-                          "group": "Tab1####Tab2",
-                          "title": "Tab2",
-                          "description": "imports:\n",
-                          "member": 1,
-                          "groupDetail": {}
-                        },
-                        {
-                          "kind": "Import",
-                          "key": "test/inputs/snippets/importc.md",
-                          "title": "importc.md",
-                          "filepath": "test/inputs/snippets/importc.md"
-                        }
-                      ]
+                      "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-10"
                     }
                   ]
                 },

--- a/test/inputs/4/wizard.json
+++ b/test/inputs/4/wizard.json
@@ -5,27 +5,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "404a7173-6631-4447-8b2d-ec7e79c117f7",
+        "key": "79a76ea5-0038-4acf-991d-4a98d8db884d",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-0",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/snippets-in-tab4.md",
-                "title": "snippets-in-tab4.md",
-                "filepath": "test/inputs/snippets/snippets-in-tab4.md"
-              },
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importa.md",
-                "title": "importa.md",
-                "filepath": "test/inputs/snippets/importa.md"
-              }
-            ]
+            "id": "8ec10849-7856-4375-a108-edf9645940e6-0"
           }
         ]
       },
@@ -45,50 +31,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "0a828d36-d55f-42e3-a4a3-36a0fc56c963",
+            "key": "3d89ed6c-86b9-4b71-bf62-bd4e12780296",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab4.md",
-                    "title": "snippets-in-tab4.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importe.md",
-                    "title": "EEE",
-                    "filepath": "test/inputs/snippets/importe.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "TabE1",
-                    "title": "TabE1",
-                    "description": "\nEEE1Content",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "EEE",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "EEE"
-                    }
-                  }
-                ]
+                "id": "8ec10849-7856-4375-a108-edf9645940e6-1"
               }
             ]
           },
@@ -120,14 +68,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "cea683cf-3920-426b-b0a3-f4bb448c3622",
+            "key": "c6d758bc-b5db-4a90-a936-3c17b8c9e447",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "58cc085b-00cb-4a35-807e-fa653865ecb4",
+                  "key": "7a1bde8b-ca56-4e12-97c9-5ee786fb36c2",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -137,160 +85,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "00e9031c-521c-4976-9831-3dfc09c5c75c",
+                            "key": "54f81dbc-e37a-4491-b040-80bee0cf5123",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-2",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab4.md",
-                                    "title": "snippets-in-tab4.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2",
-                                    "title": "Tab1",
-                                    "description": "imports:\n",
-                                    "member": 0,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab1",
-                                    "member": 0,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "8ec10849-7856-4375-a108-edf9645940e6-2"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-3",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab4.md",
-                                    "title": "snippets-in-tab4.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2",
-                                    "title": "Tab1",
-                                    "description": "imports:\n",
-                                    "member": 0,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab1",
-                                    "member": 0,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "8ec10849-7856-4375-a108-edf9645940e6-3"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-4",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab4.md",
-                                    "title": "snippets-in-tab4.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2",
-                                    "title": "Tab1",
-                                    "description": "imports:\n",
-                                    "member": 0,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab1",
-                                    "member": 0,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "8ec10849-7856-4375-a108-edf9645940e6-4"
                               }
                             ]
                           },
@@ -299,58 +112,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "8fa8768e-d470-4803-961d-03d1d0532f93",
+                            "key": "b7398028-f5b6-4f0d-8eab-b05f09061c1c",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-5",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab4.md",
-                                    "title": "snippets-in-tab4.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2",
-                                    "title": "Tab1",
-                                    "description": "imports:\n",
-                                    "member": 0,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab2",
-                                    "member": 1,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "8ec10849-7856-4375-a108-edf9645940e6-5"
                               }
                             ]
                           },
@@ -370,28 +138,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "ffe8f02a-9b3a-4278-96c8-aab063217d88",
+            "key": "3ece0c99-90dd-4b72-b9d0-c5e219e75ce7",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "0e8e1c09-11d8-4c10-8cd6-2597f7cb7b3e-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab4.md",
-                    "title": "snippets-in-tab4.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab4.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "Tab1####Tab2",
-                    "title": "Tab2",
-                    "description": "\nBBBoo",
-                    "member": 1,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "8ec10849-7856-4375-a108-edf9645940e6-6"
               }
             ]
           },

--- a/test/inputs/5/wizard.json
+++ b/test/inputs/5/wizard.json
@@ -5,27 +5,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "2b63583a-712e-4ddd-a056-c8b90085c07f",
+        "key": "deb1ee4b-aff7-483e-b9cf-05113d83979d",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-0",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/snippets-in-tab5.md",
-                "title": "snippets-in-tab5.md",
-                "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-              },
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importa.md",
-                "title": "importa.md",
-                "filepath": "test/inputs/snippets/importa.md"
-              }
-            ]
+            "id": "21579da7-7d61-438f-a31a-3d21cd10400f-0"
           }
         ]
       },
@@ -45,50 +31,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "59777299-8825-47db-8908-be99040b2ab4",
+            "key": "48bb0f83-69ff-45bf-858f-3c1d44b7821c",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                    "title": "snippets-in-tab5.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importe.md",
-                    "title": "EEE",
-                    "filepath": "test/inputs/snippets/importe.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "TabE1",
-                    "title": "TabE1",
-                    "description": "\nEEE1Content",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "EEE",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "EEE"
-                    }
-                  }
-                ]
+                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-1"
               }
             ]
           },
@@ -120,14 +68,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "6a0df852-5637-42b2-b849-837916961a21",
+            "key": "fb6f7b4a-791d-4a5f-b020-9df462bf4c6a",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "ed1f01a5-5a3a-4741-b1d6-6a68d24b40f3",
+                  "key": "fa17eb3f-1704-4d3b-863f-d9088e974a40",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -137,160 +85,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "f64dbdf6-9651-468d-ab3b-5b462ec41562",
+                            "key": "1e39486d-473e-44c2-adc6-bd61c149fe54",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-2",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                                    "title": "snippets-in-tab5.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2####Tab3",
-                                    "title": "Tab1",
-                                    "description": "imports:\n",
-                                    "member": 0,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab1",
-                                    "member": 0,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-2"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-3",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                                    "title": "snippets-in-tab5.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2####Tab3",
-                                    "title": "Tab1",
-                                    "description": "imports:\n",
-                                    "member": 0,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab1",
-                                    "member": 0,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-3"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-4",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                                    "title": "snippets-in-tab5.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2####Tab3",
-                                    "title": "Tab1",
-                                    "description": "imports:\n",
-                                    "member": 0,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab1",
-                                    "member": 0,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-4"
                               }
                             ]
                           },
@@ -299,58 +112,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "6b221e82-4a24-4f67-9737-94994b31a432",
+                            "key": "def6ed0c-3ffe-4219-99ba-ed76bee6035a",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-5",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                                    "title": "snippets-in-tab5.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2####Tab3",
-                                    "title": "Tab1",
-                                    "description": "imports:\n",
-                                    "member": 0,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab2",
-                                    "member": 1,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-5"
                               }
                             ]
                           },
@@ -370,28 +138,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "1d0c6585-d92c-4029-b7d1-c514c25ab56d",
+            "key": "051e889d-b78b-4295-b5a7-595fd93043e0",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                    "title": "snippets-in-tab5.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "Tab1####Tab2####Tab3",
-                    "title": "Tab2",
-                    "description": "\nBBBoo",
-                    "member": 1,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-6"
               }
             ]
           },
@@ -401,14 +153,14 @@
         {
           "member": 2,
           "graph": {
-            "key": "f5017c9d-b9e0-446a-b353-eee632af2e4f",
+            "key": "e5a68197-78dc-45e4-87c9-15fdcba5e62d",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "94e2d3ee-a96b-4f76-accd-788871688717",
+                  "key": "ad1a0919-eaab-4412-ad9b-b5f69bba7483",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -418,160 +170,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "ecc243d5-da1e-430e-990d-fdaf8e2d0964",
+                            "key": "88eed42f-2074-4a19-a607-765d0b6f7d99",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-7",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                                    "title": "snippets-in-tab5.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2####Tab3",
-                                    "title": "Tab3",
-                                    "description": "imports:\n",
-                                    "member": 2,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab1",
-                                    "member": 0,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-7"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-8",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                                    "title": "snippets-in-tab5.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2####Tab3",
-                                    "title": "Tab3",
-                                    "description": "imports:\n",
-                                    "member": 2,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab1",
-                                    "member": 0,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-8"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-9",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                                    "title": "snippets-in-tab5.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2####Tab3",
-                                    "title": "Tab3",
-                                    "description": "imports:\n",
-                                    "member": 2,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab1",
-                                    "member": 0,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-9"
                               }
                             ]
                           },
@@ -580,58 +197,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "c4db5c46-cccf-4b2a-a9a9-9d4ba4c553c5",
+                            "key": "84a2da65-32dd-438c-b8eb-b462e351789d",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "9a94f636-5ecf-4ee2-b1f5-619571deb0b4-10",
-                                "nesting": [
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                                    "title": "snippets-in-tab5.md",
-                                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "Tab1####Tab2####Tab3",
-                                    "title": "Tab3",
-                                    "description": "imports:\n",
-                                    "member": 2,
-                                    "groupDetail": {}
-                                  },
-                                  {
-                                    "kind": "Import",
-                                    "key": "test/inputs/snippets/importd.md",
-                                    "title": "DDD",
-                                    "filepath": "test/inputs/snippets/importd.md"
-                                  },
-                                  {
-                                    "kind": "Choice",
-                                    "group": "SubTab1####SubTab2",
-                                    "title": "SubTab2",
-                                    "member": 1,
-                                    "groupDetail": {
-                                      "child": {
-                                        "type": "element",
-                                        "tagName": "h1",
-                                        "properties": {},
-                                        "children": [
-                                          {
-                                            "type": "text",
-                                            "value": "DDD",
-                                            "position": "placeholder"
-                                          }
-                                        ],
-                                        "position": "placeholder"
-                                      },
-                                      "level": 1,
-                                      "title": "DDD"
-                                    }
-                                  }
-                                ]
+                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-10"
                               }
                             ]
                           },

--- a/test/inputs/6/wizard.json
+++ b/test/inputs/6/wizard.json
@@ -8,118 +8,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "622dfde3-eabd-4189-969d-ad1c58327a83",
+            "key": "b4fc2edf-bbd4-4e36-a28a-50dc51eed123",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0c6f9eab-4128-4c24-b394-648906b45572-0",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0c6f9eab-4128-4c24-b394-648906b45572-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0c6f9eab-4128-4c24-b394-648906b45572-2",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-2"
               }
             ]
           },
@@ -128,44 +35,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "31bdd4d7-9156-4c1c-b6ed-a92d0430fab1",
+            "key": "c786a8bd-267d-46cb-b2c1-5d13b308656f",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "0c6f9eab-4128-4c24-b394-648906b45572-3",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-3"
               }
             ]
           },
@@ -198,27 +74,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "2ee07653-d358-46fe-afd8-f08fc67ba86f",
+        "key": "bf99c98c-f86c-4a9e-8e34-879f9d71ae40",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "0c6f9eab-4128-4c24-b394-648906b45572-4",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/snippets-in-tab5.md",
-                "title": "snippets-in-tab5.md",
-                "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-              },
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importa.md",
-                "title": "importa.md",
-                "filepath": "test/inputs/snippets/importa.md"
-              }
-            ]
+            "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-4"
           }
         ]
       },
@@ -238,50 +100,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "7e022526-3eea-4a14-8961-b9d648dd856f",
+            "key": "0ae5023d-95c1-490b-a2e6-75eb03ed9e31",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "0c6f9eab-4128-4c24-b394-648906b45572-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                    "title": "snippets-in-tab5.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importe.md",
-                    "title": "EEE",
-                    "filepath": "test/inputs/snippets/importe.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "TabE1",
-                    "title": "TabE1",
-                    "description": "\nEEE1Content",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "EEE",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "EEE"
-                    }
-                  }
-                ]
+                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-5"
               }
             ]
           },
@@ -313,28 +137,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "7bd8e9bc-69c8-44d6-8477-4a59682aab1d",
+            "key": "48352c02-a635-4bba-9505-3fe1b01ac7d4",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "0c6f9eab-4128-4c24-b394-648906b45572-10",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                    "title": "snippets-in-tab5.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "Tab1####Tab2####Tab3",
-                    "title": "Tab2",
-                    "description": "\nBBBoo",
-                    "member": 1,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-10"
               }
             ]
           },

--- a/test/inputs/7/wizard.json
+++ b/test/inputs/7/wizard.json
@@ -8,118 +8,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "2a45ea57-5695-44fa-a588-1b1525ec8121",
+            "key": "4f74783c-e28a-48ab-9f54-6c3b47b85e31",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-0",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-2",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-2"
               }
             ]
           },
@@ -128,44 +35,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "f80f9286-c302-4dfb-ae84-aee2a1d489a8",
+            "key": "42231e9f-e832-49d2-9bb8-2be1345d12a7",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-3",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-3"
               }
             ]
           },
@@ -198,27 +74,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "dda041da-af71-4c89-ac1d-c16c0325cc2c",
+        "key": "28812321-3356-4d98-a719-f5e944271729",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "d32658b7-423b-464d-8186-b807c2ae7f72-4",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/snippets-in-tab5.md",
-                "title": "snippets-in-tab5.md",
-                "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-              },
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importa.md",
-                "title": "importa.md",
-                "filepath": "test/inputs/snippets/importa.md"
-              }
-            ]
+            "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-4"
           }
         ]
       },
@@ -238,50 +100,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "7aa2075a-cb05-4011-9d0c-713832440828",
+            "key": "ec64035c-6867-4030-abfb-6497772ccb91",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                    "title": "snippets-in-tab5.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importe.md",
-                    "title": "EEE",
-                    "filepath": "test/inputs/snippets/importe.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "TabE1",
-                    "title": "TabE1",
-                    "description": "\nEEE1Content",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "EEE",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "EEE"
-                    }
-                  }
-                ]
+                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-5"
               }
             ]
           },
@@ -313,28 +137,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "a5e6e911-5b38-49da-a7f6-02cb268e2989",
+            "key": "65dcab00-cb3d-45e6-853f-38437d498137",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "d32658b7-423b-464d-8186-b807c2ae7f72-10",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab5.md",
-                    "title": "snippets-in-tab5.md",
-                    "filepath": "test/inputs/snippets/snippets-in-tab5.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "Tab1####Tab2####Tab3",
-                    "title": "Tab2",
-                    "description": "\nBBBoo",
-                    "member": 1,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-10"
               }
             ]
           },

--- a/test/inputs/8/wizard.json
+++ b/test/inputs/8/wizard.json
@@ -8,205 +8,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "d31fb27f-02ab-4c2b-809c-caf8d3a71ea6",
+            "key": "c2558692-4059-43af-9420-a584dd5e895a",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "4f47be51-375e-4be9-8a90-5409539a9bec-0",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab6.md",
-                    "title": "Chooser",
-                    "filepath": "test/inputs/snippets/snippets-in-tab6.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "Tab1####Tab2####Tab3",
-                    "title": "Tab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Chooser",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Chooser"
-                    }
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "fc6dc138-100e-4664-8544-5de529da6bd2-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "4f47be51-375e-4be9-8a90-5409539a9bec-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab6.md",
-                    "title": "Chooser",
-                    "filepath": "test/inputs/snippets/snippets-in-tab6.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "Tab1####Tab2####Tab3",
-                    "title": "Tab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Chooser",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Chooser"
-                    }
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "fc6dc138-100e-4664-8544-5de529da6bd2-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "4f47be51-375e-4be9-8a90-5409539a9bec-2",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab6.md",
-                    "title": "Chooser",
-                    "filepath": "test/inputs/snippets/snippets-in-tab6.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "Tab1####Tab2####Tab3",
-                    "title": "Tab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Chooser",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Chooser"
-                    }
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "fc6dc138-100e-4664-8544-5de529da6bd2-2"
               }
             ]
           },
@@ -215,73 +35,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "e4ad1147-046e-497f-ab7d-8d4b7f424211",
+            "key": "5857e1e2-4c5a-401f-afe4-ff281c5e6600",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "4f47be51-375e-4be9-8a90-5409539a9bec-3",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/snippets-in-tab6.md",
-                    "title": "Chooser",
-                    "filepath": "test/inputs/snippets/snippets-in-tab6.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "Tab1####Tab2####Tab3",
-                    "title": "Tab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "Chooser",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "Chooser"
-                    }
-                  },
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "SubTab1####SubTab2",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "fc6dc138-100e-4664-8544-5de529da6bd2-3"
               }
             ]
           },

--- a/test/inputs/9/wizard-darwin.json
+++ b/test/inputs/9/wizard-darwin.json
@@ -5,27 +5,12 @@
       "title": "importg.md",
       "filepath": "test/inputs/snippets/importg.md",
       "graph": {
-        "key": "dd3bba0a-23a5-489f-a021-70d6e0b51cb5",
+        "key": "a8458fb6-2900-435b-b1be-657b78cf8701",
         "sequence": [
           {
             "body": "echo MMM",
             "language": "bash",
-            "id": "744557b5-ee37-42a9-96df-fce7f86f8544-0",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importg.md",
-                "title": "importg.md",
-                "filepath": "test/inputs/snippets/importg.md"
-              },
-              {
-                "kind": "Choice",
-                "group": "org.kubernetes-sigs.kui/choice/platform",
-                "title": "Darwin",
-                "member": 0,
-                "groupDetail": {}
-              }
-            ]
+            "id": "2a4fcbb4-784e-4377-b277-d64cae1b80f0-0"
           }
         ]
       },
@@ -42,21 +27,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "21e6e3c0-5963-46ad-b030-7122a4e7b002",
+        "key": "47d2e85b-fcc4-49e8-8f87-9725cc40a7a2",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "744557b5-ee37-42a9-96df-fce7f86f8544-3",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importa.md",
-                "title": "importa.md",
-                "filepath": "test/inputs/snippets/importa.md"
-              }
-            ]
+            "id": "2a4fcbb4-784e-4377-b277-d64cae1b80f0-3"
           }
         ]
       },
@@ -69,125 +46,32 @@
   },
   {
     "graph": {
-      "group": "d0aa3f86-dc61-5611-8769-9212e4fda83e",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "fb86f2e7-7f73-4a4f-880d-ecb1cf851511",
+            "key": "77cb07af-37b2-42e6-9f1a-16211dbb0d74",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "744557b5-ee37-42a9-96df-fce7f86f8544-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "d0aa3f86-dc61-5611-8769-9212e4fda83e",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "2a4fcbb4-784e-4377-b277-d64cae1b80f0-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "744557b5-ee37-42a9-96df-fce7f86f8544-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "d0aa3f86-dc61-5611-8769-9212e4fda83e",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "2a4fcbb4-784e-4377-b277-d64cae1b80f0-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "744557b5-ee37-42a9-96df-fce7f86f8544-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "d0aa3f86-dc61-5611-8769-9212e4fda83e",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "2a4fcbb4-784e-4377-b277-d64cae1b80f0-6"
               }
             ]
           },
@@ -196,44 +80,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "ff99a8ac-4fa7-47ff-9ab6-1b60aa724f91",
+            "key": "587f7d2a-37c7-445a-ae1a-77e3aa201ac5",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "744557b5-ee37-42a9-96df-fce7f86f8544-7",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "d0aa3f86-dc61-5611-8769-9212e4fda83e",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "2a4fcbb4-784e-4377-b277-d64cae1b80f0-7"
               }
             ]
           },
@@ -247,13 +100,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "d0aa3f86-dc61-5611-8769-9212e4fda83e",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "d0aa3f86-dc61-5611-8769-9212e4fda83e",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/9/wizard-linux.json
+++ b/test/inputs/9/wizard-linux.json
@@ -5,27 +5,12 @@
       "title": "importg.md",
       "filepath": "test/inputs/snippets/importg.md",
       "graph": {
-        "key": "e3c6b6d4-b5dc-41f9-bc7f-291087e023aa",
+        "key": "97b15633-2b8e-4c01-9285-0b8d19803200",
         "sequence": [
           {
             "body": "echo LLL",
             "language": "bash",
-            "id": "ab8084c7-9cb1-438b-b89d-29e5e26df4cb-1",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importg.md",
-                "title": "importg.md",
-                "filepath": "test/inputs/snippets/importg.md"
-              },
-              {
-                "kind": "Choice",
-                "group": "org.kubernetes-sigs.kui/choice/platform",
-                "title": "Linux",
-                "member": 1,
-                "groupDetail": {}
-              }
-            ]
+            "id": "28fb4629-f845-418b-837c-72e9aa921ddd-1"
           }
         ]
       },
@@ -42,21 +27,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "10fcbe11-cc75-4246-a6ce-b0caeb5c84f4",
+        "key": "23b6c82a-2691-4eb0-a9ac-809971a58463",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "ab8084c7-9cb1-438b-b89d-29e5e26df4cb-3",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importa.md",
-                "title": "importa.md",
-                "filepath": "test/inputs/snippets/importa.md"
-              }
-            ]
+            "id": "28fb4629-f845-418b-837c-72e9aa921ddd-3"
           }
         ]
       },
@@ -69,125 +46,32 @@
   },
   {
     "graph": {
-      "group": "49af7d72-9ca7-5259-9518-c4150f0242ff",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "39073eb8-77ef-49a2-8f56-7dd2e6471db4",
+            "key": "4bdee940-b752-439f-9caf-0023a44615ab",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "ab8084c7-9cb1-438b-b89d-29e5e26df4cb-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "49af7d72-9ca7-5259-9518-c4150f0242ff",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "28fb4629-f845-418b-837c-72e9aa921ddd-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "ab8084c7-9cb1-438b-b89d-29e5e26df4cb-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "49af7d72-9ca7-5259-9518-c4150f0242ff",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "28fb4629-f845-418b-837c-72e9aa921ddd-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "ab8084c7-9cb1-438b-b89d-29e5e26df4cb-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "49af7d72-9ca7-5259-9518-c4150f0242ff",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "28fb4629-f845-418b-837c-72e9aa921ddd-6"
               }
             ]
           },
@@ -196,44 +80,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "e42ccc74-2b84-4559-96e4-5323299aeac3",
+            "key": "ded3006c-31ef-4b5a-9993-f7b61b3cee38",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "ab8084c7-9cb1-438b-b89d-29e5e26df4cb-7",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "49af7d72-9ca7-5259-9518-c4150f0242ff",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "28fb4629-f845-418b-837c-72e9aa921ddd-7"
               }
             ]
           },
@@ -247,13 +100,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "49af7d72-9ca7-5259-9518-c4150f0242ff",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "49af7d72-9ca7-5259-9518-c4150f0242ff",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": true
         }

--- a/test/inputs/9/wizard-noaprioris.json
+++ b/test/inputs/9/wizard-noaprioris.json
@@ -1,34 +1,19 @@
 [
   {
     "graph": {
-      "group": "cd748591-123d-5715-bd7a-82bb622cf890",
+      "group": "MacOS####Linux####Windows",
       "title": "importg.md",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "6a94bc16-0e9b-4b27-ba15-4dc662b3e7b3",
+            "key": "5895c316-09ea-4c3a-88f1-771e0f9bc57b",
             "sequence": [
               {
                 "body": "echo MMM",
                 "language": "bash",
-                "id": "7251e892-9b48-4ed9-91c7-016c21fbc0a4-0",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importg.md",
-                    "title": "importg.md",
-                    "filepath": "test/inputs/snippets/importg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "cd748591-123d-5715-bd7a-82bb622cf890",
-                    "title": "MacOS",
-                    "member": 0,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "8fa6b88e-0d4d-4157-9bf2-0ca9c3bee918-0"
               }
             ]
           },
@@ -37,27 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "47ae2014-38b5-4596-8f04-f1a5c87ed400",
+            "key": "9de6ab92-c5eb-44c9-b921-6e1dceac99f6",
             "sequence": [
               {
                 "body": "echo LLL",
                 "language": "bash",
-                "id": "7251e892-9b48-4ed9-91c7-016c21fbc0a4-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importg.md",
-                    "title": "importg.md",
-                    "filepath": "test/inputs/snippets/importg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "cd748591-123d-5715-bd7a-82bb622cf890",
-                    "title": "Linux",
-                    "member": 1,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "8fa6b88e-0d4d-4157-9bf2-0ca9c3bee918-1"
               }
             ]
           },
@@ -66,27 +36,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "8c2a7d3a-40a2-4a25-a18b-7ec91a330cf1",
+            "key": "9cf44221-2dde-412a-9e1b-1c7eab3a07d3",
             "sequence": [
               {
                 "body": "echo WWW",
                 "language": "bash",
-                "id": "7251e892-9b48-4ed9-91c7-016c21fbc0a4-2",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importg.md",
-                    "title": "importg.md",
-                    "filepath": "test/inputs/snippets/importg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "cd748591-123d-5715-bd7a-82bb622cf890",
-                    "title": "Windows",
-                    "member": 2,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "8fa6b88e-0d4d-4157-9bf2-0ca9c3bee918-2"
               }
             ]
           },
@@ -100,19 +55,19 @@
       "content": [
         {
           "title": "MacOS",
-          "group": "cd748591-123d-5715-bd7a-82bb622cf890",
+          "group": "MacOS####Linux####Windows",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "Linux",
-          "group": "cd748591-123d-5715-bd7a-82bb622cf890",
+          "group": "MacOS####Linux####Windows",
           "member": 1,
           "isFirstChoice": true
         },
         {
           "title": "Windows",
-          "group": "cd748591-123d-5715-bd7a-82bb622cf890",
+          "group": "MacOS####Linux####Windows",
           "member": 2,
           "isFirstChoice": true
         }
@@ -125,21 +80,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "eeeaf30b-d28a-49bf-bc37-f743175fdac4",
+        "key": "021649b3-3075-4f36-a705-a3fa53b66078",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "7251e892-9b48-4ed9-91c7-016c21fbc0a4-3",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importa.md",
-                "title": "importa.md",
-                "filepath": "test/inputs/snippets/importa.md"
-              }
-            ]
+            "id": "8fa6b88e-0d4d-4157-9bf2-0ca9c3bee918-3"
           }
         ]
       },
@@ -152,125 +99,32 @@
   },
   {
     "graph": {
-      "group": "1336d532-be5f-5088-8c4d-7fe33e7e79d4",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "f881d236-026f-49ec-8a02-31d9a27e5b81",
+            "key": "375ef5ba-a132-46e1-b7a6-ea4430a2fb0d",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "7251e892-9b48-4ed9-91c7-016c21fbc0a4-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "1336d532-be5f-5088-8c4d-7fe33e7e79d4",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "8fa6b88e-0d4d-4157-9bf2-0ca9c3bee918-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "7251e892-9b48-4ed9-91c7-016c21fbc0a4-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "1336d532-be5f-5088-8c4d-7fe33e7e79d4",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "8fa6b88e-0d4d-4157-9bf2-0ca9c3bee918-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "7251e892-9b48-4ed9-91c7-016c21fbc0a4-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "1336d532-be5f-5088-8c4d-7fe33e7e79d4",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "8fa6b88e-0d4d-4157-9bf2-0ca9c3bee918-6"
               }
             ]
           },
@@ -279,44 +133,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "5dda6e2f-0cc8-4edb-b48e-2995ce8fdd3b",
+            "key": "4f030f46-35b4-4c0f-a98e-6934e7505c4e",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "7251e892-9b48-4ed9-91c7-016c21fbc0a4-7",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "1336d532-be5f-5088-8c4d-7fe33e7e79d4",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "8fa6b88e-0d4d-4157-9bf2-0ca9c3bee918-7"
               }
             ]
           },
@@ -330,13 +153,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "1336d532-be5f-5088-8c4d-7fe33e7e79d4",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": false
         },
         {
           "title": "SubTab2",
-          "group": "1336d532-be5f-5088-8c4d-7fe33e7e79d4",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": false
         }

--- a/test/inputs/9/wizard-noopt.json
+++ b/test/inputs/9/wizard-noopt.json
@@ -1,34 +1,19 @@
 [
   {
     "graph": {
-      "group": "0a027ff2-5db8-54a0-8e3f-2985a6f5e13d",
+      "group": "MacOS####Linux####Windows",
       "title": "importg.md",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "faa60e8e-eed4-4aea-a98f-288bd1703f41",
+            "key": "44b9f93a-367c-4567-b835-6f44073c0e04",
             "sequence": [
               {
                 "body": "echo MMM",
                 "language": "bash",
-                "id": "be13e240-52fd-46d9-9494-544404ea22d3-0",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importg.md",
-                    "title": "importg.md",
-                    "filepath": "test/inputs/snippets/importg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "0a027ff2-5db8-54a0-8e3f-2985a6f5e13d",
-                    "title": "MacOS",
-                    "member": 0,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "7d419cbf-6177-40f4-aa49-d6ffc6e6c9bc-0"
               }
             ]
           },
@@ -37,27 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "327d1e72-d90f-4fde-8404-769519c3234a",
+            "key": "75437fbf-9054-4703-992f-999c2c081c92",
             "sequence": [
               {
                 "body": "echo LLL",
                 "language": "bash",
-                "id": "be13e240-52fd-46d9-9494-544404ea22d3-1",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importg.md",
-                    "title": "importg.md",
-                    "filepath": "test/inputs/snippets/importg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "0a027ff2-5db8-54a0-8e3f-2985a6f5e13d",
-                    "title": "Linux",
-                    "member": 1,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "7d419cbf-6177-40f4-aa49-d6ffc6e6c9bc-1"
               }
             ]
           },
@@ -66,27 +36,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "daf7ea5e-5fe1-440e-9466-09781e481999",
+            "key": "91a600a3-022c-48d2-9c43-2ea3bb105347",
             "sequence": [
               {
                 "body": "echo WWW",
                 "language": "bash",
-                "id": "be13e240-52fd-46d9-9494-544404ea22d3-2",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importg.md",
-                    "title": "importg.md",
-                    "filepath": "test/inputs/snippets/importg.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "0a027ff2-5db8-54a0-8e3f-2985a6f5e13d",
-                    "title": "Windows",
-                    "member": 2,
-                    "groupDetail": {}
-                  }
-                ]
+                "id": "7d419cbf-6177-40f4-aa49-d6ffc6e6c9bc-2"
               }
             ]
           },
@@ -100,19 +55,19 @@
       "content": [
         {
           "title": "MacOS",
-          "group": "0a027ff2-5db8-54a0-8e3f-2985a6f5e13d",
+          "group": "MacOS####Linux####Windows",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "Linux",
-          "group": "0a027ff2-5db8-54a0-8e3f-2985a6f5e13d",
+          "group": "MacOS####Linux####Windows",
           "member": 1,
           "isFirstChoice": true
         },
         {
           "title": "Windows",
-          "group": "0a027ff2-5db8-54a0-8e3f-2985a6f5e13d",
+          "group": "MacOS####Linux####Windows",
           "member": 2,
           "isFirstChoice": true
         }
@@ -125,21 +80,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "6d45729a-0e28-49ee-98ca-1d60d4b9b25d",
+        "key": "7bebeac0-0c25-46f6-a113-5d447dc87cc9",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "be13e240-52fd-46d9-9494-544404ea22d3-3",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importa.md",
-                "title": "importa.md",
-                "filepath": "test/inputs/snippets/importa.md"
-              }
-            ]
+            "id": "7d419cbf-6177-40f4-aa49-d6ffc6e6c9bc-3"
           }
         ]
       },
@@ -152,125 +99,32 @@
   },
   {
     "graph": {
-      "group": "01e5f6ba-2ffe-5453-8f59-16eb78f2878f",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "1667effc-f1b5-49f3-9edc-f083dd752589",
+            "key": "0b8d423b-beb9-41b4-8bcb-48daf369f507",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "be13e240-52fd-46d9-9494-544404ea22d3-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "01e5f6ba-2ffe-5453-8f59-16eb78f2878f",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "7d419cbf-6177-40f4-aa49-d6ffc6e6c9bc-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "be13e240-52fd-46d9-9494-544404ea22d3-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "01e5f6ba-2ffe-5453-8f59-16eb78f2878f",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "7d419cbf-6177-40f4-aa49-d6ffc6e6c9bc-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "be13e240-52fd-46d9-9494-544404ea22d3-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "01e5f6ba-2ffe-5453-8f59-16eb78f2878f",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "7d419cbf-6177-40f4-aa49-d6ffc6e6c9bc-6"
               }
             ]
           },
@@ -279,44 +133,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "9d9bb5be-47b5-44ad-9baa-4cfa8be575d7",
+            "key": "ae13c829-4aaf-44b7-9774-8a273d751ba9",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "be13e240-52fd-46d9-9494-544404ea22d3-7",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "01e5f6ba-2ffe-5453-8f59-16eb78f2878f",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "7d419cbf-6177-40f4-aa49-d6ffc6e6c9bc-7"
               }
             ]
           },
@@ -330,13 +153,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "01e5f6ba-2ffe-5453-8f59-16eb78f2878f",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": false
         },
         {
           "title": "SubTab2",
-          "group": "01e5f6ba-2ffe-5453-8f59-16eb78f2878f",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": false
         }

--- a/test/inputs/9/wizard-win32.json
+++ b/test/inputs/9/wizard-win32.json
@@ -5,27 +5,12 @@
       "title": "importg.md",
       "filepath": "test/inputs/snippets/importg.md",
       "graph": {
-        "key": "4f0f40a3-d705-47d9-9bd1-8e8633db8165",
+        "key": "49e9b197-60f5-4637-bc9f-ff78c9b788d9",
         "sequence": [
           {
-            "body": "echo LLL",
+            "body": "echo WWW",
             "language": "bash",
-            "id": "cf846266-d5e5-487f-ac4c-d07c542e246e-1",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importg.md",
-                "title": "importg.md",
-                "filepath": "test/inputs/snippets/importg.md"
-              },
-              {
-                "kind": "Choice",
-                "group": "org.kubernetes-sigs.kui/choice/platform",
-                "title": "Linux",
-                "member": 1,
-                "groupDetail": {}
-              }
-            ]
+            "id": "76d1b4f3-035f-48b3-a7d9-1129dcc41900-2"
           }
         ]
       },
@@ -42,21 +27,13 @@
       "title": "importa.md",
       "filepath": "test/inputs/snippets/importa.md",
       "graph": {
-        "key": "13d94f14-694b-420c-8f51-285065cc23bc",
+        "key": "7a4c0a45-d772-4971-b6e8-2dac789e5da5",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "cf846266-d5e5-487f-ac4c-d07c542e246e-3",
-            "nesting": [
-              {
-                "kind": "Import",
-                "key": "test/inputs/snippets/importa.md",
-                "title": "importa.md",
-                "filepath": "test/inputs/snippets/importa.md"
-              }
-            ]
+            "id": "76d1b4f3-035f-48b3-a7d9-1129dcc41900-3"
           }
         ]
       },
@@ -69,125 +46,32 @@
   },
   {
     "graph": {
-      "group": "382aec25-3cc5-5438-a03e-2f1c1d600653",
+      "group": "SubTab1####SubTab2",
       "title": "DDD",
       "source": "placeholder",
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "8af62e02-5987-49e4-833f-76b793b3a15a",
+            "key": "836068d8-afca-427d-a17b-6231f9840790",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "cf846266-d5e5-487f-ac4c-d07c542e246e-4",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "382aec25-3cc5-5438-a03e-2f1c1d600653",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "76d1b4f3-035f-48b3-a7d9-1129dcc41900-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "cf846266-d5e5-487f-ac4c-d07c542e246e-5",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "382aec25-3cc5-5438-a03e-2f1c1d600653",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "76d1b4f3-035f-48b3-a7d9-1129dcc41900-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "cf846266-d5e5-487f-ac4c-d07c542e246e-6",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "382aec25-3cc5-5438-a03e-2f1c1d600653",
-                    "title": "SubTab1",
-                    "member": 0,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "76d1b4f3-035f-48b3-a7d9-1129dcc41900-6"
               }
             ]
           },
@@ -196,44 +80,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "ba47c079-924a-4dfa-9b19-cd7b9b855aee",
+            "key": "b7aa6960-f409-4f5c-bf92-f9d4c88d3736",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "cf846266-d5e5-487f-ac4c-d07c542e246e-7",
-                "nesting": [
-                  {
-                    "kind": "Import",
-                    "key": "test/inputs/snippets/importd.md",
-                    "title": "DDD",
-                    "filepath": "test/inputs/snippets/importd.md"
-                  },
-                  {
-                    "kind": "Choice",
-                    "group": "382aec25-3cc5-5438-a03e-2f1c1d600653",
-                    "title": "SubTab2",
-                    "member": 1,
-                    "groupDetail": {
-                      "child": {
-                        "type": "element",
-                        "tagName": "h1",
-                        "properties": {},
-                        "children": [
-                          {
-                            "type": "text",
-                            "value": "DDD",
-                            "position": "placeholder"
-                          }
-                        ],
-                        "position": "placeholder"
-                      },
-                      "level": 1,
-                      "title": "DDD"
-                    }
-                  }
-                ]
+                "id": "76d1b4f3-035f-48b3-a7d9-1129dcc41900-7"
               }
             ]
           },
@@ -247,13 +100,13 @@
       "content": [
         {
           "title": "SubTab1",
-          "group": "382aec25-3cc5-5438-a03e-2f1c1d600653",
+          "group": "SubTab1####SubTab2",
           "member": 0,
           "isFirstChoice": true
         },
         {
           "title": "SubTab2",
-          "group": "382aec25-3cc5-5438-a03e-2f1c1d600653",
+          "group": "SubTab1####SubTab2",
           "member": 1,
           "isFirstChoice": true
         }


### PR DESCRIPTION
We aren't leveraging this change yet. The goal is to improve support for guidebooks where the outcome of an expansion (e.g. even whether it is successful) depends on the successful execution of a prior task.

For example, you may need to log in to your cloud provider before you can enumerate properties of your account.

To support that kind of complexity will require some changes to the guide logic. It currently assumes that it can resolve all choices before executing any tasks :/