### PR TITLE
fix: improve title discovery for imports

### DIFF
--- a/src/parser/markdown/remark-import.ts
+++ b/src/parser/markdown/remark-import.ts
@@ -98,6 +98,14 @@ export function visitImportContainers(
   })
 }
 
+function findFirstHeading(children: Node2[]) {
+  const headingIdx = children.findIndex(isHeading)
+  if (headingIdx >= 0) {
+    const heading = children[headingIdx]
+    return toString(heading).replace(/\s*\(\)\s*/g, "")
+  }
+}
+
 export function remarkImports() {
   return function transformer(tree /*: Root */) {
     const debug = Debug("madwizard/timing/parser:markdown/remark-import")
@@ -133,10 +141,7 @@ export function remarkImports() {
             "data-kui-is-barrier": frontmatter.barrier,
             "data-kui-filepath": filepath,
             "data-kui-provenance": provenance,
-            "data-kui-import-title":
-              title ||
-              (children[0] && isHeading(children[0]) ? toString(children[0]).replace(/\s*\(\)\s*/g, "") : "") ||
-              basename(filepath),
+            "data-kui-import-title": title || findFirstHeading(children) || basename(filepath),
           },
         }
       })

--- a/test/inputs/1/wizard.json
+++ b/test/inputs/1/wizard.json
@@ -7,12 +7,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "6864e759-3b93-4688-b41b-d601a1c88a9b",
+            "key": "1f044aaa-3673-4d5c-9a86-861e54f33ede",
             "sequence": [
               {
                 "body": "echo 111",
                 "language": "bash",
-                "id": "eb1bab5e-398f-4258-b0cb-ce38cf5ca146-0"
+                "id": "5559fcd8-f451-4bad-81fa-8069848d697d-0"
               }
             ]
           },
@@ -22,12 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "c9a9e723-4734-4ecc-96d5-5d0bca80bc40",
+            "key": "49df6650-afdd-40f6-8c5d-f0bb848b8b0a",
             "sequence": [
               {
                 "body": "echo 222",
                 "language": "bash",
-                "id": "eb1bab5e-398f-4258-b0cb-ce38cf5ca146-1"
+                "id": "5559fcd8-f451-4bad-81fa-8069848d697d-1"
               }
             ]
           },

--- a/test/inputs/3/tree-noopt.txt
+++ b/test/inputs/3/tree-noopt.txt
@@ -1,4 +1,4 @@
-snippets-in-tab3.md
+AAA
 ├── importa.md
 │   └── echo AAA †
 ├── EEE

--- a/test/inputs/3/tree.txt
+++ b/test/inputs/3/tree.txt
@@ -1,4 +1,4 @@
-snippets-in-tab3.md
+AAA
 ├── Prerequisites
 │   ├── importa.md
 │   │   └── echo AAA †

--- a/test/inputs/3/wizard.json
+++ b/test/inputs/3/wizard.json
@@ -1,17 +1,17 @@
 [
   {
     "graph": {
-      "key": "test/inputs/snippets/importa.md",
+      "key": "importa.md",
       "title": "importa.md",
-      "filepath": "test/inputs/snippets/importa.md",
+      "filepath": "",
       "graph": {
-        "key": "e0b05e94-dc68-455b-82a6-a40b71bc8b38",
+        "key": "df466159-9e08-4d4f-bc56-f936da6a625a",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-0"
+            "id": "7c660e75-11a4-47e3-8313-eb3516bb72e9-0"
           }
         ]
       },
@@ -31,12 +31,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "66114bf3-c46f-414e-b486-ee3412f557d0",
+            "key": "a569a845-f4e5-4f7a-b81f-6521b7de7651",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-1"
+                "id": "7c660e75-11a4-47e3-8313-eb3516bb72e9-1"
               }
             ]
           },
@@ -68,25 +68,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "e0e67ddb-5add-475e-b506-10b1504b8722",
+            "key": "e9e34dda-1b85-4973-9a64-c577a7ef54bb",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-2"
+                "id": "7c660e75-11a4-47e3-8313-eb3516bb72e9-2"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-3"
+                "id": "7c660e75-11a4-47e3-8313-eb3516bb72e9-3"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-4"
+                "id": "7c660e75-11a4-47e3-8313-eb3516bb72e9-4"
               }
             ]
           },
