### PR TITLE
fix: guide memoizes too aggressively

### DIFF
--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -161,7 +161,7 @@ export class Guide {
                     await this.waitTillDone(taskIdx - 1)
 
                     status =
-                      (this.memos.statusMemo && this.memos.statusMemo[block.body]) ||
+                      (this.memos.statusMemo && this.memos.statusMemo[block.body] === "success" && "success") ||
                       (await shellExec(block.body, this.memos, block.language))
 
                     if (status == "success" && this.memos.statusMemo) {


### PR DESCRIPTION
we are memoizing "blank" as the status of code blocks, and treating that as a sign that we've already executed