### PR TITLE
feat: allow fetching from the store in short form

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { read } from "to-vfile"
 import { VFileCompatible } from "vfile"
 import { extname as pathExtname } from "path"
 
+import { madwizardRead } from "./markdown"
 import { ChoiceState, MadWizardOptions } from "../../"
 
 export * from "./markdown"
@@ -40,11 +40,11 @@ export async function parse(
   input: VFileCompatible,
   choices?: ChoiceState,
   uuid?: string,
-  reader?: typeof read,
+  reader?: typeof madwizardRead,
   madwizardOptions?: MadWizardOptions
 ) {
   const ext = extname(input)
-  if (ext === ".md") {
+  if (ext === ".md" || !ext) {
     return await import("./markdown").then((_) => _.blockify(input, choices, uuid, reader, madwizardOptions))
   } else {
     throw new Error(`Unsupported file type: ${String(input)}`)


### PR DESCRIPTION
e.g. ibm/cloud/target will fetch from
https://github.com/guidebooks/store/blob/main/guidebooks/ibm/cloud/target.md