@@ -95,13 +95,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "01bc66f4-4f81-4d5a-a6bd-8e0c545b2061",
+            "key": "5dfe148c-b5d3-4af6-9666-7680c7246bbf",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-5"
+                "id": "7c660e75-11a4-47e3-8313-eb3516bb72e9-5"
               }
             ]
           },
@@ -137,20 +137,20 @@
         {
           "member": 1,
           "graph": {
-            "key": "8337e722-f32e-4577-895e-932700d58275",
+            "key": "e6b2eed1-4f7e-43c6-a764-38dcbbf57de7",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importc.md",
                 "title": "importc.md",
                 "filepath": "test/inputs/snippets/importc.md",
                 "graph": {
-                  "key": "65349943-aa99-4fbe-8a1e-988527930c1d",
+                  "key": "2bc446f5-8e94-461f-ad9a-81eb9f3bcb4c",
                   "sequence": [
                     {
                       "body": "echo CCC",
                       "language": "bash",
                       "validate": true,
-                      "id": "9eeeb71e-2b4e-4305-a829-4b33a6d2d529-10"
+                      "id": "7c660e75-11a4-47e3-8313-eb3516bb72e9-10"
                     }
                   ]
                 },

--- a/test/inputs/4/tree-noopt.txt
+++ b/test/inputs/4/tree-noopt.txt
@@ -1,4 +1,4 @@
-snippets-in-tab4.md
+AAA
 ├── importa.md
 │   └── echo AAA †
 ├── EEE

--- a/test/inputs/4/tree.txt
+++ b/test/inputs/4/tree.txt
@@ -1,4 +1,4 @@
-snippets-in-tab4.md
+AAA
 ├── Prerequisites
 │   ├── importa.md
 │   │   └── echo AAA †

--- a/test/inputs/4/wizard.json
+++ b/test/inputs/4/wizard.json
@@ -1,17 +1,17 @@
 [
   {
     "graph": {
-      "key": "test/inputs/snippets/importa.md",
+      "key": "importa.md",
       "title": "importa.md",
-      "filepath": "test/inputs/snippets/importa.md",
+      "filepath": "",
       "graph": {
-        "key": "79a76ea5-0038-4acf-991d-4a98d8db884d",
+        "key": "b3a98376-d8b2-49e6-8e73-bdad906360c5",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "8ec10849-7856-4375-a108-edf9645940e6-0"
+            "id": "4d4f25dc-1746-4455-a7c0-c4c0d1e9e73b-0"
           }
         ]
       },
@@ -31,12 +31,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "3d89ed6c-86b9-4b71-bf62-bd4e12780296",
+            "key": "e1bd3f29-1fcb-41e3-b819-43e329758b2d",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "8ec10849-7856-4375-a108-edf9645940e6-1"
+                "id": "4d4f25dc-1746-4455-a7c0-c4c0d1e9e73b-1"
               }
             ]
           },
@@ -68,14 +68,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "c6d758bc-b5db-4a90-a936-3c17b8c9e447",
+            "key": "3f5a1837-fbed-4c11-b24e-73bac594d337",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "7a1bde8b-ca56-4e12-97c9-5ee786fb36c2",
+                  "key": "e8956b0c-cbee-4b8d-b171-fcdeb8acce72",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -85,25 +85,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "54f81dbc-e37a-4491-b040-80bee0cf5123",
+                            "key": "18f23633-574e-4069-9d88-2a442e30eda3",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "8ec10849-7856-4375-a108-edf9645940e6-2"
+                                "id": "4d4f25dc-1746-4455-a7c0-c4c0d1e9e73b-2"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "8ec10849-7856-4375-a108-edf9645940e6-3"
+                                "id": "4d4f25dc-1746-4455-a7c0-c4c0d1e9e73b-3"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "8ec10849-7856-4375-a108-edf9645940e6-4"
+                                "id": "4d4f25dc-1746-4455-a7c0-c4c0d1e9e73b-4"
                               }
                             ]
                           },
