### PR TITLE
fix: when expansion fails, uncaught exceptions ensue

### DIFF
--- a/bin/madwizard.js
+++ b/bin/madwizard.js
@@ -12,6 +12,10 @@ const isNpx = process.env.npm_command === "exec"
 import(isNpx ? "madwizard" : "..")
   .then((_) => _.cli(process.argv.slice(1)))
   .catch((err) => {
-    console.log(err.message)
+    if (process.env.DEBUG) {
+      console.log(err)
+    } else {
+      console.log(err.message)
+    }
     process.exit(1)
   })

--- a/src/graph/collapseMadeChoices.ts
+++ b/src/graph/collapseMadeChoices.ts
@@ -62,6 +62,7 @@ function collapse(graph: Graph, choices: ChoiceState): Graph {
 
     // otherwise, scan the subgraphs across the choices
     const subchoices = graph.choices
+      .filter(Boolean)
       .map((_) => {
         const subgraph = collapse(_.graph, choices)
         if (subgraph) {

--- a/src/util/ora-delayed-promise.ts
+++ b/src/util/ora-delayed-promise.ts
@@ -17,17 +17,19 @@
 import { oraPromise as theRealOraPromise, PromiseOptions } from "ora"
 
 /** Fire of an `oraPromise` with a delay */
-export function oraPromise<T>(action: PromiseLike<T>, options?: string | PromiseOptions<T>, delayMs = 500): Promise<T> {
+export function oraPromise<T>(action: Promise<T>, options?: string | PromiseOptions<T>, delayMs = 500): Promise<T> {
   let isResolved = false
-  action.then(() => (isResolved = true))
+  action.then(() => (isResolved = true)).catch(() => (isResolved = true))
 
   if (!isResolved) {
     setTimeout(() => {
       if (!isResolved) {
-        theRealOraPromise(action, options)
+        theRealOraPromise(action, options).catch(() => {
+          /* the caller will be alerted by our `return action` */
+        })
       }
     }, delayMs)
   }
 
-  return Promise.resolve(action)
+  return action
 }


### PR DESCRIPTION
our ora-promise-with-delay wrapper isn't properly handling underlying exceptions

this can be caused by group expansion failures. there is also a chained issue, when expansion fails, that collapseMadeChoices may have a null pointer exception