### PR TITLE
fix: tree view needlessly trims each line of code blocks

### DIFF
--- a/src/fe/tree/index.ts
+++ b/src/fe/tree/index.ts
@@ -258,7 +258,7 @@ export class Treeifier<Content> {
           name: this.ui.code(
             graph.body
               .split(/\n/)
-              .map((_) => _.replace(/#.*/, "").trim()) // remove comments
+              .map((_) => _.replace(/#.*/, "")) // remove comments
               .filter(Boolean)
               .join(EOL),
             graph.optional,


### PR DESCRIPTION
This won't work, at least, for python blocks.