@@ -112,13 +112,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "b7398028-f5b6-4f0d-8eab-b05f09061c1c",
+                            "key": "9f161342-abff-4706-a06c-b8996ac86561",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "8ec10849-7856-4375-a108-edf9645940e6-5"
+                                "id": "4d4f25dc-1746-4455-a7c0-c4c0d1e9e73b-5"
                               }
                             ]
                           },
@@ -138,12 +138,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "3ece0c99-90dd-4b72-b9d0-c5e219e75ce7",
+            "key": "3c60a90a-653a-41ad-9504-9afa29a4053e",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "8ec10849-7856-4375-a108-edf9645940e6-6"
+                "id": "4d4f25dc-1746-4455-a7c0-c4c0d1e9e73b-6"
               }
             ]
           },

--- a/test/inputs/5/tree-noopt.txt
+++ b/test/inputs/5/tree-noopt.txt
@@ -1,4 +1,4 @@
-snippets-in-tab5.md
+AAA
 ├── importa.md
 │   └── echo AAA †
 ├── EEE

--- a/test/inputs/5/tree.txt
+++ b/test/inputs/5/tree.txt
@@ -1,4 +1,4 @@
-snippets-in-tab5.md
+AAA
 ├── Prerequisites
 │   ├── importa.md
 │   │   └── echo AAA †

--- a/test/inputs/5/wizard.json
+++ b/test/inputs/5/wizard.json
@@ -1,17 +1,17 @@
 [
   {
     "graph": {
-      "key": "test/inputs/snippets/importa.md",
+      "key": "importa.md",
       "title": "importa.md",
-      "filepath": "test/inputs/snippets/importa.md",
+      "filepath": "",
       "graph": {
-        "key": "deb1ee4b-aff7-483e-b9cf-05113d83979d",
+        "key": "7942eb2d-fe79-4ace-b800-9171ec3f1d79",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "21579da7-7d61-438f-a31a-3d21cd10400f-0"
+            "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-0"
           }
         ]
       },
@@ -31,12 +31,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "48bb0f83-69ff-45bf-858f-3c1d44b7821c",
+            "key": "4af9f0c0-e72c-47a1-98cc-72aff609fe0f",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-1"
+                "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-1"
               }
             ]
           },
@@ -68,14 +68,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "fb6f7b4a-791d-4a5f-b020-9df462bf4c6a",
+            "key": "2d2bb695-dbdf-44d2-adee-233ba6ea40af",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "fa17eb3f-1704-4d3b-863f-d9088e974a40",
+                  "key": "bf1dcd12-2945-46e8-ac0f-90121f7246e8",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -85,25 +85,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "1e39486d-473e-44c2-adc6-bd61c149fe54",
+                            "key": "679aa78a-64b6-4289-9fc9-3c0bb9185130",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-2"
+                                "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-2"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-3"
+                                "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-3"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-4"
+                                "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-4"
                               }
                             ]
                           },
@@ -112,13 +112,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "def6ed0c-3ffe-4219-99ba-ed76bee6035a",
+                            "key": "067e886b-720b-47a8-a81b-41037c8439e0",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-5"
+                                "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-5"
                               }
                             ]
                           },
@@ -138,12 +138,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "051e889d-b78b-4295-b5a7-595fd93043e0",
+            "key": "9dd2bca4-5103-433e-86fb-075bce0d3fe6",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-6"
+                "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-6"
               }
             ]
           },
@@ -153,14 +153,14 @@
         {
           "member": 2,
           "graph": {
-            "key": "e5a68197-78dc-45e4-87c9-15fdcba5e62d",
+            "key": "bba99c58-455e-48d0-808f-9a8d93494692",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "ad1a0919-eaab-4412-ad9b-b5f69bba7483",
+                  "key": "dfdb4d66-c4f8-40f0-8ee7-d9726e3ba907",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -170,25 +170,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "88eed42f-2074-4a19-a607-765d0b6f7d99",
+                            "key": "8ed86565-6444-4b29-bdc7-fb22535cf62e",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-7"
+                                "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-7"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-8"
+                                "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-8"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-9"
+                                "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-9"
                               }
                             ]
                           },
