### PR TITLE
fix: nested imports may fail due to use of encodeURIComponent

### DIFF
--- a/src/codeblock/CodeBlockProps.ts
+++ b/src/codeblock/CodeBlockProps.ts
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 
+export interface Validatable {
+  /**
+   * If given, this command line will be executed. If it exits with
+   * exit code 0, then the code block will be seen as "already
+   * executed", and thus represent a valid state. Non-zero exit
+   * codes will not be seen as errors, but rather as representative
+   * of a default state.
+   */
+  validate: string
+}
+
 export interface GroupMember {
   /**
    * This option names the group, to keep it distinct from other
@@ -67,6 +78,7 @@ export type Import = Source &
   Title &
   Partial<Description> &
   Partial<Barrier> &
+  Partial<Validatable> &
   Kind<"Import"> & {
     key: string
     filepath: string
@@ -113,12 +125,11 @@ export function isWizardStep(part: CodeBlockNestingParent): part is WizardStep {
   return hasKind(part, "WizardStep")
 }
 
-export interface CodeBlockProps {
+export type CodeBlockProps = Partial<Validatable> & {
   id: string
   body: string
   language: string
   optional?: boolean
-  validate?: string
   nesting?: CodeBlockNestingParent[]
 }
 

--- a/src/graph/compile.ts
+++ b/src/graph/compile.ts
@@ -140,7 +140,8 @@ export async function compile(
         parent.filepath,
         isDeepest ? seq(block) : emptySequence(),
         parent.source,
-        parent.barrier
+        parent.barrier,
+        parent.validate
       )
     }
 

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -29,7 +29,7 @@ import { v4 } from "uuid"
 import { basename } from "path"
 
 import { ChoiceState } from "../choices"
-import { CodeBlockProps, Source, Title, Description } from "../codeblock/CodeBlockProps"
+import { Barrier, Validatable, CodeBlockProps, Source, Title, Description } from "../codeblock/CodeBlockProps"
 
 export * from "./order"
 export * from "./Status"
@@ -171,20 +171,13 @@ function sameTitledSteps(A: TitledSteps, B: TitledSteps) {
   )
 }
 
-/**
- * Does this guidebook need to be executed before subsequent choices
- * even make sense? e.g. logging in to a cluster.
- */
-type Barrier = {
-  barrier: boolean
-}
-
 export type SubTask<T extends Unordered | Ordered = Unordered> = Key &
   Source &
   Filepath &
   Title &
   Partial<Description> &
   Partial<Barrier> &
+  Partial<Validatable> &
   T & {
     graph: Sequence<T>
   }
@@ -198,7 +191,8 @@ export function subtask<T extends Unordered | Ordered = Unordered>(
   filepath: string,
   graph: Sequence<T>,
   source: Source["source"] = () => "",
-  barrier = false
+  barrier = false,
+  validate?: string
 ): SubTask<Unordered> {
   return {
     key,
@@ -208,6 +202,7 @@ export function subtask<T extends Unordered | Ordered = Unordered>(
     graph,
     source,
     barrier,
+    validate,
   }
 }
 
@@ -387,4 +382,8 @@ export function extractDescription(graph: Graph) {
 
 export function isBarrier(graph: Graph): graph is Graph & Barrier & { barrier: true } {
   return isSubTask(graph) && graph.barrier
+}
+
+export function isValidatable(graph: Graph): graph is Graph & Validatable {
+  return typeof (graph as Validatable).validate === "string"
 }

--- a/src/parser/markdown/frontmatter/KuiFrontmatter.ts
+++ b/src/parser/markdown/frontmatter/KuiFrontmatter.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { Barrier, Validatable } from "../../../codeblock"
+
 export interface WizardSteps {
   /** An alternate way to define the steps of a wizard layout */
   wizard: {
@@ -37,35 +39,27 @@ interface Language {
   language?: string
 }
 
-export type CodeBlock = Partial<Language> & {
-  /**
-   * A string that will be interpreted as regular expression. Any
-   * markdown code blocks whose body matches this pattern will be seen
-   * as instances of the rules below (e.g. `language`, `validate`, etc.)
-   */
-  match: string
+export type CodeBlock = Partial<Language> &
+  Partial<Validatable> & {
+    /**
+     * A string that will be interpreted as regular expression. Any
+     * markdown code blocks whose body matches this pattern will be seen
+     * as instances of the rules below (e.g. `language`, `validate`, etc.)
+     */
+    match: string
 
-  /**
-   * If given, this command line will be executed. If it exits with
-   * exit code 0, then the code block will be seen as "already
-   * executed", and thus represent a valid state. Non-zero exit
-   * codes will not be seen as errors, but rather as representative
-   * of a default state.
-   */
-  validate?: string
+    /**
+     * If given, this command line will undo the effects of the code
+     * block body.
+     */
+    cleanup?: string
 
-  /**
-   * If given, this command line will undo the effects of the code
-   * block body.
-   */
-  cleanup?: string
-
-  /**
-   * Is successful execution of this code block seen as necessary
-   * for overall successful completion of the enclosing
-   * guidebook? */
-  optional?: boolean
-}
+    /**
+     * Is successful execution of this code block seen as necessary
+     * for overall successful completion of the enclosing
+     * guidebook? */
+    optional?: boolean
+  }
 
 interface CodeBlocks {
   codeblocks: CodeBlock[]
@@ -85,17 +79,14 @@ export function hasImports(attributes: any): attributes is Imports {
 }
 
 type KuiFrontmatter = Partial<WizardSteps> &
+  Partial<Barrier> &
   Partial<Imports> &
+  Partial<Validatable> &
   Partial<CodeBlocks> & {
     /** Title of the Notebook */
     title?: string
 
-    /**
-     * Does this guidebook need to be executed before subsequent
-     * choices even make sense? e.g. logging in to a cluster.
-     */
-    barrier?: boolean
-
+    /** Used internally */
     layoutCount?: Record<string, number>
 
     /**

--- a/src/parser/markdown/rehype-code-indexer/index.ts
+++ b/src/parser/markdown/rehype-code-indexer/index.ts
@@ -53,6 +53,7 @@ import {
   getImportKey,
   getImportFilepath,
   getImportTitle,
+  getValidate,
 } from "../remark-import"
 import { CodeBlockProps, addNesting as addCodeBlockNesting } from "../../../codeblock/CodeBlockProps"
 
@@ -249,6 +250,7 @@ export function rehypeCodeIndexer(uuid: string, codeblocks?: CodeBlockProps[]) {
                         key: getImportKey(_.properties),
                         title: getImportTitle(_.properties),
                         filepath: getImportFilepath(_.properties),
+                        validate: getValidate(_.properties),
                       })
                     } else if (isTipWithFullTitle(_)) {
                       const title = getTipTitle(_)

--- a/src/parser/markdown/remark-import.ts
+++ b/src/parser/markdown/remark-import.ts
@@ -27,6 +27,7 @@ import KuiFrontmatter from "./frontmatter/KuiFrontmatter"
 
 export interface ImportProps {
   "data-kui-import": "true"
+  "data-kui-validate": string
   "data-kui-is-barrier": boolean
   "data-kui-filepath": string
   "data-kui-import-title": string
@@ -65,6 +66,10 @@ function isHeading(node: Node): boolean {
   return node.type === "heading"
 }
 
+export function getValidate(props: ImportProps) {
+  return props["data-kui-validate"]
+}
+
 export function visitImportContainers(
   tree,
   visitor: (importProps: {
@@ -87,7 +92,7 @@ export function visitImportContainers(
         frontmatter:
           typeof node.attributes.attributes !== "string" || node.attributes.attributes.length === 0
             ? {}
-            : JSON.parse(decodeURIComponent(node.attributes.attributes)),
+            : JSON.parse(Buffer.from(node.attributes.attributes, "base64").toString()),
       })
     }
   })
@@ -124,6 +129,7 @@ export function remarkImports() {
           hProperties: {
             containedCodeBlocks: [],
             "data-kui-import": "true",
+            "data-kui-validate": frontmatter.validate,
             "data-kui-is-barrier": frontmatter.barrier,
             "data-kui-filepath": filepath,
             "data-kui-provenance": provenance,

--- a/src/parser/markdown/snippets/index.ts
+++ b/src/parser/markdown/snippets/index.ts
@@ -357,7 +357,7 @@ ${indent(errorMessage)}`
 
     const { attributes, body, bodyBegin } = tryFrontmatter(snippetData.trim())
 
-    const attributesEnc = bodyBegin === 0 ? "" : encodeURIComponent(JSON.stringify(attributes))
+    const attributesEnc = bodyBegin === 0 ? "" : Buffer.from(JSON.stringify(attributes)).toString("base64")
 
     // remark-directive uses ::: to indicate container directives,
     // i.e. directives that allow one to mark a block of text as
@@ -367,7 +367,7 @@ ${indent(errorMessage)}`
     // :::
     const colons = colonColonColon(nestingDepth)
     return `
-${colons}import{provenance=${provenance.concat([snippetFileName])} filepath=${filepath} attributes=${attributesEnc}${
+${colons}import{provenance=${provenance.concat([snippetFileName])} filepath=${filepath} attributes="${attributesEnc}"${
       attributes.title ? ` title="${attributes.title}"` : ""
     }}
 ${body}


### PR DESCRIPTION
if topmatter of an import has certain unsafe characters, remark-directive fails to process our container directive imports as such. switching from encodeURIComponent to "quoted base64" seems to fix that

this pr also adds initial support for placing import-wide validation in topmatter. not 100% functional yet.