@@ -197,13 +197,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "84a2da65-32dd-438c-b8eb-b462e351789d",
+                            "key": "4129d9cc-8ab0-4dc3-bd98-98c3e93aea57",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "21579da7-7d61-438f-a31a-3d21cd10400f-10"
+                                "id": "8316e3a4-6c82-45d1-8a1a-e4f9a9aaab94-10"
                               }
                             ]
                           },

--- a/test/inputs/6/tree-noopt.txt
+++ b/test/inputs/6/tree-noopt.txt
@@ -6,7 +6,7 @@ Sequence
 │   │   └── echo AAA †
 │   └── Option 2: SubTab2
 │       └── echo BBB
-└── snippets-in-tab5.md
+└── AAA
     ├── importa.md
     │   └── echo AAA †
     ├── EEE

--- a/test/inputs/6/tree.txt
+++ b/test/inputs/6/tree.txt
@@ -11,6 +11,6 @@ Sequence
 ├── EEE
 │   └── Option 1: TabE1
 │       └── echo EEE
-└── snippets-in-tab5.md
+└── AAA
     └── Option 2: Tab2
         └── echo XXX

--- a/test/inputs/6/wizard.json
+++ b/test/inputs/6/wizard.json
@@ -8,25 +8,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "b4fc2edf-bbd4-4e36-a28a-50dc51eed123",
+            "key": "625691ca-f2b3-470e-899d-d6f62f091599",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-0"
+                "id": "cf133032-d9c6-4260-825e-5124229a640a-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-1"
+                "id": "cf133032-d9c6-4260-825e-5124229a640a-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-2"
+                "id": "cf133032-d9c6-4260-825e-5124229a640a-2"
               }
             ]
           },
@@ -35,13 +35,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "c786a8bd-267d-46cb-b2c1-5d13b308656f",
+            "key": "9aa4a475-2fd7-49db-b302-6d8035cbff1c",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-3"
+                "id": "cf133032-d9c6-4260-825e-5124229a640a-3"
               }
             ]
           },
@@ -70,17 +70,17 @@
   },
   {
     "graph": {
-      "key": "test/inputs/snippets/importa.md",
+      "key": "importa.md",
       "title": "importa.md",
-      "filepath": "test/inputs/snippets/importa.md",
+      "filepath": "",
       "graph": {
-        "key": "bf99c98c-f86c-4a9e-8e34-879f9d71ae40",
+        "key": "39534efe-581f-403c-8031-835a9a0f40b9",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-4"
+            "id": "cf133032-d9c6-4260-825e-5124229a640a-4"
           }
         ]
       },
@@ -100,12 +100,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "0ae5023d-95c1-490b-a2e6-75eb03ed9e31",
+            "key": "d0d64264-0c9f-426b-b385-c047f931ef03",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-5"
+                "id": "cf133032-d9c6-4260-825e-5124229a640a-5"
               }
             ]
           },
@@ -131,18 +131,18 @@
   {
     "graph": {
       "group": "Tab1####Tab2####Tab3",
-      "title": "snippets-in-tab5.md",
+      "title": "AAA",
       "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "48352c02-a635-4bba-9505-3fe1b01ac7d4",
+            "key": "7e91b71d-58e4-4425-b88b-f20c639bf423",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "16d6e9e8-ff40-4031-8a13-48c52a00d61c-10"
+                "id": "cf133032-d9c6-4260-825e-5124229a640a-10"
               }
             ]
           },
@@ -152,7 +152,7 @@
       ]
     },
     "step": {
-      "name": "snippets-in-tab5.md",
+      "name": "AAA",
       "description": "This step requires you to choose how to proceed",
       "content": [
         {

--- a/test/inputs/7/tree-noopt.txt
+++ b/test/inputs/7/tree-noopt.txt
@@ -6,7 +6,7 @@ Sequence
 │   │   └── echo AAA †
 │   └── Option 2: SubTab2
 │       └── echo BBB
-└── snippets-in-tab5.md
+└── AAA
     ├── importa.md
     │   └── echo AAA †
     ├── EEE

--- a/test/inputs/7/tree.txt
+++ b/test/inputs/7/tree.txt
@@ -11,6 +11,6 @@ Sequence
 ├── EEE
 │   └── Option 1: TabE1
 │       └── echo EEE
-└── snippets-in-tab5.md
+└── AAA
     └── Option 2: Tab2
         └── echo XXX

--- a/test/inputs/7/wizard.json
+++ b/test/inputs/7/wizard.json
@@ -8,25 +8,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "4f74783c-e28a-48ab-9f54-6c3b47b85e31",
+            "key": "1c48b98f-30bd-42b5-aae8-6ffeb2adccc6",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-0"
+                "id": "4691d4d8-eeaf-42e4-9a69-0a8cdde33186-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-1"
+                "id": "4691d4d8-eeaf-42e4-9a69-0a8cdde33186-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-2"
+                "id": "4691d4d8-eeaf-42e4-9a69-0a8cdde33186-2"
               }
             ]
           },
@@ -35,13 +35,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "42231e9f-e832-49d2-9bb8-2be1345d12a7",
+            "key": "4ccfa41d-7f0a-4117-b6bf-751c357ba2d0",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-3"
+                "id": "4691d4d8-eeaf-42e4-9a69-0a8cdde33186-3"
               }
             ]
           },
@@ -70,17 +70,17 @@
   },
   {
     "graph": {
-      "key": "test/inputs/snippets/importa.md",
+      "key": "importa.md",
       "title": "importa.md",
-      "filepath": "test/inputs/snippets/importa.md",
+      "filepath": "",
       "graph": {
-        "key": "28812321-3356-4d98-a719-f5e944271729",
+        "key": "ad8890cb-03ba-4b35-816d-08cd1474f030",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-4"
+            "id": "4691d4d8-eeaf-42e4-9a69-0a8cdde33186-4"
           }
         ]
       },
@@ -100,12 +100,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "ec64035c-6867-4030-abfb-6497772ccb91",
+            "key": "ebcdf44d-0ead-4d79-9609-8a98811ebfe9",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-5"
+                "id": "4691d4d8-eeaf-42e4-9a69-0a8cdde33186-5"
               }
             ]
           },
@@ -131,18 +131,18 @@
   {
     "graph": {
       "group": "Tab1####Tab2####Tab3",
-      "title": "snippets-in-tab5.md",
+      "title": "AAA",
       "source": "placeholder",
       "choices": [
         {
           "member": 1,
           "graph": {
-            "key": "65dcab00-cb3d-45e6-853f-38437d498137",
+            "key": "dfafd5e7-53ee-4d1b-8467-acf442ed111d",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "171d8174-276e-4bcf-a4a5-863f23c2c91a-10"
+                "id": "4691d4d8-eeaf-42e4-9a69-0a8cdde33186-10"
               }
             ]
           },
@@ -152,7 +152,7 @@
       ]
     },
     "step": {
-      "name": "snippets-in-tab5.md",
+      "name": "AAA",
       "description": "This step requires you to choose how to proceed",
       "content": [
         {

--- a/test/inputs/8/wizard.json
+++ b/test/inputs/8/wizard.json
@@ -8,25 +8,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "c2558692-4059-43af-9420-a584dd5e895a",
+            "key": "1987024f-e66e-4150-acf2-579179a61d63",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "fc6dc138-100e-4664-8544-5de529da6bd2-0"
+                "id": "85be3b89-3b2d-48cc-b5d9-5f0d928cb36e-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "fc6dc138-100e-4664-8544-5de529da6bd2-1"
+                "id": "85be3b89-3b2d-48cc-b5d9-5f0d928cb36e-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "fc6dc138-100e-4664-8544-5de529da6bd2-2"
+                "id": "85be3b89-3b2d-48cc-b5d9-5f0d928cb36e-2"
               }
             ]
           },
@@ -35,13 +35,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "5857e1e2-4c5a-401f-afe4-ff281c5e6600",
+            "key": "2e01f47a-a69c-4400-b3e2-ddd9eca3d941",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "fc6dc138-100e-4664-8544-5de529da6bd2-3"
+                "id": "85be3b89-3b2d-48cc-b5d9-5f0d928cb36e-3"
               }
             ]
           },


### PR DESCRIPTION
we were only looking at the first child of imports, which, due to us! in snippets/, is bound to be a comment