### PR TITLE
fix: self-veto of a top-level guidebook is not possible

### DIFF
--- a/src/codeblock/CodeBlockProps.ts
+++ b/src/codeblock/CodeBlockProps.ts
@@ -84,6 +84,7 @@ export type Import = Source &
   Kind<"Import"> & {
     key: string
     filepath: string
+    provenance?: string
   }
 
 type Kind<T extends string> = {

--- a/src/graph/compile.ts
+++ b/src/graph/compile.ts
@@ -112,7 +112,9 @@ export async function compile(
 
     /** Find the nearest enclosing Import */
     const currentProvenance = () => {
-      const provs = currentNesting.map((_) => (isImportNesting(_) ? provenanceOf(_.graph) : undefined)).filter(Boolean)
+      const provs = currentNesting
+        .map((_) => (isImportNesting(_) ? _.parent.provenance || provenanceOf(_.graph) : undefined))
+        .filter(Boolean)
       if (provs.length === 0) {
         return undefined
       } else {

--- a/src/graph/provenance.ts
+++ b/src/graph/provenance.ts
@@ -32,16 +32,18 @@ export function hasProvenance(graph: Graph): graph is Graph & Provenance {
   return Array.isArray(provenance) && provenance.length > 0 && provenance.every((_) => typeof _ === "string")
 }
 
+export function provenanceOfFilepath(filepath: string) {
+  const match = filepath.match(/^https:\/\/raw.githubusercontent.com\/guidebooks\/store\/main\/guidebooks\/(.+)\..+$/)
+  if (match) {
+    return match[1].replace(/\/index$/, "")
+  } else {
+    return relative(process.cwd(), filepath)
+  }
+}
+
 /** Determine the `Provenance` of the given `SubTask` */
 export default function provenanceOf(task: SubTask) {
   if (task.filepath) {
-    const match = task.filepath.match(
-      /^https:\/\/raw.githubusercontent.com\/guidebooks\/store\/main\/guidebooks\/(.+)\..+$/
-    )
-    if (match) {
-      return match[1]
-    } else {
-      return relative(process.cwd(), task.filepath)
-    }
+    return provenanceOfFilepath(task.filepath)
   }
 }

--- a/src/parser/markdown/index.ts
+++ b/src/parser/markdown/index.ts
@@ -72,16 +72,14 @@ const rehypePlugins = (
   uuid: string,
   choices: ChoiceState,
   codeblocks: CodeBlockProps[],
-  madwizardOptions: MadWizardOptions
+  madwizardOptions: MadWizardOptions,
+  filepath: string
 ): PluggableList => [
   wizard,
   [rehypeTabbed, uuid, choices, madwizardOptions],
   rehypeTip,
-  [rehypeCodeIndexer, uuid, codeblocks],
+  [rehypeCodeIndexer, uuid, filepath, codeblocks],
   rehypeImports,
-  // icons,
-  // rehypeRaw,
-  // rehypeSlug,
 ]
 
 /** Parse the given `input` into a `Graph` syntax tree. */
@@ -102,7 +100,7 @@ async function parse(
       .use(remarkParse)
       .use(remarkPlugins())
       .use(remarkRehype, { allowDangerousHtml: true })
-      .use(rehypePlugins(uuid, choices, blocks, madwizardOptions))
+      .use(rehypePlugins(uuid, choices, blocks, madwizardOptions, input.path))
 
     const fetcher = (filepath: string) => reader(new VFile({ path: filepath })).then((_) => _.value.toString())
 

--- a/src/parser/markdown/rehype-code-indexer/index.ts
+++ b/src/parser/markdown/rehype-code-indexer/index.ts
@@ -21,6 +21,8 @@ import { Transformer } from "unified"
 import { toString } from "hast-util-to-string"
 import { visitParents } from "unist-util-visit-parents"
 
+import { provenanceOfFilepath } from "../../../graph/provenance"
+
 import dump from "./dump"
 import { isTab } from "../rehype-tabbed"
 import { isExecutable } from "../../../codeblock/isCodeBlock"
@@ -124,8 +126,12 @@ function findNearestEnclosingTitle(grandparent: Parent, parent: Node, node: Node
 /**
  * This rehype plugin adds a unique codeIdx ordinal property to each
  * executable code block.
+ *
+ * @param uuid an identifier for this document
+ * @param filepath the origin filepath of this document
+ * @param codeblocks in case the caller wants us to smash in the codeblocks we find
  */
-export function rehypeCodeIndexer(uuid: string, codeblocks?: CodeBlockProps[]) {
+export function rehypeCodeIndexer(uuid: string, filepath: string, codeblocks?: CodeBlockProps[]) {
   const transformer: Transformer<Element> = (ast /*: Root */) => {
     const timing = Debug("madwizard/timing/parser:markdown/rehype-code-indexer")
     const debug = Debug("madwizard/graph/parser:markdown/rehype-code-indexer")
@@ -304,8 +310,9 @@ export function rehypeCodeIndexer(uuid: string, codeblocks?: CodeBlockProps[]) {
                               source,
                               key: title,
                               title,
-                              description: extractFirstParagraph(grandparent, child),
                               filepath: "",
+                              provenance: provenanceOfFilepath(filepath),
+                              description: extractFirstParagraph(grandparent, child),
                             },
                             0
                           )

--- a/test/inputs/1/wizard-noaprioris.json
+++ b/test/inputs/1/wizard-noaprioris.json
@@ -7,12 +7,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "621531e3-979a-46dd-9cce-875fd46ed21d",
+            "key": "8bfaed90-4dc7-4588-b0ca-5eede54344ee",
             "sequence": [
               {
                 "body": "echo 111",
                 "language": "bash",
-                "id": "32fd39ad-fe1f-4e57-af53-e720eb048804-0"
+                "id": "4ad120e4-61f3-4f5a-8dba-49ccf0fedaa3-0"
               }
             ]
           },
@@ -22,12 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "684e658d-6011-4852-b7ce-8bfbff4e06da",
+            "key": "d7fa4239-57ea-483e-bf58-37c23cb66098",
             "sequence": [
               {
                 "body": "echo 222",
                 "language": "bash",
-                "id": "32fd39ad-fe1f-4e57-af53-e720eb048804-1"
+                "id": "4ad120e4-61f3-4f5a-8dba-49ccf0fedaa3-1"
               }
             ]
           },

--- a/test/inputs/1/wizard-noopt.json
+++ b/test/inputs/1/wizard-noopt.json
@@ -7,12 +7,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "cc545c9f-b8d7-4b33-882a-a79b2fc114d2",
+            "key": "2ad9173f-0f22-444c-8229-54fad37a6230",
             "sequence": [
               {
                 "body": "echo 111",
                 "language": "bash",
-                "id": "ceacfb8e-5ae0-411f-a1cc-faadbb932f50-0"
+                "id": "0e097d79-35e7-43ed-94d3-bc9c0ff9873c-0"
               }
             ]
           },
@@ -22,12 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "fbc76882-97ba-4c9f-a375-1e04b0724870",
+            "key": "c4f3d556-d355-403e-b6e1-d8a153cd9321",
             "sequence": [
               {
                 "body": "echo 222",
                 "language": "bash",
-                "id": "ceacfb8e-5ae0-411f-a1cc-faadbb932f50-1"
+                "id": "0e097d79-35e7-43ed-94d3-bc9c0ff9873c-1"
               }
             ]
           },

--- a/test/inputs/1/wizard.json
+++ b/test/inputs/1/wizard.json
@@ -7,12 +7,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "ea90d4a0-de44-4528-8cc6-f074d90a030e",
+            "key": "df177505-b7df-4687-b99d-c0ce1910bcc2",
             "sequence": [
               {
                 "body": "echo 111",
                 "language": "bash",
-                "id": "baed18c9-3ccf-4ed4-8cfc-f55ce61d9702-0"
+                "id": "5a20c324-b1b3-4be7-b211-d9e0d6a8a2cb-0"
               }
             ]
           },
@@ -22,12 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "20cf948b-68d4-48e1-9c39-459528ca33f1",
+            "key": "5999e3be-007e-4a38-aa3a-b434a59947f7",
             "sequence": [
               {
                 "body": "echo 222",
                 "language": "bash",
-                "id": "baed18c9-3ccf-4ed4-8cfc-f55ce61d9702-1"
+                "id": "5a20c324-b1b3-4be7-b211-d9e0d6a8a2cb-1"
               }
             ]
           },

--- a/test/inputs/10/wizard-darwin.json
+++ b/test/inputs/10/wizard-darwin.json
@@ -5,12 +5,12 @@
       "title": "importgg.md",
       "filepath": "",
       "graph": {
-        "key": "ff1c6a57-b1e3-467a-81cb-953563cd17bf",
+        "key": "f409cf1f-9eb8-41cb-9b28-fb1c6efc194f",
         "sequence": [
           {
             "body": "echo MMM",
             "language": "bash",
-            "id": "4a02dc59-1e52-4f7c-9f62-eae0e21ab8f0-0"
+            "id": "e15d7f93-8a7e-4ca9-9de6-8934720684c3-0"
           }
         ]
       },
@@ -31,25 +31,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "179e6e8d-7c7e-44e9-b973-c33385024a4b",
+            "key": "7e378cff-8d3c-432b-adcc-0169ee7058f5",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "4a02dc59-1e52-4f7c-9f62-eae0e21ab8f0-4"
+                "id": "e15d7f93-8a7e-4ca9-9de6-8934720684c3-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "4a02dc59-1e52-4f7c-9f62-eae0e21ab8f0-5"
+                "id": "e15d7f93-8a7e-4ca9-9de6-8934720684c3-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "4a02dc59-1e52-4f7c-9f62-eae0e21ab8f0-6"
+                "id": "e15d7f93-8a7e-4ca9-9de6-8934720684c3-6"
               }
             ]
           },
@@ -58,13 +58,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "4fef3e9e-d457-44d7-a29b-9f905139b064",
+            "key": "6e6de1eb-f06f-4fad-867e-f2e886f4445e",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "4a02dc59-1e52-4f7c-9f62-eae0e21ab8f0-7"
+                "id": "e15d7f93-8a7e-4ca9-9de6-8934720684c3-7"
               }
             ]
           },

--- a/test/inputs/10/wizard-linux.json
+++ b/test/inputs/10/wizard-linux.json
@@ -5,12 +5,12 @@
       "title": "importgg.md",
       "filepath": "",
       "graph": {
-        "key": "cf435c81-2f45-4ef3-976c-01ed797ee952",
+        "key": "e4da7a08-6bf8-4058-a582-b4e47023a954",
         "sequence": [
           {
             "body": "echo LLL",
             "language": "bash",
-            "id": "7ca67849-6dbf-44eb-9401-a705a046028e-1"
+            "id": "fd0a81b6-e07f-49a9-9757-588f4f98e696-1"
           }
         ]
       },
@@ -31,25 +31,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "66a233c3-6313-4a39-8067-b6e48c0e6e55",
+            "key": "657ce616-0008-45ff-bf59-23a3383d05f3",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "7ca67849-6dbf-44eb-9401-a705a046028e-4"
+                "id": "fd0a81b6-e07f-49a9-9757-588f4f98e696-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "7ca67849-6dbf-44eb-9401-a705a046028e-5"
+                "id": "fd0a81b6-e07f-49a9-9757-588f4f98e696-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "7ca67849-6dbf-44eb-9401-a705a046028e-6"
+                "id": "fd0a81b6-e07f-49a9-9757-588f4f98e696-6"
               }
             ]
           },
@@ -58,13 +58,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "493ee3a7-dd0b-4750-b3cf-7212775fdb06",
+            "key": "db8b04d3-07f6-435f-8aeb-9209e1b16f35",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "7ca67849-6dbf-44eb-9401-a705a046028e-7"
+                "id": "fd0a81b6-e07f-49a9-9757-588f4f98e696-7"
               }
             ]
           },

--- a/test/inputs/10/wizard-noaprioris.json
+++ b/test/inputs/10/wizard-noaprioris.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "27c15905-e292-4999-9045-cef0da7a8078",
+            "key": "683625fd-0f96-4c0d-ad36-584402395392",
             "sequence": [
               {
                 "body": "echo MMM",
                 "language": "bash",
-                "id": "b2bd5318-e28e-456a-a029-dbcc92861227-0"
+                "id": "fad1e836-11da-4021-901d-4d2b569da631-0"
               }
             ]
           },
@@ -23,12 +23,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "565edb73-0039-4507-bb47-81314d032536",
+            "key": "30195dfc-2ec7-45c0-9b34-4584ef1df863",
             "sequence": [
               {
                 "body": "echo LLL",
                 "language": "bash",
-                "id": "b2bd5318-e28e-456a-a029-dbcc92861227-1"
+                "id": "fad1e836-11da-4021-901d-4d2b569da631-1"
               }
             ]
           },
@@ -37,12 +37,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "c1f795cb-f640-4456-8b7d-d66ade708754",
+            "key": "00bef8a7-6b75-4cb3-98de-600c53489cd5",
             "sequence": [
               {
                 "body": "echo WWW",
                 "language": "bash",
-                "id": "b2bd5318-e28e-456a-a029-dbcc92861227-2"
+                "id": "fad1e836-11da-4021-901d-4d2b569da631-2"
               }
             ]
           },
@@ -85,25 +85,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "d183680b-6cc9-4e45-8932-28a290228e1f",
+            "key": "03f2a443-8c77-418c-83d4-80402890c127",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "b2bd5318-e28e-456a-a029-dbcc92861227-4"
+                "id": "fad1e836-11da-4021-901d-4d2b569da631-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "b2bd5318-e28e-456a-a029-dbcc92861227-5"
+                "id": "fad1e836-11da-4021-901d-4d2b569da631-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "b2bd5318-e28e-456a-a029-dbcc92861227-6"
+                "id": "fad1e836-11da-4021-901d-4d2b569da631-6"
               }
             ]
           },
@@ -112,13 +112,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "8cbf9164-aafa-4bd5-8144-805eefdaee9f",
+            "key": "aae3c227-3ba0-4448-8eaf-f2df92db2145",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "b2bd5318-e28e-456a-a029-dbcc92861227-7"
+                "id": "fad1e836-11da-4021-901d-4d2b569da631-7"
               }
             ]
           },

--- a/test/inputs/10/wizard-noopt.json
+++ b/test/inputs/10/wizard-noopt.json
@@ -8,12 +8,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "54d1ec82-f0ab-4fe4-9d7a-75eaaee2b1e2",
+            "key": "92da5611-dd7c-436f-989e-6a856b6f23bf",
             "sequence": [
               {
                 "body": "echo MMM",
                 "language": "bash",
-                "id": "217a40d7-828d-4cc8-a977-dcca737cb9de-0"
+                "id": "aa57e43e-d2b1-41c1-bf21-cb7c700bb87e-0"
               }
             ]
           },
@@ -22,12 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "23989beb-fde4-4554-b84a-699862aacbea",
+            "key": "c536d7f8-84a9-4cf4-9c07-2cebec8167bf",
             "sequence": [
               {
                 "body": "echo LLL",
                 "language": "bash",
-                "id": "217a40d7-828d-4cc8-a977-dcca737cb9de-1"
+                "id": "aa57e43e-d2b1-41c1-bf21-cb7c700bb87e-1"
               }
             ]
           },
@@ -36,12 +36,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "d6871890-49ca-4147-b8e4-0f7e2c1679a4",
+            "key": "624035e1-ec5b-4f3f-873f-eec5f216979b",
             "sequence": [
               {
                 "body": "echo WWW",
                 "language": "bash",
-                "id": "217a40d7-828d-4cc8-a977-dcca737cb9de-2"
+                "id": "aa57e43e-d2b1-41c1-bf21-cb7c700bb87e-2"
               }
             ]
           },
@@ -79,13 +79,13 @@
       "title": "importaa.md",
       "filepath": "",
       "graph": {
-        "key": "fe77f728-f3a2-4c63-b6e2-d6b8357b7e01",
+        "key": "2fb5e3b8-7367-4a35-95d1-71361768d32b",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "217a40d7-828d-4cc8-a977-dcca737cb9de-3"
+            "id": "aa57e43e-d2b1-41c1-bf21-cb7c700bb87e-3"
           }
         ]
       },
@@ -106,25 +106,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "5f74a6ea-4ed0-4a3a-b2d4-6daca2f522a4",
+            "key": "8ad2d360-a94f-461c-b05e-30d059b01609",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "217a40d7-828d-4cc8-a977-dcca737cb9de-4"
+                "id": "aa57e43e-d2b1-41c1-bf21-cb7c700bb87e-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "217a40d7-828d-4cc8-a977-dcca737cb9de-5"
+                "id": "aa57e43e-d2b1-41c1-bf21-cb7c700bb87e-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "217a40d7-828d-4cc8-a977-dcca737cb9de-6"
+                "id": "aa57e43e-d2b1-41c1-bf21-cb7c700bb87e-6"
               }
             ]
           },
@@ -133,13 +133,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "a85eef53-925d-4770-ae93-c7842d03933a",
+            "key": "e70e32bf-caa9-4e6c-b8b7-9e5444c9e268",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "217a40d7-828d-4cc8-a977-dcca737cb9de-7"
+                "id": "aa57e43e-d2b1-41c1-bf21-cb7c700bb87e-7"
               }
             ]
           },

--- a/test/inputs/10/wizard-win32.json
+++ b/test/inputs/10/wizard-win32.json
@@ -5,12 +5,12 @@
       "title": "importgg.md",
       "filepath": "",
       "graph": {
-        "key": "9e0b1859-d441-47d1-9bf1-a1cbf2e8d6ef",
+        "key": "dda5f655-63e1-48d1-b7ab-238b8c133953",
         "sequence": [
           {
             "body": "echo WWW",
             "language": "bash",
-            "id": "956f12a8-884a-4d90-bb4d-0f9b4edf00ca-2"
+            "id": "27e4798b-7d1a-402a-bc28-3dadd96fffc5-2"
           }
         ]
       },
@@ -31,25 +31,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "167bab4f-9c9c-4c3a-816e-2c8d9c834477",
+            "key": "3e473385-9b8a-4a42-9522-de3c9fc3f113",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "956f12a8-884a-4d90-bb4d-0f9b4edf00ca-4"
+                "id": "27e4798b-7d1a-402a-bc28-3dadd96fffc5-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "956f12a8-884a-4d90-bb4d-0f9b4edf00ca-5"
+                "id": "27e4798b-7d1a-402a-bc28-3dadd96fffc5-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "956f12a8-884a-4d90-bb4d-0f9b4edf00ca-6"
+                "id": "27e4798b-7d1a-402a-bc28-3dadd96fffc5-6"
               }
             ]
           },
@@ -58,13 +58,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "f2a0b07d-fab7-4de0-8ff7-a5534dc48b97",
+            "key": "20340fbd-a7e5-4844-afaf-f5a192820035",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "956f12a8-884a-4d90-bb4d-0f9b4edf00ca-7"
+                "id": "27e4798b-7d1a-402a-bc28-3dadd96fffc5-7"
               }
             ]
           },

--- a/test/inputs/11/wizard-noaprioris.json
+++ b/test/inputs/11/wizard-noaprioris.json
@@ -4,16 +4,17 @@
       "group": "Text####HTML",
       "title": "Text versus HTML?",
       "source": "placeholder",
+      "provenance": ["test/inputs/11/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "1000c238-dd23-404f-b628-1cda5be38638",
+            "key": "520b4b9f-4915-4761-a4bf-4e9b110d1c23",
             "sequence": [
               {
                 "body": "echo text",
                 "language": "shell",
-                "id": "607c96eb-be27-41d5-a3a0-d9cd96cc19ac-0"
+                "id": "530bd5c1-0b7f-49cb-8102-004006b0f717-0"
               }
             ]
           },
@@ -22,12 +23,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "f44d8482-7bc0-4669-a3df-bceba45f12f5",
+            "key": "6fd6ead5-37c6-4ed5-8ece-18796eaf0e82",
             "sequence": [
               {
                 "body": "echo html",
                 "language": "shell",
-                "id": "607c96eb-be27-41d5-a3a0-d9cd96cc19ac-1"
+                "id": "530bd5c1-0b7f-49cb-8102-004006b0f717-1"
               }
             ]
           },

--- a/test/inputs/11/wizard-noopt.json
+++ b/test/inputs/11/wizard-noopt.json
@@ -4,16 +4,17 @@
       "group": "Text####HTML",
       "title": "Text versus HTML?",
       "source": "placeholder",
+      "provenance": ["test/inputs/11/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "e84eb2ef-9de9-4dbe-9c08-6ed8ba6a044e",
+            "key": "95380c0d-a953-482c-a7ec-4937002fa8b0",
             "sequence": [
               {
                 "body": "echo text",
                 "language": "shell",
-                "id": "64d580e1-da2e-4414-a23d-2df69b196f89-0"
+                "id": "2595c59a-bb03-48e7-9a7f-a8fb8c238d06-0"
               }
             ]
           },
@@ -22,12 +23,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "95da6734-1e1e-45f3-af77-b4b0aacb8f94",
+            "key": "fb9e9389-4201-4f1e-98a9-37a021a82fd4",
             "sequence": [
               {
                 "body": "echo html",
                 "language": "shell",
-                "id": "64d580e1-da2e-4414-a23d-2df69b196f89-1"
+                "id": "2595c59a-bb03-48e7-9a7f-a8fb8c238d06-1"
               }
             ]
           },

--- a/test/inputs/11/wizard.json
+++ b/test/inputs/11/wizard.json
@@ -5,12 +5,12 @@
       "title": "Text versus HTML?",
       "filepath": "",
       "graph": {
-        "key": "3d024f21-6448-490e-aad6-67223f5d080b",
+        "key": "8929755b-da27-4d2b-be50-c03b74dda26c",
         "sequence": [
           {
             "body": "echo text",
             "language": "shell",
-            "id": "2c074cba-4c63-434f-ae76-e831acf8da28-0"
+            "id": "4862731b-fc5d-4821-82a2-c800a5f59a3c-0"
           }
         ]
       },

--- a/test/inputs/12/wizard-noopt.json
+++ b/test/inputs/12/wizard-noopt.json
@@ -4,7 +4,7 @@
       "body": "echo AAA",
       "language": "shell",
       "validate": "echo true",
-      "id": "edc41a30-388c-4bc6-8f46-fc1a7e204255-0"
+      "id": "05baa4c9-90dc-4f49-acb0-9627353ecd4f-0"
     },
     "step": {
       "content": "```shell\necho AAA\n```"

--- a/test/inputs/13/wizard-noaprioris.json
+++ b/test/inputs/13/wizard-noaprioris.json
@@ -5,12 +5,12 @@
       "title": "H1",
       "filepath": "",
       "graph": {
-        "key": "ae144ba4-4112-4665-85d5-47f3bdc51cdc",
+        "key": "a0705630-7d50-4841-b439-14ab1b8f5c58",
         "sequence": [
           {
             "body": "111",
             "language": "shell",
-            "id": "b9825769-78e8-4b3d-ad19-a0698468ae18-0"
+            "id": "53302906-1189-4f29-8fd0-918a2e9fe992-0"
           }
         ]
       },

--- a/test/inputs/13/wizard-noopt.json
+++ b/test/inputs/13/wizard-noopt.json
@@ -5,12 +5,12 @@
       "title": "H1",
       "filepath": "",
       "graph": {
-        "key": "606ad2da-1d7e-4246-8c30-e72a10221cf5",
+        "key": "ecaf7c81-161d-40b0-ae20-b961ba94732e",
         "sequence": [
           {
             "body": "111",
             "language": "shell",
-            "id": "a99b4944-b68f-4bee-ab6a-72f8191fe827-0"
+            "id": "f689bb34-ace9-4235-8cc5-dbe6900dd9ef-0"
           }
         ]
       },

--- a/test/inputs/13/wizard.json
+++ b/test/inputs/13/wizard.json
@@ -5,12 +5,12 @@
       "title": "H1",
       "filepath": "",
       "graph": {
-        "key": "8a6813c8-12cc-403b-ae5a-721b2cbef759",
+        "key": "fb519b8a-f8cd-4dc3-9c52-0a5316b366e2",
         "sequence": [
           {
             "body": "111",
             "language": "shell",
-            "id": "04b05267-9fd9-497b-b242-5c0869435fc4-0"
+            "id": "30e84506-f08d-4833-bc52-c326b9cfd6de-0"
           }
         ]
       },

--- a/test/inputs/14/wizard-noaprioris.json
+++ b/test/inputs/14/wizard-noaprioris.json
@@ -4,16 +4,17 @@
       "group": "expand(echo 3 ; echo 4 ; echo 5)",
       "title": "Testing tab expansion",
       "source": "placeholder",
+      "provenance": ["test/inputs/14/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "c1b5b115-8cdd-42ed-a706-0d5b17b0179e",
+            "key": "a50fb802-d0d1-4b13-b40d-22872aec94f3",
             "sequence": [
               {
                 "body": "echo \"3\"",
                 "language": "shell",
-                "id": "98131c9f-331c-4f65-b8e1-59c84e698837-0"
+                "id": "4d97cbe9-73b4-4943-88df-6a1c6bbbdf1e-0"
               }
             ]
           },
@@ -23,12 +24,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "c1b5b115-8cdd-42ed-a706-0d5b17b0179e",
+            "key": "a50fb802-d0d1-4b13-b40d-22872aec94f3",
             "sequence": [
               {
                 "body": "echo \"4\"",
                 "language": "shell",
-                "id": "98131c9f-331c-4f65-b8e1-59c84e698837-0"
+                "id": "4d97cbe9-73b4-4943-88df-6a1c6bbbdf1e-0"
               }
             ]
           },
@@ -38,12 +39,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "c1b5b115-8cdd-42ed-a706-0d5b17b0179e",
+            "key": "a50fb802-d0d1-4b13-b40d-22872aec94f3",
             "sequence": [
               {
                 "body": "echo \"5\"",
                 "language": "shell",
-                "id": "98131c9f-331c-4f65-b8e1-59c84e698837-0"
+                "id": "4d97cbe9-73b4-4943-88df-6a1c6bbbdf1e-0"
               }
             ]
           },

--- a/test/inputs/14/wizard-noopt.json
+++ b/test/inputs/14/wizard-noopt.json
@@ -4,16 +4,17 @@
       "group": "expand(echo 3 ; echo 4 ; echo 5)",
       "title": "Testing tab expansion",
       "source": "placeholder",
+      "provenance": ["test/inputs/14/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "89f74310-5530-46cf-b354-3511a3926709",
+            "key": "8ac5c93e-e73d-42c5-8d16-41921a98a9fc",
             "sequence": [
               {
                 "body": "echo \"3\"",
                 "language": "shell",
-                "id": "1daaaf36-e244-4351-aef8-a45615f339c6-0"
+                "id": "1c10243b-4fff-425b-9571-1173c1ed05a8-0"
               }
             ]
           },
@@ -23,12 +24,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "89f74310-5530-46cf-b354-3511a3926709",
+            "key": "8ac5c93e-e73d-42c5-8d16-41921a98a9fc",
             "sequence": [
               {
                 "body": "echo \"4\"",
                 "language": "shell",
-                "id": "1daaaf36-e244-4351-aef8-a45615f339c6-0"
+                "id": "1c10243b-4fff-425b-9571-1173c1ed05a8-0"
               }
             ]
           },
@@ -38,12 +39,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "89f74310-5530-46cf-b354-3511a3926709",
+            "key": "8ac5c93e-e73d-42c5-8d16-41921a98a9fc",
             "sequence": [
               {
                 "body": "echo \"5\"",
                 "language": "shell",
-                "id": "1daaaf36-e244-4351-aef8-a45615f339c6-0"
+                "id": "1c10243b-4fff-425b-9571-1173c1ed05a8-0"
               }
             ]
           },

--- a/test/inputs/14/wizard.json
+++ b/test/inputs/14/wizard.json
@@ -4,16 +4,17 @@
       "group": "expand(echo 3 ; echo 4 ; echo 5)",
       "title": "Testing tab expansion",
       "source": "placeholder",
+      "provenance": ["test/inputs/14/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "351d4f0d-8fee-4da4-b876-c7cc4490c316",
+            "key": "fa421aba-2deb-4552-869b-b22183a99eb4",
             "sequence": [
               {
                 "body": "echo \"3\"",
                 "language": "shell",
-                "id": "a6d5bfa6-23e1-4819-9b91-b8b4d60caa5a-0"
+                "id": "6fcb4141-15a8-4283-845c-427bd8e4f486-0"
               }
             ]
           },
@@ -23,12 +24,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "351d4f0d-8fee-4da4-b876-c7cc4490c316",
+            "key": "fa421aba-2deb-4552-869b-b22183a99eb4",
             "sequence": [
               {
                 "body": "echo \"4\"",
                 "language": "shell",
-                "id": "a6d5bfa6-23e1-4819-9b91-b8b4d60caa5a-0"
+                "id": "6fcb4141-15a8-4283-845c-427bd8e4f486-0"
               }
             ]
           },
@@ -38,12 +39,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "351d4f0d-8fee-4da4-b876-c7cc4490c316",
+            "key": "fa421aba-2deb-4552-869b-b22183a99eb4",
             "sequence": [
               {
                 "body": "echo \"5\"",
                 "language": "shell",
-                "id": "a6d5bfa6-23e1-4819-9b91-b8b4d60caa5a-0"
+                "id": "6fcb4141-15a8-4283-845c-427bd8e4f486-0"
               }
             ]
           },

--- a/test/inputs/15/wizard-noaprioris.json
+++ b/test/inputs/15/wizard-noaprioris.json
@@ -4,26 +4,28 @@
       "group": "Tab1",
       "title": "MainTitle",
       "source": "placeholder",
+      "provenance": ["test/inputs/15/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "96d464dd-d231-4ceb-9a7b-ff887f4b46fa",
+            "key": "4c8db03b-acdf-418f-aa1c-b55022c0a728",
             "sequence": [
               {
                 "group": "SubTab1####SubTab2",
                 "title": "Tab1",
                 "source": "placeholder",
+                "provenance": ["test/inputs/15/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "b03f2a38-8f58-4922-8f6d-fa45d6c6bddf",
+                      "key": "d4f76638-0a4d-423b-a309-ca831efeb4c4",
                       "sequence": [
                         {
                           "body": "echo 111",
                           "language": "shell",
-                          "id": "cf5075df-dc27-4824-ae03-bc322bbb70ee-0"
+                          "id": "f3e86389-832c-44e8-b028-3801d54ff10a-0"
                         }
                       ]
                     },
@@ -32,12 +34,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "fc337cee-8ada-403b-8389-9c910ac2dd89",
+                      "key": "30d7ee73-011d-44dc-ad75-3b0067e3aff0",
                       "sequence": [
                         {
                           "body": "echo 222",
                           "language": "shell",
-                          "id": "cf5075df-dc27-4824-ae03-bc322bbb70ee-1"
+                          "id": "f3e86389-832c-44e8-b028-3801d54ff10a-1"
                         }
                       ]
                     },

--- a/test/inputs/15/wizard-noopt.json
+++ b/test/inputs/15/wizard-noopt.json
@@ -4,25 +4,27 @@
       "group": "Tab1",
       "title": "MainTitle",
       "source": "placeholder",
+      "provenance": ["test/inputs/15/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "c9468ca3-67d3-477d-8714-e8116bdb3d4e",
+            "key": "9a975dde-0df1-43e3-a8f9-be470246d009",
             "sequence": [
               {
                 "group": "SubTab1####SubTab2",
                 "source": "placeholder",
+                "provenance": ["test/inputs/15/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "f97862a9-47d6-421f-a71f-b07cc5f0521d",
+                      "key": "fe3cd538-719b-44b2-9643-60acf4a4e317",
                       "sequence": [
                         {
                           "body": "echo 111",
                           "language": "shell",
-                          "id": "20ef7578-c8c7-4931-a48a-ca4c2996becf-0"
+                          "id": "1d2dcbe3-69ac-41cf-a04f-944da43d8f2f-0"
                         }
                       ]
                     },
@@ -31,12 +33,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "2ba60f78-34b5-499e-864f-d5af238243ef",
+                      "key": "08ce6905-f012-47ca-a45d-1570fbe8cf62",
                       "sequence": [
                         {
                           "body": "echo 222",
                           "language": "shell",
-                          "id": "20ef7578-c8c7-4931-a48a-ca4c2996becf-1"
+                          "id": "1d2dcbe3-69ac-41cf-a04f-944da43d8f2f-1"
                         }
                       ]
                     },

--- a/test/inputs/15/wizard.json
+++ b/test/inputs/15/wizard.json
@@ -4,26 +4,28 @@
       "group": "Tab1",
       "title": "MainTitle",
       "source": "placeholder",
+      "provenance": ["test/inputs/15/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "34e17fc1-10a6-492d-848f-94dc5777de40",
+            "key": "c2f02c91-c5ab-4059-b8ad-0d418bb0200d",
             "sequence": [
               {
                 "group": "SubTab1####SubTab2",
                 "title": "Tab1",
                 "source": "placeholder",
+                "provenance": ["test/inputs/15/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "65874bc8-c4d8-448a-b030-47102921c17c",
+                      "key": "df971858-dfaa-445e-b6da-9e2fc13e25f5",
                       "sequence": [
                         {
                           "body": "echo 111",
                           "language": "shell",
-                          "id": "0dc1bdf2-ffc2-43a0-9f1a-e03309ece96e-0"
+                          "id": "b8c5ea55-0832-4ab1-a8b9-22495575fffe-0"
                         }
                       ]
                     },
@@ -32,12 +34,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "636d9b9d-545f-435e-8002-dd5b644e30fa",
+                      "key": "03b63799-d1d4-4dac-86c1-8443a40a0050",
                       "sequence": [
                         {
                           "body": "echo 222",
                           "language": "shell",
-                          "id": "0dc1bdf2-ffc2-43a0-9f1a-e03309ece96e-1"
+                          "id": "b8c5ea55-0832-4ab1-a8b9-22495575fffe-1"
                         }
                       ]
                     },

--- a/test/inputs/16/wizard-noaprioris.json
+++ b/test/inputs/16/wizard-noaprioris.json
@@ -4,26 +4,28 @@
       "group": "Tab1",
       "title": "MainTitle",
       "source": "placeholder",
+      "provenance": ["test/inputs/16/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "f84cec2a-c358-4fc3-a1e1-539b8fd19384",
+            "key": "5c181616-629e-4432-a9bd-73535819c48d",
             "sequence": [
               {
                 "group": "SubTab1####SubTab2",
                 "title": "Tab1",
                 "source": "placeholder",
+                "provenance": ["test/inputs/16/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "99dfa3bd-e060-49b7-9756-6beacc60b631",
+                      "key": "3137b232-68bf-4d24-86fb-f851e44a1d9b",
                       "sequence": [
                         {
                           "body": "echo 111",
                           "language": "shell",
-                          "id": "988d8d3c-b6bb-419b-b7c7-ff8a559a7868-0"
+                          "id": "afed487b-c6db-4466-8811-9260c1c838da-0"
                         }
                       ]
                     },
@@ -32,12 +34,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "8c8e7670-3c40-4ca4-8015-724fee6bc8c0",
+                      "key": "6e242a00-5dd6-4a61-a058-d29032657b82",
                       "sequence": [
                         {
                           "body": "echo 222",
                           "language": "shell",
-                          "id": "988d8d3c-b6bb-419b-b7c7-ff8a559a7868-1"
+                          "id": "afed487b-c6db-4466-8811-9260c1c838da-1"
                         }
                       ]
                     },

--- a/test/inputs/16/wizard-noopt.json
+++ b/test/inputs/16/wizard-noopt.json
@@ -4,25 +4,27 @@
       "group": "Tab1",
       "title": "MainTitle",
       "source": "placeholder",
+      "provenance": ["test/inputs/16/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "7bc6d711-c6e6-4ad0-82ad-7efaa2abfa8b",
+            "key": "f491da8e-9f29-440f-9a36-fd130a1795e8",
             "sequence": [
               {
                 "group": "SubTab1####SubTab2",
                 "source": "placeholder",
+                "provenance": ["test/inputs/16/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "91bfb7fd-e942-4467-b90c-ed905294abaf",
+                      "key": "c7ffb272-2527-477e-80dd-db423137fd7f",
                       "sequence": [
                         {
                           "body": "echo 111",
                           "language": "shell",
-                          "id": "777bc097-90dc-4be8-b2f7-64a796b03f14-0"
+                          "id": "9b456d85-4b72-491e-9084-095900d80ce2-0"
                         }
                       ]
                     },
@@ -31,12 +33,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "4600df3e-5eab-4ae6-b7e9-cdd511b7cc88",
+                      "key": "c0706bae-fe59-43b6-9637-743e1c4838e2",
                       "sequence": [
                         {
                           "body": "echo 222",
                           "language": "shell",
-                          "id": "777bc097-90dc-4be8-b2f7-64a796b03f14-1"
+                          "id": "9b456d85-4b72-491e-9084-095900d80ce2-1"
                         }
                       ]
                     },

--- a/test/inputs/16/wizard.json
+++ b/test/inputs/16/wizard.json
@@ -4,26 +4,28 @@
       "group": "Tab1",
       "title": "MainTitle",
       "source": "placeholder",
+      "provenance": ["test/inputs/16/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "c4c5fdd0-2d0d-4595-9081-d72d1736f66c",
+            "key": "47780a6a-ecd4-477d-bd54-1158067d7609",
             "sequence": [
               {
                 "group": "SubTab1####SubTab2",
                 "title": "Tab1",
                 "source": "placeholder",
+                "provenance": ["test/inputs/16/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "38fd4af1-7646-4186-85ae-b6aad051c077",
+                      "key": "353dc69a-978a-4f46-bcdf-d1f0e2857aaf",
                       "sequence": [
                         {
                           "body": "echo 111",
                           "language": "shell",
-                          "id": "fdbc9d24-7892-409d-a7e0-a7de1f1c8657-0"
+                          "id": "9b16c22e-ea2c-45d5-90f6-5f59404b9973-0"
                         }
                       ]
                     },
@@ -32,12 +34,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "1c6f0273-6db5-4a43-9b09-e92f26143b5a",
+                      "key": "d00a91d0-06c8-4864-90b9-1f5fc65d894d",
                       "sequence": [
                         {
                           "body": "echo 222",
                           "language": "shell",
-                          "id": "fdbc9d24-7892-409d-a7e0-a7de1f1c8657-1"
+                          "id": "9b16c22e-ea2c-45d5-90f6-5f59404b9973-1"
                         }
                       ]
                     },

--- a/test/inputs/17/wizard-noaprioris.json
+++ b/test/inputs/17/wizard-noaprioris.json
@@ -5,12 +5,12 @@
       "title": "barrier.md",
       "filepath": "",
       "graph": {
-        "key": "c0b942d2-c213-424c-a3e2-13eff13027b6",
+        "key": "94986f92-fe6e-40a4-8e9d-1f4c3472f012",
         "sequence": [
           {
             "body": "echo barrier",
             "language": "shell",
-            "id": "797e1b21-be38-4ab8-af05-20583b533769-1"
+            "id": "ffcefd5f-3b35-41a0-975d-ff47ce567b1e-1"
           }
         ]
       },
@@ -33,12 +33,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "3faf76fc-e435-48b1-956d-8156c0f1e685",
+            "key": "b1f9198e-93b1-428c-aa9e-d25bc00c49e0",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "797e1b21-be38-4ab8-af05-20583b533769-2"
+                "id": "ffcefd5f-3b35-41a0-975d-ff47ce567b1e-2"
               }
             ]
           },

--- a/test/inputs/17/wizard-noopt.json
+++ b/test/inputs/17/wizard-noopt.json
@@ -5,13 +5,13 @@
       "title": "importa.md",
       "filepath": "",
       "graph": {
-        "key": "fd9a368a-f093-4fe5-a273-210987a4267b",
+        "key": "57510e8f-e624-4822-b4d4-bfa40fcbe30b",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "b449516f-7b0b-4602-8fce-9a59847b5527-0"
+            "id": "90e2da00-dc2e-4f16-9f23-6fa745488c16-0"
           }
         ]
       },
@@ -28,12 +28,12 @@
       "title": "barrier.md",
       "filepath": "",
       "graph": {
-        "key": "48bccb2f-a96a-4931-a9bf-5c84c7f04021",
+        "key": "1feb58bd-b6e3-4825-9234-d257948cb209",
         "sequence": [
           {
             "body": "echo barrier",
             "language": "shell",
-            "id": "b449516f-7b0b-4602-8fce-9a59847b5527-1"
+            "id": "90e2da00-dc2e-4f16-9f23-6fa745488c16-1"
           }
         ]
       },
@@ -56,12 +56,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "6a845ae0-f1a3-4059-be27-164d6218c901",
+            "key": "1027cabf-7692-44fd-8f2a-fc9da37a5651",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "b449516f-7b0b-4602-8fce-9a59847b5527-2"
+                "id": "90e2da00-dc2e-4f16-9f23-6fa745488c16-2"
               }
             ]
           },
@@ -89,7 +89,7 @@
       "body": "echo \"testing barrier imports\"",
       "language": "shell",
       "validate": true,
-      "id": "b449516f-7b0b-4602-8fce-9a59847b5527-3"
+      "id": "90e2da00-dc2e-4f16-9f23-6fa745488c16-3"
     },
     "step": {
       "content": "```shell\necho \"testing barrier imports\"\n```"

--- a/test/inputs/17/wizard.json
+++ b/test/inputs/17/wizard.json
@@ -5,12 +5,12 @@
       "title": "barrier.md",
       "filepath": "",
       "graph": {
-        "key": "03344a6f-981a-4d1a-bce1-a80275d75975",
+        "key": "953ea391-72f1-4e97-a930-2d79be83254c",
         "sequence": [
           {
             "body": "echo barrier",
             "language": "shell",
-            "id": "b8416677-c541-4ecc-9c74-711163fd0280-1"
+            "id": "308c75f3-c90c-4f10-99ce-4792b683f7fa-1"
           }
         ]
       },
@@ -33,12 +33,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "8d0e03d5-6061-49c1-bd6f-90cb377744f5",
+            "key": "9eb9c408-42ac-43b4-82c8-7fbe5b8c283e",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "b8416677-c541-4ecc-9c74-711163fd0280-2"
+                "id": "308c75f3-c90c-4f10-99ce-4792b683f7fa-2"
               }
             ]
           },

--- a/test/inputs/18/wizard-noaprioris.json
+++ b/test/inputs/18/wizard-noaprioris.json
@@ -9,20 +9,20 @@
         {
           "member": 0,
           "graph": {
-            "key": "9f219828-2e75-4a3d-9f05-ddec25f150f4",
+            "key": "9437bacb-5dff-450c-a481-d6502e7b6ea6",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
                 "filepath": "test/inputs/snippets/importa.md",
                 "graph": {
-                  "key": "c39c0810-318c-4550-9b10-5c7e9090efbc",
+                  "key": "e4551006-a5d9-4315-a14f-4ad70a5225d2",
                   "sequence": [
                     {
                       "body": "echo AAA",
                       "language": "bash",
                       "validate": true,
-                      "id": "56ce8f59-63c0-4aba-8676-1dcb37f51404-0"
+                      "id": "62140a74-8f5f-453e-9b40-e193a87fec72-0"
                     }
                   ]
                 },
@@ -35,14 +35,14 @@
         {
           "member": 1,
           "graph": {
-            "key": "d50cf448-bfcc-4a19-908c-5a4e747bbcd4",
+            "key": "509ce04f-367f-4bee-bd6c-214292f64076",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importe.md",
                 "title": "EEE",
                 "filepath": "test/inputs/snippets/importe.md",
                 "graph": {
-                  "key": "27db5c74-638b-4fe1-a4ff-24c15ee2ff9d",
+                  "key": "1dd8cff3-282b-424f-a5a2-a0a651bc7ca4",
                   "sequence": [
                     {
                       "group": "TabE1",
@@ -53,12 +53,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "d2537049-3386-4933-a4ad-d80617132b74",
+                            "key": "588e53ef-b4bc-4bdb-8b91-bd636945cc11",
                             "sequence": [
                               {
                                 "body": "echo EEE",
                                 "language": "bash",
-                                "id": "56ce8f59-63c0-4aba-8676-1dcb37f51404-1"
+                                "id": "62140a74-8f5f-453e-9b40-e193a87fec72-1"
                               }
                             ]
                           },

--- a/test/inputs/18/wizard-noopt.json
+++ b/test/inputs/18/wizard-noopt.json
@@ -9,20 +9,20 @@
         {
           "member": 0,
           "graph": {
-            "key": "4c40972f-c96a-4c34-b279-21f104f9be29",
+            "key": "0a545216-7577-452f-8b5c-cbe3c81335c6",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
                 "filepath": "test/inputs/snippets/importa.md",
                 "graph": {
-                  "key": "67aa8f6a-a33e-4968-b8ef-8f5762b5be77",
+                  "key": "833c2035-9a65-4554-bb99-cb5f7f687d47",
                   "sequence": [
                     {
                       "body": "echo AAA",
                       "language": "bash",
                       "validate": true,
-                      "id": "9fcaca5f-9687-4940-872d-cf52bf63be65-0"
+                      "id": "122776fa-8cd6-4bd0-b5d1-5ee31b101021-0"
                     }
                   ]
                 },
@@ -35,14 +35,14 @@
         {
           "member": 1,
           "graph": {
-            "key": "095af675-b21f-4aba-a2b2-e6b2207c8c89",
+            "key": "42fde952-e36e-49ce-8daf-41b56a4470ca",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importe.md",
                 "title": "EEE",
                 "filepath": "test/inputs/snippets/importe.md",
                 "graph": {
-                  "key": "cff9cdb5-e70a-4359-8316-7012f2a9c31f",
+                  "key": "0d42b924-8252-431c-99c7-00af51d6df84",
                   "sequence": [
                     {
                       "group": "TabE1",
@@ -53,12 +53,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "1f643e3e-f25f-4bed-a860-b204e7995092",
+                            "key": "0ff6a9c7-1712-4f3b-b4c5-92b831372498",
                             "sequence": [
                               {
                                 "body": "echo EEE",
                                 "language": "bash",
-                                "id": "9fcaca5f-9687-4940-872d-cf52bf63be65-1"
+                                "id": "122776fa-8cd6-4bd0-b5d1-5ee31b101021-1"
                               }
                             ]
                           },

--- a/test/inputs/18/wizard.json
+++ b/test/inputs/18/wizard.json
@@ -9,20 +9,20 @@
         {
           "member": 0,
           "graph": {
-            "key": "9971b31b-3634-4b23-b0a1-bba6d68432bb",
+            "key": "976e7008-7116-4b72-b6eb-272309788ea0",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importa.md",
                 "title": "importa.md",
                 "filepath": "test/inputs/snippets/importa.md",
                 "graph": {
-                  "key": "4ae5886f-14ec-44f3-8326-9a8a41b89c9a",
+                  "key": "b001ecb1-8c1a-45be-aa20-263e924b5c62",
                   "sequence": [
                     {
                       "body": "echo AAA",
                       "language": "bash",
                       "validate": true,
-                      "id": "60a87ad3-fc92-4099-be8e-fb0188da66e8-0"
+                      "id": "cf64dc46-5674-45d5-abe9-36180e44a625-0"
                     }
                   ]
                 },
@@ -35,14 +35,14 @@
         {
           "member": 1,
           "graph": {
-            "key": "f62c7bb7-a56d-4b0f-95d6-f25a4be7bcad",
+            "key": "53c67cd5-20b3-43ca-aa69-f29bd56455a6",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importe.md",
                 "title": "EEE",
                 "filepath": "test/inputs/snippets/importe.md",
                 "graph": {
-                  "key": "2baf32ae-a9b0-4316-8f79-4ebfa8338a6a",
+                  "key": "58b0dfff-4fb1-4fdf-ba08-95faf14a856a",
                   "sequence": [
                     {
                       "group": "TabE1",
@@ -53,12 +53,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "47ef3e53-0095-4d6c-9bfc-f0a1fe1baff8",
+                            "key": "3c730c2f-365f-478f-a553-ca2bc9182f08",
                             "sequence": [
                               {
                                 "body": "echo EEE",
                                 "language": "bash",
-                                "id": "60a87ad3-fc92-4099-be8e-fb0188da66e8-1"
+                                "id": "cf64dc46-5674-45d5-abe9-36180e44a625-1"
                               }
                             ]
                           },

--- a/test/inputs/19/wizard-darwin.json
+++ b/test/inputs/19/wizard-darwin.json
@@ -4,16 +4,17 @@
       "group": "Local Install####Kubernetes Install",
       "title": "Install Ray",
       "source": "placeholder",
+      "provenance": ["test/inputs/19/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "ec5f1c5e-8185-435e-83e3-48140c7014cf",
+            "key": "d7eba1b7-c7a7-400c-82f4-f60ef3686e43",
             "sequence": [
               {
                 "body": "pip install -U ray",
                 "language": "shell",
-                "id": "35c7f575-f9b2-436f-b809-8dec5d3db536-2"
+                "id": "43b5656d-a3fa-4a50-9d3e-5d53711c71b4-2"
               }
             ]
           },
@@ -23,26 +24,26 @@
         {
           "member": 1,
           "graph": {
-            "key": "352abe3b-dec9-4dfb-9472-e10a8a478c89",
+            "key": "af936d2c-9ab2-4871-ba74-2e5af5fd91ab",
             "sequence": [
               {
                 "key": "test/inputs/19/snippets/kubectl.md",
                 "title": "Install kubectl",
                 "filepath": "test/inputs/19/snippets/kubectl.md",
                 "graph": {
-                  "key": "4989998e-1b9f-4ddd-a174-cd6ebd2e7146",
+                  "key": "2e03cae2-2f9e-4566-88f8-22c4e4b8e77e",
                   "sequence": [
                     {
                       "key": "org.kubernetes-sigs.kui/choice/platform",
                       "title": "Install kubectl",
                       "filepath": "",
                       "graph": {
-                        "key": "ad835feb-be88-4399-a9c0-06fb50d7cf23",
+                        "key": "324b4206-8fca-44de-8bb0-efcd21a7424c",
                         "sequence": [
                           {
                             "body": "brew install kubectl",
                             "language": "bash",
-                            "id": "35c7f575-f9b2-436f-b809-8dec5d3db536-16"
+                            "id": "43b5656d-a3fa-4a50-9d3e-5d53711c71b4-16"
                           }
                         ]
                       },
@@ -57,19 +58,19 @@
                 "title": "Install Helm",
                 "filepath": "test/inputs/19/snippets/helm3.md",
                 "graph": {
-                  "key": "6b0fde49-9efc-4de3-bd36-503500c1cfff",
+                  "key": "58030172-a7c9-4c44-a28c-80020988d588",
                   "sequence": [
                     {
                       "key": "org.kubernetes-sigs.kui/choice/platform",
                       "title": "Install Helm",
                       "filepath": "",
                       "graph": {
-                        "key": "4a06a080-5722-4ed1-bf18-423c34895f98",
+                        "key": "8a94a30b-33a3-43d9-8894-596839bb0e22",
                         "sequence": [
                           {
                             "body": "brew install helm",
                             "language": "shell",
-                            "id": "35c7f575-f9b2-436f-b809-8dec5d3db536-21"
+                            "id": "43b5656d-a3fa-4a50-9d3e-5d53711c71b4-21"
                           }
                         ]
                       },
@@ -82,7 +83,7 @@
               {
                 "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
                 "language": "shell",
-                "id": "35c7f575-f9b2-436f-b809-8dec5d3db536-25"
+                "id": "43b5656d-a3fa-4a50-9d3e-5d53711c71b4-25"
               }
             ]
           },

--- a/test/inputs/19/wizard-linux.json
+++ b/test/inputs/19/wizard-linux.json
@@ -4,16 +4,17 @@
       "group": "Local Install####Kubernetes Install",
       "title": "Install Ray",
       "source": "placeholder",
+      "provenance": ["test/inputs/19/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "20c97d62-9129-462e-b83e-085ef592344b",
+            "key": "f6f963a8-e4ce-403b-bdc6-7959ce108733",
             "sequence": [
               {
                 "body": "pip install -U ray",
                 "language": "shell",
-                "id": "3d8b530b-0648-4bdd-9f08-0e70036ddd4b-0"
+                "id": "173fb32d-2c75-4a5e-b652-762800a024e0-0"
               }
             ]
           },
@@ -23,26 +24,26 @@
         {
           "member": 1,
           "graph": {
-            "key": "a70785e6-59f2-42f4-a91d-edb697b2111d",
+            "key": "766dade5-2bc5-40f6-a1fe-51cd6a15cc94",
             "sequence": [
               {
                 "key": "test/inputs/19/snippets/kubectl.md",
                 "title": "Install kubectl",
                 "filepath": "test/inputs/19/snippets/kubectl.md",
                 "graph": {
-                  "key": "713661bd-586a-4af6-a39e-ddabe6b42a64",
+                  "key": "b782a639-dde8-4652-a480-eb6e1961b30a",
                   "sequence": [
                     {
                       "key": "org.kubernetes-sigs.kui/choice/platform",
                       "title": "Install kubectl",
                       "filepath": "",
                       "graph": {
-                        "key": "f262cd66-d5c9-481c-b8ba-94bbf2ee7c04",
+                        "key": "4b7a9057-b542-48d2-801a-6d198831432c",
                         "sequence": [
                           {
                             "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\"",
                             "language": "bash",
-                            "id": "3d8b530b-0648-4bdd-9f08-0e70036ddd4b-14"
+                            "id": "173fb32d-2c75-4a5e-b652-762800a024e0-14"
                           }
                         ]
                       },
@@ -57,19 +58,19 @@
                 "title": "Install Helm",
                 "filepath": "test/inputs/19/snippets/helm3.md",
                 "graph": {
-                  "key": "b7c7a76d-d12d-45da-b0dd-23b100a3f2b2",
+                  "key": "6abcc4f2-8a97-4e66-a143-73b8a0ed46b9",
                   "sequence": [
                     {
                       "key": "org.kubernetes-sigs.kui/choice/platform",
                       "title": "Install Helm",
                       "filepath": "",
                       "graph": {
-                        "key": "aac6f663-5698-4716-b791-2ba16a31e72f",
+                        "key": "52fd8aa6-8eb9-49c9-8333-6f2221f292c2",
                         "sequence": [
                           {
                             "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                             "language": "shell",
-                            "id": "3d8b530b-0648-4bdd-9f08-0e70036ddd4b-23"
+                            "id": "173fb32d-2c75-4a5e-b652-762800a024e0-23"
                           }
                         ]
                       },
@@ -82,7 +83,7 @@
               {
                 "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
                 "language": "shell",
-                "id": "3d8b530b-0648-4bdd-9f08-0e70036ddd4b-25"
+                "id": "173fb32d-2c75-4a5e-b652-762800a024e0-25"
               }
             ]
           },

--- a/test/inputs/19/wizard-noaprioris.json
+++ b/test/inputs/19/wizard-noaprioris.json
@@ -4,26 +4,28 @@
       "group": "Local Install####Kubernetes Install",
       "title": "Install Ray",
       "source": "placeholder",
+      "provenance": ["test/inputs/19/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "42657689-ab71-4fd8-b06e-9b879d5fc50d",
+            "key": "5cf3dbe1-0b9f-4ec0-bffa-a2af78ce0ce0",
             "sequence": [
               {
                 "group": "Linux####Windows####MacOS",
                 "title": "Local Install",
                 "source": "placeholder",
+                "provenance": ["test/inputs/19/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "5f52169e-ac96-4cf3-9a49-e5f6cc26be6e",
+                      "key": "2b889414-b139-4ae5-a5ea-a0f753dfe50e",
                       "sequence": [
                         {
                           "body": "pip install -U ray",
                           "language": "shell",
-                          "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-0"
+                          "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-0"
                         }
                       ]
                     },
@@ -32,12 +34,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "2afa6eb2-b88e-42dc-9070-3765ef28a08e",
+                      "key": "bd2ede4a-bca6-45a4-bfd9-f36def04d71c",
                       "sequence": [
                         {
                           "body": "pip install -U ray",
                           "language": "shell",
-                          "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-1"
+                          "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-1"
                         }
                       ]
                     },
@@ -46,22 +48,23 @@
                   {
                     "member": 2,
                     "graph": {
-                      "key": "b98fbc49-81ee-47c1-83f2-63f95b1e20ad",
+                      "key": "7ef60bd3-dd77-4721-bbb0-f9a724d943b9",
                       "sequence": [
                         {
                           "group": "Intel####Apple Silicon",
                           "title": "MacOS",
                           "source": "placeholder",
+                          "provenance": ["test/inputs/19/in.md"],
                           "choices": [
                             {
                               "member": 0,
                               "graph": {
-                                "key": "3327b225-a8d4-4523-a8cf-25ad811261a2",
+                                "key": "f2d38687-c23a-44cb-aead-b9a5538643e3",
                                 "sequence": [
                                   {
                                     "body": "pip install -U ray",
                                     "language": "shell",
-                                    "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-2"
+                                    "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-2"
                                   }
                                 ]
                               },
@@ -71,14 +74,14 @@
                             {
                               "member": 1,
                               "graph": {
-                                "key": "52f39d4d-64ea-439e-8892-f5efad65159d",
+                                "key": "32190569-e53f-42a8-8787-c091cdfbfd48",
                                 "sequence": [
                                   {
                                     "key": "test/inputs/19/snippets/conda.md",
                                     "title": "Conda: Installation",
                                     "filepath": "test/inputs/19/snippets/conda.md",
                                     "graph": {
-                                      "key": "0f1c8a9e-f7de-4cc3-9677-565bed238fe4",
+                                      "key": "1525c8ee-dd3f-4c86-86d6-ce6a6dee4e0d",
                                       "sequence": [
                                         {
                                           "group": "Miniconda####Anaconda",
@@ -89,7 +92,7 @@
                                             {
                                               "member": 0,
                                               "graph": {
-                                                "key": "0c73a9e8-69cb-4371-8d2d-8d0ce36996de",
+                                                "key": "51d35a92-e74d-42c8-ae3f-8c9e4e2e318e",
                                                 "sequence": [
                                                   {
                                                     "group": "Windows####MacOS####Linux",
@@ -100,12 +103,12 @@
                                                       {
                                                         "member": 0,
                                                         "graph": {
-                                                          "key": "ad9a62d9-000e-4143-b626-63900d3b15f3",
+                                                          "key": "7ac0a7a1-4942-4647-8df0-904626441b5a",
                                                           "sequence": [
                                                             {
                                                               "body": "echo windowsfake",
                                                               "language": "shell",
-                                                              "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-3"
+                                                              "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-3"
                                                             }
                                                           ]
                                                         },
@@ -114,7 +117,7 @@
                                                       {
                                                         "member": 1,
                                                         "graph": {
-                                                          "key": "5c188d8c-f936-410a-8757-32e6c471896a",
+                                                          "key": "7b58dafe-b027-452f-862f-1a7a5a6377e0",
                                                           "sequence": [
                                                             {
                                                               "group": "Intel####Apple Silicon",
@@ -125,12 +128,12 @@
                                                                 {
                                                                   "member": 0,
                                                                   "graph": {
-                                                                    "key": "35bdb0c8-5d85-4b59-a313-bfbca786cbef",
+                                                                    "key": "1c59bce7-1ed4-422a-b292-94c26d0e87bb",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash <(curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh)",
                                                                         "language": "shell",
-                                                                        "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-4"
+                                                                        "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-4"
                                                                       }
                                                                     ]
                                                                   },
@@ -140,12 +143,12 @@
                                                                 {
                                                                   "member": 1,
                                                                   "graph": {
-                                                                    "key": "073b0c93-c91c-43e8-a3bf-174076a4e087",
+                                                                    "key": "294fb1d4-b550-4120-8ba6-42df5d17424d",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash <(curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh)",
                                                                         "language": "shell",
-                                                                        "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-5"
+                                                                        "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-5"
                                                                       }
                                                                     ]
                                                                   },
@@ -161,12 +164,12 @@
                                                       {
                                                         "member": 2,
                                                         "graph": {
-                                                          "key": "690744fe-98eb-4ab2-8273-bb46c6c11a51",
+                                                          "key": "0dff38fd-5545-4184-bb67-08105251d9bc",
                                                           "sequence": [
                                                             {
                                                               "body": "echo linuxfake",
                                                               "language": "shell",
-                                                              "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-6"
+                                                              "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-6"
                                                             }
                                                           ]
                                                         },
@@ -182,7 +185,7 @@
                                             {
                                               "member": 1,
                                               "graph": {
-                                                "key": "b30344b0-7227-400d-b7be-5af82e8cd6d3",
+                                                "key": "3647ae22-f32f-46ca-9cff-74c580dd76a6",
                                                 "sequence": [
                                                   {
                                                     "group": "Windows####MacOS####Linux",
@@ -193,12 +196,12 @@
                                                       {
                                                         "member": 0,
                                                         "graph": {
-                                                          "key": "39195633-c08b-4152-904b-995b36b2da13",
+                                                          "key": "db7833a7-8546-4b3e-9d43-128b1a3311df",
                                                           "sequence": [
                                                             {
                                                               "body": "echo windowsfake",
                                                               "language": "shell",
-                                                              "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-7"
+                                                              "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-7"
                                                             }
                                                           ]
                                                         },
@@ -207,12 +210,12 @@
                                                       {
                                                         "member": 1,
                                                         "graph": {
-                                                          "key": "7b0b9592-331e-4499-a48d-8cf04f2daae6",
+                                                          "key": "20e18d0e-6ef4-45cb-9ade-8e79cab5660a",
                                                           "sequence": [
                                                             {
                                                               "body": "bash $<(curl -L https://repo.anaconda.com/archive/Anaconda3-2021.11-MacOSX-x86_64.sh)",
                                                               "language": "shell",
-                                                              "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-8"
+                                                              "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-8"
                                                             }
                                                           ]
                                                         },
@@ -221,7 +224,7 @@
                                                       {
                                                         "member": 2,
                                                         "graph": {
-                                                          "key": "5388ca10-7958-41b5-ad31-260fde46b094",
+                                                          "key": "cfb411e2-ac7a-49a8-a465-3d92924ca032",
                                                           "sequence": [
                                                             {
                                                               "group": "x86####POWER8 and POWER9####AWS Graviton2/ARM64####IBM z/Linux and LinuxONE",
@@ -232,12 +235,12 @@
                                                                 {
                                                                   "member": 0,
                                                                   "graph": {
-                                                                    "key": "7fd95874-027b-4277-85a0-03c4e1c449eb",
+                                                                    "key": "e53540ef-34f0-4ae9-8fbd-4025ba2e0ea0",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash $<(curl -L https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-x86_64.sh)",
                                                                         "language": "shell",
-                                                                        "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-9"
+                                                                        "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-9"
                                                                       }
                                                                     ]
                                                                   },
@@ -246,12 +249,12 @@
                                                                 {
                                                                   "member": 1,
                                                                   "graph": {
-                                                                    "key": "d390c973-6cd4-43c1-a886-17f90623a7c7",
+                                                                    "key": "6ec85093-1104-4e19-aa0c-6b3fd37bebab",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash $<(curl -L https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-ppc64le.sh)",
                                                                         "language": "shell",
-                                                                        "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-10"
+                                                                        "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-10"
                                                                       }
                                                                     ]
                                                                   },
@@ -260,12 +263,12 @@
                                                                 {
                                                                   "member": 2,
                                                                   "graph": {
-                                                                    "key": "3eb10f84-70b7-4d99-9959-f7149341ab67",
+                                                                    "key": "cdf0118a-1982-43ae-acfb-326d34166d87",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash $<(curl -L https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-aarch64.sh)",
                                                                         "language": "shell",
-                                                                        "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-11"
+                                                                        "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-11"
                                                                       }
                                                                     ]
                                                                   },
@@ -274,12 +277,12 @@
                                                                 {
                                                                   "member": 3,
                                                                   "graph": {
-                                                                    "key": "cbd09b9e-3ec0-4447-920f-6fdb11f29d07",
+                                                                    "key": "dadacd3c-a045-4f41-a7e0-ad0db44646e5",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash $<(curl -L https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-s390x.sh)",
                                                                         "language": "shell",
-                                                                        "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-12"
+                                                                        "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-12"
                                                                       }
                                                                     ]
                                                                   },
@@ -307,7 +310,7 @@
                                   {
                                     "body": "conda activate\npip uninstall grpcio\nconda install grpcio\npip install ray",
                                     "language": "shell",
-                                    "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-13"
+                                    "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-13"
                                   }
                                 ]
                               },
@@ -330,14 +333,14 @@
         {
           "member": 1,
           "graph": {
-            "key": "e600a6bb-8618-4c13-8c73-eab2737d7370",
+            "key": "f3335abc-b576-47ee-a6e1-8bf207b76c2b",
             "sequence": [
               {
                 "key": "test/inputs/19/snippets/kubectl.md",
                 "title": "Install kubectl",
                 "filepath": "test/inputs/19/snippets/kubectl.md",
                 "graph": {
-                  "key": "5ebfdd72-ce38-40d6-8b44-6cd871f527ae",
+                  "key": "3449e548-7e45-47bf-a335-1359e3ccb5a8",
                   "sequence": [
                     {
                       "group": "Linux####Windows####MacOS",
@@ -348,12 +351,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "891b26c5-1817-4d2c-970b-56a28cba7996",
+                            "key": "decfcef0-2504-4531-97e8-abb5511dd89d",
                             "sequence": [
                               {
                                 "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\"",
                                 "language": "bash",
-                                "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-14"
+                                "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-14"
                               }
                             ]
                           },
@@ -363,12 +366,12 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "d210ffba-93db-4f1d-973a-5bddfb957be9",
+                            "key": "47958fb7-8116-46c1-8ef7-c878724a5d14",
                             "sequence": [
                               {
                                 "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/windows/amd64/kubectl.exe\"",
                                 "language": "bash",
-                                "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-15"
+                                "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-15"
                               }
                             ]
                           },
@@ -378,7 +381,7 @@
                         {
                           "member": 2,
                           "graph": {
-                            "key": "08695f8a-e8d4-4969-8f7f-945b03e27686",
+                            "key": "522efab1-7d9c-4366-a711-69b4f5dfc7c0",
                             "sequence": [
                               {
                                 "group": "Homebrew####curl",
@@ -389,12 +392,12 @@
                                   {
                                     "member": 0,
                                     "graph": {
-                                      "key": "3b8f136b-c833-4762-9d53-724096a25a5e",
+                                      "key": "17f3ad7f-4723-4203-9425-5fdc8189eeef",
                                       "sequence": [
                                         {
                                           "body": "brew install kubectl",
                                           "language": "bash",
-                                          "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-16"
+                                          "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-16"
                                         }
                                       ]
                                     },
@@ -404,7 +407,7 @@
                                   {
                                     "member": 1,
                                     "graph": {
-                                      "key": "3909dd1f-a5a7-45d6-b344-40eea9039ebc",
+                                      "key": "586a0302-6ecd-4cc5-82e8-37bb5461522a",
                                       "sequence": [
                                         {
                                           "group": "Intel####Apple Silicon",
@@ -415,12 +418,12 @@
                                             {
                                               "member": 0,
                                               "graph": {
-                                                "key": "016d9277-382e-47a6-a161-de4730881f9f",
+                                                "key": "93201f4f-c9f8-4039-9ab2-62b7a7ef2de8",
                                                 "sequence": [
                                                   {
                                                     "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256\"",
                                                     "language": "bash",
-                                                    "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-17"
+                                                    "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-17"
                                                   }
                                                 ]
                                               },
@@ -429,12 +432,12 @@
                                             {
                                               "member": 1,
                                               "graph": {
-                                                "key": "cf968a5a-aa48-48c9-b09c-7300508ec893",
+                                                "key": "f8cc8267-a96a-489c-9131-b67688f8402b",
                                                 "sequence": [
                                                   {
                                                     "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl.sha256\"",
                                                     "language": "bash",
-                                                    "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-18"
+                                                    "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-18"
                                                   }
                                                 ]
                                               },
@@ -447,7 +450,7 @@
                                           "title": "Installing a Specific Version",
                                           "filepath": "",
                                           "graph": {
-                                            "key": "6ed1f9b8-48d9-4a12-9444-0e2b569aa726",
+                                            "key": "af2cd4b8-9d9c-4628-9ff0-580eb93be321",
                                             "sequence": [
                                               {
                                                 "group": "Intel####Apple Silicon",
@@ -458,12 +461,12 @@
                                                   {
                                                     "member": 0,
                                                     "graph": {
-                                                      "key": "3ce08064-846f-4c06-94f0-a368599a7fa2",
+                                                      "key": "fc42cf34-e589-4110-9ec4-14899f7ccdd4",
                                                       "sequence": [
                                                         {
                                                           "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/amd64/kubectl\"",
                                                           "language": "bash",
-                                                          "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-19",
+                                                          "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-19",
                                                           "optional": true
                                                         }
                                                       ]
@@ -474,12 +477,12 @@
                                                   {
                                                     "member": 1,
                                                     "graph": {
-                                                      "key": "a174cdb7-c6c1-4aa5-ab4a-f57486befb1b",
+                                                      "key": "6191c6d5-8ad6-4b61-8d04-5e37fa50235e",
                                                       "sequence": [
                                                         {
                                                           "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/arm64/kubectl\"",
                                                           "language": "bash",
-                                                          "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-20",
+                                                          "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-20",
                                                           "optional": true
                                                         }
                                                       ]
@@ -516,7 +519,7 @@
                 "title": "Install Helm",
                 "filepath": "test/inputs/19/snippets/helm3.md",
                 "graph": {
-                  "key": "5b433d68-dd9e-43a8-b695-9bc0fb5dcb3d",
+                  "key": "ba0d828c-0a2c-4b8a-8b27-6d9ce057d1cc",
                   "sequence": [
                     {
                       "group": "MacOS####Linux####Windows",
@@ -527,7 +530,7 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "d9f6918c-7b83-4f2c-ae0f-6eeb46a5fb35",
+                            "key": "8a4c40d8-5df5-4221-ae47-8c838e218684",
                             "sequence": [
                               {
                                 "group": "Homebrew####curl",
@@ -538,12 +541,12 @@
                                   {
                                     "member": 0,
                                     "graph": {
-                                      "key": "2841a9db-9447-49b3-93e2-fa0ff7599a2c",
+                                      "key": "cec4ae7c-6669-4add-bbf3-beee35b00dec",
                                       "sequence": [
                                         {
                                           "body": "brew install helm",
                                           "language": "shell",
-                                          "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-21"
+                                          "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-21"
                                         }
                                       ]
                                     },
@@ -552,12 +555,12 @@
                                   {
                                     "member": 1,
                                     "graph": {
-                                      "key": "593f746e-a5c0-4c4f-a1cc-5e084979b502",
+                                      "key": "772deda2-3e14-4a6c-8ed8-511dd94d099e",
                                       "sequence": [
                                         {
                                           "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                           "language": "shell",
-                                          "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-22"
+                                          "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-22"
                                         }
                                       ]
                                     },
@@ -572,12 +575,12 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "14e799cf-8131-4bd2-ac05-07f0790c0c2f",
+                            "key": "99cde524-f063-4012-8720-a635c3c1bd17",
                             "sequence": [
                               {
                                 "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                 "language": "shell",
-                                "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-23"
+                                "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-23"
                               }
                             ]
                           },
@@ -586,12 +589,12 @@
                         {
                           "member": 2,
                           "graph": {
-                            "key": "202cc1d2-9753-434e-ba64-265b27a9d0fa",
+                            "key": "3b53ba67-d574-4efd-bc94-f277a87d7378",
                             "sequence": [
                               {
                                 "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                 "language": "shell",
-                                "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-24"
+                                "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-24"
                               }
                             ]
                           },
@@ -606,7 +609,7 @@
               {
                 "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
                 "language": "shell",
-                "id": "ba231a46-6be8-4425-b6d6-bb6acbe7610c-25"
+                "id": "f784e40a-54e9-4f42-86a1-66a07e36a452-25"
               }
             ]
           },

--- a/test/inputs/19/wizard-noopt.json
+++ b/test/inputs/19/wizard-noopt.json
@@ -4,25 +4,27 @@
       "group": "Local Install####Kubernetes Install",
       "title": "Install Ray",
       "source": "placeholder",
+      "provenance": ["test/inputs/19/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "bf843da7-9a99-4c49-817f-7db2361f27fa",
+            "key": "9337a57f-f29f-4873-88d7-c1dbdffe46a0",
             "sequence": [
               {
                 "group": "Linux####Windows####MacOS",
                 "source": "placeholder",
+                "provenance": ["test/inputs/19/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "7f8e6970-93a9-4339-b5c9-b202db2b79ca",
+                      "key": "45c7121b-4e91-4dbe-b88e-5b316d9f76c1",
                       "sequence": [
                         {
                           "body": "pip install -U ray",
                           "language": "shell",
-                          "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-0"
+                          "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-0"
                         }
                       ]
                     },
@@ -31,12 +33,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "079a14e3-1f54-4bd3-8232-c33104d9dbe7",
+                      "key": "51ac0570-c106-4836-9110-d7c57031c436",
                       "sequence": [
                         {
                           "body": "pip install -U ray",
                           "language": "shell",
-                          "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-1"
+                          "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-1"
                         }
                       ]
                     },
@@ -45,21 +47,22 @@
                   {
                     "member": 2,
                     "graph": {
-                      "key": "b32be5f9-6e73-434f-9d3f-55512a36aa02",
+                      "key": "eae78c36-9d72-4cd5-a84c-1779cea090a8",
                       "sequence": [
                         {
                           "group": "Intel####Apple Silicon",
                           "source": "placeholder",
+                          "provenance": ["test/inputs/19/in.md"],
                           "choices": [
                             {
                               "member": 0,
                               "graph": {
-                                "key": "c7703555-a1f4-4547-b8ac-57bedba51646",
+                                "key": "ecb01007-de0e-42aa-9883-0c2d0891660a",
                                 "sequence": [
                                   {
                                     "body": "pip install -U ray",
                                     "language": "shell",
-                                    "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-2"
+                                    "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-2"
                                   }
                                 ]
                               },
@@ -69,14 +72,14 @@
                             {
                               "member": 1,
                               "graph": {
-                                "key": "24f79a38-d86e-4efe-9feb-6c94a228aab3",
+                                "key": "3ead4448-019d-48d2-8779-edc1aecdb27d",
                                 "sequence": [
                                   {
                                     "key": "test/inputs/19/snippets/conda.md",
                                     "title": "Conda: Installation",
                                     "filepath": "test/inputs/19/snippets/conda.md",
                                     "graph": {
-                                      "key": "9efc3fb3-64c0-42d0-b318-ae155163c955",
+                                      "key": "95585f6a-11bb-448f-8434-056ffcfdb063",
                                       "sequence": [
                                         {
                                           "group": "Miniconda####Anaconda",
@@ -87,7 +90,7 @@
                                             {
                                               "member": 0,
                                               "graph": {
-                                                "key": "a84b545d-352f-47c7-afc5-5077c3b8d5af",
+                                                "key": "f0b189ae-25c1-4cd9-8528-fbea16fc264a",
                                                 "sequence": [
                                                   {
                                                     "group": "Windows####MacOS####Linux",
@@ -97,12 +100,12 @@
                                                       {
                                                         "member": 0,
                                                         "graph": {
-                                                          "key": "71ea7135-a824-44da-a17a-6907ee79783d",
+                                                          "key": "b28c2143-387d-4881-afb5-f58514505dce",
                                                           "sequence": [
                                                             {
                                                               "body": "echo windowsfake",
                                                               "language": "shell",
-                                                              "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-3"
+                                                              "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-3"
                                                             }
                                                           ]
                                                         },
@@ -111,7 +114,7 @@
                                                       {
                                                         "member": 1,
                                                         "graph": {
-                                                          "key": "b80cdedd-3798-48b1-a4f9-246e85f04ba7",
+                                                          "key": "a8ff9aaa-7a43-4a33-8c1e-ab46464fd5dd",
                                                           "sequence": [
                                                             {
                                                               "group": "Intel####Apple Silicon",
@@ -121,12 +124,12 @@
                                                                 {
                                                                   "member": 0,
                                                                   "graph": {
-                                                                    "key": "1f554143-7397-43c9-8866-9daa8df4a3d8",
+                                                                    "key": "ae4cf7cf-fa87-4485-af3d-116f2ddd6b5b",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash <(curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh)",
                                                                         "language": "shell",
-                                                                        "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-4"
+                                                                        "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-4"
                                                                       }
                                                                     ]
                                                                   },
@@ -136,12 +139,12 @@
                                                                 {
                                                                   "member": 1,
                                                                   "graph": {
-                                                                    "key": "45775473-ae60-4bf4-81c2-65917a5cef9a",
+                                                                    "key": "517b37b8-870d-4053-9931-a9d4a7382ba3",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash <(curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh)",
                                                                         "language": "shell",
-                                                                        "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-5"
+                                                                        "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-5"
                                                                       }
                                                                     ]
                                                                   },
@@ -157,12 +160,12 @@
                                                       {
                                                         "member": 2,
                                                         "graph": {
-                                                          "key": "15d8cd16-67ac-4fb7-989c-a61a2a3adb6a",
+                                                          "key": "b5646049-ca9a-4696-87f9-6ce29fb3bd8e",
                                                           "sequence": [
                                                             {
                                                               "body": "echo linuxfake",
                                                               "language": "shell",
-                                                              "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-6"
+                                                              "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-6"
                                                             }
                                                           ]
                                                         },
@@ -178,7 +181,7 @@
                                             {
                                               "member": 1,
                                               "graph": {
-                                                "key": "5b3402e9-c49d-4b67-84fe-bf891f18c5c1",
+                                                "key": "a2d3f5b1-10e1-4658-9cc6-e31c11923381",
                                                 "sequence": [
                                                   {
                                                     "group": "Windows####MacOS####Linux",
@@ -188,12 +191,12 @@
                                                       {
                                                         "member": 0,
                                                         "graph": {
-                                                          "key": "abb5fa84-6862-4d5b-92ac-680df54dbcf5",
+                                                          "key": "b9ebf602-2a91-4fac-95d1-adc5579f5767",
                                                           "sequence": [
                                                             {
                                                               "body": "echo windowsfake",
                                                               "language": "shell",
-                                                              "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-7"
+                                                              "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-7"
                                                             }
                                                           ]
                                                         },
@@ -202,12 +205,12 @@
                                                       {
                                                         "member": 1,
                                                         "graph": {
-                                                          "key": "e6d8c25a-9548-4f2d-b3d9-f570c7d540ac",
+                                                          "key": "71f0da03-20b5-464d-8e90-7d66732e7224",
                                                           "sequence": [
                                                             {
                                                               "body": "bash $<(curl -L https://repo.anaconda.com/archive/Anaconda3-2021.11-MacOSX-x86_64.sh)",
                                                               "language": "shell",
-                                                              "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-8"
+                                                              "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-8"
                                                             }
                                                           ]
                                                         },
@@ -216,7 +219,7 @@
                                                       {
                                                         "member": 2,
                                                         "graph": {
-                                                          "key": "bebff51a-ad7c-44aa-8245-79edf8e6f17f",
+                                                          "key": "ecceec09-6304-44cb-866f-9d343c67867d",
                                                           "sequence": [
                                                             {
                                                               "group": "x86####POWER8 and POWER9####AWS Graviton2/ARM64####IBM z/Linux and LinuxONE",
@@ -226,12 +229,12 @@
                                                                 {
                                                                   "member": 0,
                                                                   "graph": {
-                                                                    "key": "9f107b9c-e9c8-4dfa-afb7-56e6e04d3015",
+                                                                    "key": "24d47f71-8c4b-409d-be9d-6db4129c535f",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash $<(curl -L https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-x86_64.sh)",
                                                                         "language": "shell",
-                                                                        "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-9"
+                                                                        "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-9"
                                                                       }
                                                                     ]
                                                                   },
@@ -240,12 +243,12 @@
                                                                 {
                                                                   "member": 1,
                                                                   "graph": {
-                                                                    "key": "68846b77-bc8d-4ff8-af80-ef68d651a02b",
+                                                                    "key": "d56df26a-fff4-42cd-81ab-cd8dddfe3435",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash $<(curl -L https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-ppc64le.sh)",
                                                                         "language": "shell",
-                                                                        "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-10"
+                                                                        "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-10"
                                                                       }
                                                                     ]
                                                                   },
@@ -254,12 +257,12 @@
                                                                 {
                                                                   "member": 2,
                                                                   "graph": {
-                                                                    "key": "288776a5-9169-4204-961a-92c5c2e6c62e",
+                                                                    "key": "b959afdb-78c3-497f-af53-e4a59cb28b44",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash $<(curl -L https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-aarch64.sh)",
                                                                         "language": "shell",
-                                                                        "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-11"
+                                                                        "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-11"
                                                                       }
                                                                     ]
                                                                   },
@@ -268,12 +271,12 @@
                                                                 {
                                                                   "member": 3,
                                                                   "graph": {
-                                                                    "key": "79194a28-3726-4657-9108-a5caf23651ce",
+                                                                    "key": "48c9c1ee-fa45-4381-900e-d4ca5df1d831",
                                                                     "sequence": [
                                                                       {
                                                                         "body": "bash $<(curl -L https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-s390x.sh)",
                                                                         "language": "shell",
-                                                                        "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-12"
+                                                                        "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-12"
                                                                       }
                                                                     ]
                                                                   },
@@ -301,7 +304,7 @@
                                   {
                                     "body": "conda activate\npip uninstall grpcio\nconda install grpcio\npip install ray",
                                     "language": "shell",
-                                    "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-13"
+                                    "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-13"
                                   }
                                 ]
                               },
@@ -324,14 +327,14 @@
         {
           "member": 1,
           "graph": {
-            "key": "65013403-8f16-4e13-bae1-af4f49a69c24",
+            "key": "96126524-55b2-494d-9fb4-ed45eb3a27b1",
             "sequence": [
               {
                 "key": "test/inputs/19/snippets/kubectl.md",
                 "title": "Install kubectl",
                 "filepath": "test/inputs/19/snippets/kubectl.md",
                 "graph": {
-                  "key": "b9b8bd8c-6b79-44a0-84fe-3cdca355b3bc",
+                  "key": "9d163777-8bc6-4b58-a7fc-1d02604f6513",
                   "sequence": [
                     {
                       "group": "Linux####Windows####MacOS",
@@ -342,12 +345,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "0242d785-0d8c-4390-83ab-d79ce3c2f083",
+                            "key": "3d46637f-73e1-46ce-a518-172efe516dc5",
                             "sequence": [
                               {
                                 "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\"",
                                 "language": "bash",
-                                "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-14"
+                                "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-14"
                               }
                             ]
                           },
@@ -357,12 +360,12 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "728e710e-cd21-483e-b0f5-2a19d9da660c",
+                            "key": "4765aa61-f418-40a0-a123-145b47fb637e",
                             "sequence": [
                               {
                                 "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/windows/amd64/kubectl.exe\"",
                                 "language": "bash",
-                                "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-15"
+                                "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-15"
                               }
                             ]
                           },
@@ -372,7 +375,7 @@
                         {
                           "member": 2,
                           "graph": {
-                            "key": "fede5aa9-7398-43c6-83ab-5f11967f71b9",
+                            "key": "037ba6c2-ef20-4706-9a9f-e7929c58495d",
                             "sequence": [
                               {
                                 "group": "Homebrew####curl",
@@ -382,12 +385,12 @@
                                   {
                                     "member": 0,
                                     "graph": {
-                                      "key": "9011c76e-36b8-4ba0-860e-cac3769bf43c",
+                                      "key": "5506a8ed-e590-4d05-b4bb-f2803e0ff6b6",
                                       "sequence": [
                                         {
                                           "body": "brew install kubectl",
                                           "language": "bash",
-                                          "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-16"
+                                          "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-16"
                                         }
                                       ]
                                     },
@@ -397,7 +400,7 @@
                                   {
                                     "member": 1,
                                     "graph": {
-                                      "key": "804a8a3b-b709-4e6c-b908-7694bfacc54e",
+                                      "key": "57d19273-544d-4060-8691-109593a4f979",
                                       "sequence": [
                                         {
                                           "group": "Intel####Apple Silicon",
@@ -407,12 +410,12 @@
                                             {
                                               "member": 0,
                                               "graph": {
-                                                "key": "a3d60b63-6bd5-4b5a-898c-d87e20194b1d",
+                                                "key": "8a75b02a-dd0f-4e02-bc46-67795ebe95cb",
                                                 "sequence": [
                                                   {
                                                     "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256\"",
                                                     "language": "bash",
-                                                    "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-17"
+                                                    "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-17"
                                                   }
                                                 ]
                                               },
@@ -421,12 +424,12 @@
                                             {
                                               "member": 1,
                                               "graph": {
-                                                "key": "fe8e6043-84d0-4473-8af2-28ed1b70d966",
+                                                "key": "b8f20cae-b77a-40d2-84a6-4cdc363357e3",
                                                 "sequence": [
                                                   {
                                                     "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl.sha256\"",
                                                     "language": "bash",
-                                                    "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-18"
+                                                    "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-18"
                                                   }
                                                 ]
                                               },
@@ -439,7 +442,7 @@
                                           "title": "Installing a Specific Version",
                                           "filepath": "",
                                           "graph": {
-                                            "key": "b59bf59b-af84-409c-823e-69b709536a79",
+                                            "key": "c16a4f62-c616-4578-a140-924c0733dca4",
                                             "sequence": [
                                               {
                                                 "group": "Intel####Apple Silicon",
@@ -449,12 +452,12 @@
                                                   {
                                                     "member": 0,
                                                     "graph": {
-                                                      "key": "ea6ed738-117b-4055-8c52-53f4532607aa",
+                                                      "key": "7e640d62-cca4-4207-95bc-95f1103af8a4",
                                                       "sequence": [
                                                         {
                                                           "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/amd64/kubectl\"",
                                                           "language": "bash",
-                                                          "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-19",
+                                                          "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-19",
                                                           "optional": true
                                                         }
                                                       ]
@@ -465,12 +468,12 @@
                                                   {
                                                     "member": 1,
                                                     "graph": {
-                                                      "key": "cd1fb07c-cbf2-4b98-9332-08f7a6116c1f",
+                                                      "key": "163e1a9b-ab4f-4843-ba25-d5a475e10b3f",
                                                       "sequence": [
                                                         {
                                                           "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/arm64/kubectl\"",
                                                           "language": "bash",
-                                                          "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-20",
+                                                          "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-20",
                                                           "optional": true
                                                         }
                                                       ]
@@ -507,7 +510,7 @@
                 "title": "Install Helm",
                 "filepath": "test/inputs/19/snippets/helm3.md",
                 "graph": {
-                  "key": "849ef82a-3cbc-4585-9b73-74144e2e3cfe",
+                  "key": "7a487a6f-d1a0-46b7-90f0-2281c20bedb9",
                   "sequence": [
                     {
                       "group": "MacOS####Linux####Windows",
@@ -518,7 +521,7 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "42cf1939-2418-45d6-8f9b-0ce12b98695a",
+                            "key": "858547b8-79c2-48c2-876e-a8c4cde7c40f",
                             "sequence": [
                               {
                                 "group": "Homebrew####curl",
@@ -528,12 +531,12 @@
                                   {
                                     "member": 0,
                                     "graph": {
-                                      "key": "6487a11f-eded-48c4-8406-a8bca41da56e",
+                                      "key": "ce78a108-2bcb-4420-91bf-f5e715ad7fcc",
                                       "sequence": [
                                         {
                                           "body": "brew install helm",
                                           "language": "shell",
-                                          "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-21"
+                                          "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-21"
                                         }
                                       ]
                                     },
@@ -542,12 +545,12 @@
                                   {
                                     "member": 1,
                                     "graph": {
-                                      "key": "9ad56806-9284-4540-8814-14adf50b74c6",
+                                      "key": "119c9ecf-51af-4055-8d41-4018220fd00d",
                                       "sequence": [
                                         {
                                           "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                           "language": "shell",
-                                          "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-22"
+                                          "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-22"
                                         }
                                       ]
                                     },
@@ -562,12 +565,12 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "42792cb8-5a96-43c4-88cc-f77d66671bb7",
+                            "key": "2a6b0b6b-e29b-4187-a6a4-7cb0da2a52b7",
                             "sequence": [
                               {
                                 "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                 "language": "shell",
-                                "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-23"
+                                "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-23"
                               }
                             ]
                           },
@@ -576,12 +579,12 @@
                         {
                           "member": 2,
                           "graph": {
-                            "key": "2d59622e-4e3b-4ea5-a7ea-9ecd1182bf21",
+                            "key": "31e0db3c-1d77-49fd-91a5-9f38d81d630f",
                             "sequence": [
                               {
                                 "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                 "language": "shell",
-                                "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-24"
+                                "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-24"
                               }
                             ]
                           },
@@ -596,7 +599,7 @@
               {
                 "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
                 "language": "shell",
-                "id": "d9fb6474-6dc6-40c0-b46b-fa9d8f1fdf67-25"
+                "id": "c285e064-84fe-4ea6-9598-c9eba602f7ec-25"
               }
             ]
           },

--- a/test/inputs/2/wizard-noaprioris.json
+++ b/test/inputs/2/wizard-noaprioris.json
@@ -7,12 +7,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "7e128a35-70a5-4b99-9004-a7f7f3955b3e",
+            "key": "de9f7078-1a35-4995-adb8-695e9f2ef654",
             "sequence": [
               {
                 "body": "echo 111",
                 "language": "bash",
-                "id": "97bea28f-8b6b-447f-a795-de5e3a575f6c-0"
+                "id": "2073c164-30d1-4fb1-b31c-64261ebfec2e-0"
               }
             ]
           },
@@ -22,12 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "8d40654a-b848-45ba-8f80-b72aef998a45",
+            "key": "2387256e-f705-418c-ad38-6cefc3683f5d",
             "sequence": [
               {
                 "body": "echo 222",
                 "language": "bash",
-                "id": "97bea28f-8b6b-447f-a795-de5e3a575f6c-1"
+                "id": "2073c164-30d1-4fb1-b31c-64261ebfec2e-1"
               }
             ]
           },

--- a/test/inputs/2/wizard-noopt.json
+++ b/test/inputs/2/wizard-noopt.json
@@ -7,12 +7,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "3ae6be80-94fc-453e-bcfa-03b7b8157d67",
+            "key": "1582025c-cc48-4611-9ba9-5118b979e640",
             "sequence": [
               {
                 "body": "echo 111",
                 "language": "bash",
-                "id": "39ed9976-4f36-4a62-bcb6-92dde16f0bf3-0"
+                "id": "19e93772-2d1d-4a63-b20a-45b7e359d675-0"
               }
             ]
           },
@@ -22,12 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "290d6616-2876-4c2f-a8e3-4bf404d6b8e4",
+            "key": "77ebb6a3-8e28-482e-a2b3-f5840aefe699",
             "sequence": [
               {
                 "body": "echo 222",
                 "language": "bash",
-                "id": "39ed9976-4f36-4a62-bcb6-92dde16f0bf3-1"
+                "id": "19e93772-2d1d-4a63-b20a-45b7e359d675-1"
               }
             ]
           },

--- a/test/inputs/20/wizard-noaprioris.json
+++ b/test/inputs/20/wizard-noaprioris.json
@@ -5,12 +5,12 @@
       "title": "b.md",
       "filepath": "",
       "graph": {
-        "key": "5836d878-159f-4dbf-9f76-dc20e9679ef5",
+        "key": "97f83b92-03be-4dcd-bef0-1756600a4e18",
         "sequence": [
           {
             "body": "echo BBB",
             "language": "shell",
-            "id": "d4ac71ef-86ca-48dc-b662-be942a1dd8cc-2"
+            "id": "827fcf59-f458-41bc-b166-bee3a24c7eb4-2"
           }
         ]
       },
@@ -27,12 +27,12 @@
       "title": "a.md",
       "filepath": "",
       "graph": {
-        "key": "bfd8b75d-9b51-458e-91cb-758bba297621",
+        "key": "cba2f114-4b00-4946-bb14-f4429f41c43f",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "shell",
-            "id": "d4ac71ef-86ca-48dc-b662-be942a1dd8cc-0"
+            "id": "827fcf59-f458-41bc-b166-bee3a24c7eb4-0"
           }
         ]
       },
@@ -48,31 +48,33 @@
       "group": "Tab1",
       "title": "Conditional Inline of Imports",
       "source": "placeholder",
+      "provenance": ["test/inputs/20/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "d4ad6dd5-d1e8-42f2-8a90-720d3684157e",
+            "key": "a7384f69-1c33-4952-b6c3-257db19e752b",
             "sequence": [
               {
                 "body": "echo III",
                 "language": "shell",
-                "id": "d4ac71ef-86ca-48dc-b662-be942a1dd8cc-1"
+                "id": "827fcf59-f458-41bc-b166-bee3a24c7eb4-1"
               },
               {
                 "group": "ITab1",
                 "title": "Tab1",
                 "source": "placeholder",
+                "provenance": ["test/inputs/20/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "8552ba93-95a1-425d-b808-f9d0916ea17d",
+                      "key": "190f567f-cb55-48ca-89fd-3fff8d201a88",
                       "sequence": [
                         {
                           "body": "echo III2",
                           "language": "shell",
-                          "id": "d4ac71ef-86ca-48dc-b662-be942a1dd8cc-3"
+                          "id": "827fcf59-f458-41bc-b166-bee3a24c7eb4-3"
                         }
                       ]
                     },

--- a/test/inputs/20/wizard-noopt.json
+++ b/test/inputs/20/wizard-noopt.json
@@ -4,23 +4,24 @@
       "group": "Tab1",
       "title": "Conditional Inline of Imports",
       "source": "placeholder",
+      "provenance": ["test/inputs/20/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "fee7ea1a-67fe-4c64-ae8a-876cd066cb8b",
+            "key": "5067e5aa-348a-4dd5-9daf-cbcb1f1fb582",
             "sequence": [
               {
                 "key": "test/inputs/20/snippets/a.md",
                 "title": "a.md",
                 "filepath": "test/inputs/20/snippets/a.md",
                 "graph": {
-                  "key": "3f704e57-e4fd-4abd-8927-9e6a0bb6d096",
+                  "key": "3d9a228d-636f-4e2d-a61e-c12a6a044b9f",
                   "sequence": [
                     {
                       "body": "echo AAA",
                       "language": "shell",
-                      "id": "9146a74f-24c1-49aa-8f3d-fbba92f52c58-0"
+                      "id": "96eff1ba-6616-4d6f-9335-06d1ec48aee7-0"
                     }
                   ]
                 },
@@ -29,28 +30,29 @@
               {
                 "body": "echo III",
                 "language": "shell",
-                "id": "9146a74f-24c1-49aa-8f3d-fbba92f52c58-1"
+                "id": "96eff1ba-6616-4d6f-9335-06d1ec48aee7-1"
               },
               {
                 "group": "ITab1",
                 "source": "placeholder",
+                "provenance": ["test/inputs/20/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "7739f57b-4d25-419f-93c8-706dcd244338",
+                      "key": "98cf8474-5b01-4142-ac39-48d4de39ebbf",
                       "sequence": [
                         {
                           "key": "test/inputs/20/snippets/b.md",
                           "title": "b.md",
                           "filepath": "test/inputs/20/snippets/b.md",
                           "graph": {
-                            "key": "f23b9863-cede-471c-82b8-6a538a836724",
+                            "key": "e9f06eb8-e6fa-4975-8c00-23272c60c94b",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "shell",
-                                "id": "9146a74f-24c1-49aa-8f3d-fbba92f52c58-2"
+                                "id": "96eff1ba-6616-4d6f-9335-06d1ec48aee7-2"
                               }
                             ]
                           },
@@ -59,7 +61,7 @@
                         {
                           "body": "echo III2",
                           "language": "shell",
-                          "id": "9146a74f-24c1-49aa-8f3d-fbba92f52c58-3"
+                          "id": "96eff1ba-6616-4d6f-9335-06d1ec48aee7-3"
                         }
                       ]
                     },

--- a/test/inputs/20/wizard.json
+++ b/test/inputs/20/wizard.json
@@ -5,12 +5,12 @@
       "title": "b.md",
       "filepath": "",
       "graph": {
-        "key": "44a5512b-1c9f-4cbc-9cfd-e9d82dd8215b",
+        "key": "a1702973-c95b-4d92-aa7f-de248fcdf466",
         "sequence": [
           {
             "body": "echo BBB",
             "language": "shell",
-            "id": "57f95e88-a93a-45af-a71f-beaf7a542fcc-2"
+            "id": "77b7223e-50e5-4067-9966-378279c8a4fc-2"
           }
         ]
       },
@@ -27,12 +27,12 @@
       "title": "a.md",
       "filepath": "",
       "graph": {
-        "key": "1128660c-3d6b-4f0d-83db-497fed446e65",
+        "key": "0bdb5e8b-c278-4734-ba8b-5f1fb53dac7d",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "shell",
-            "id": "57f95e88-a93a-45af-a71f-beaf7a542fcc-0"
+            "id": "77b7223e-50e5-4067-9966-378279c8a4fc-0"
           }
         ]
       },
@@ -48,31 +48,33 @@
       "group": "Tab1",
       "title": "Conditional Inline of Imports",
       "source": "placeholder",
+      "provenance": ["test/inputs/20/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "300ffc62-0d23-4a1a-abed-2c093ba9f96e",
+            "key": "0dc6712b-aa0b-48d0-88e5-799d5f29c9da",
             "sequence": [
               {
                 "body": "echo III",
                 "language": "shell",
-                "id": "57f95e88-a93a-45af-a71f-beaf7a542fcc-1"
+                "id": "77b7223e-50e5-4067-9966-378279c8a4fc-1"
               },
               {
                 "group": "ITab1",
                 "title": "Tab1",
                 "source": "placeholder",
+                "provenance": ["test/inputs/20/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "cc8740fb-7995-4588-88c1-cbe914766bb9",
+                      "key": "72be20c0-f93e-4746-ba98-6a5ff10a14f7",
                       "sequence": [
                         {
                           "body": "echo III2",
                           "language": "shell",
-                          "id": "57f95e88-a93a-45af-a71f-beaf7a542fcc-3"
+                          "id": "77b7223e-50e5-4067-9966-378279c8a4fc-3"
                         }
                       ]
                     },

--- a/test/inputs/21/wizard-noaprioris.json
+++ b/test/inputs/21/wizard-noaprioris.json
@@ -6,12 +6,12 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "0fa70281-8c7e-43d7-9ed5-2b841c560581",
+        "key": "888df101-a66e-42ad-840d-57b7ab6d576d",
         "sequence": [
           {
             "body": "export FOO=3",
             "language": "shell",
-            "id": "4a171327-4e3d-425d-9077-361f77be9ed3-0"
+            "id": "61840c40-5fb6-4473-a052-bf8fd4a83cea-0"
           }
         ]
       },
@@ -30,12 +30,12 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "d4ba77d5-9530-470e-a88e-0d92a0e0de8b",
+        "key": "1f4af032-1f09-4cb1-867c-31f321619a1a",
         "sequence": [
           {
             "body": "export FOO=2:$FOO",
             "language": "shell",
-            "id": "4a171327-4e3d-425d-9077-361f77be9ed3-1"
+            "id": "61840c40-5fb6-4473-a052-bf8fd4a83cea-1"
           }
         ]
       },
@@ -54,12 +54,12 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "1414650c-c8b9-4006-b2de-f2c5b47e1276",
+        "key": "6ba2d54f-9be8-408c-ad51-d1c3a00b46ba",
         "sequence": [
           {
             "body": "echo \"This should be 2:3 --> $FOO\"",
             "language": "shell",
-            "id": "4a171327-4e3d-425d-9077-361f77be9ed3-2"
+            "id": "61840c40-5fb6-4473-a052-bf8fd4a83cea-2"
           }
         ]
       },
@@ -78,13 +78,13 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "affe0528-76bb-4820-a7e8-b8c81f16aa01",
+        "key": "443a7d67-e391-48a3-bcfe-0c1f1b22b17a",
         "sequence": [
           {
             "body": "echo \"Bug if we get here\"",
             "language": "shell",
             "validate": "[ \"$FOO\" = \"2:3\" ]",
-            "id": "4a171327-4e3d-425d-9077-361f77be9ed3-3"
+            "id": "61840c40-5fb6-4473-a052-bf8fd4a83cea-3"
           }
         ]
       },

--- a/test/inputs/21/wizard-noopt.json
+++ b/test/inputs/21/wizard-noopt.json
@@ -6,12 +6,12 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "9d893cd4-752b-4fd3-bb8b-ff62c12e8807",
+        "key": "b449b280-e5b5-4252-a0c7-5e9fb57fb29a",
         "sequence": [
           {
             "body": "export FOO=3",
             "language": "shell",
-            "id": "9fe8ad4b-ef8a-43c2-bf58-6bce9d93f1c8-0"
+            "id": "ed3186e1-c299-47fc-be07-9d8e95977daf-0"
           }
         ]
       },
@@ -30,12 +30,12 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "0d689580-249f-44f6-8451-0f65951fc3ed",
+        "key": "0e400542-0efc-4ad4-8deb-e1f25469bd52",
         "sequence": [
           {
             "body": "export FOO=2:$FOO",
             "language": "shell",
-            "id": "9fe8ad4b-ef8a-43c2-bf58-6bce9d93f1c8-1"
+            "id": "ed3186e1-c299-47fc-be07-9d8e95977daf-1"
           }
         ]
       },
@@ -54,12 +54,12 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "07e4db75-329e-49b8-82b0-e7c66798ce85",
+        "key": "52863da8-a257-40dc-9f5a-38674fe56fb1",
         "sequence": [
           {
             "body": "echo \"This should be 2:3 --> $FOO\"",
             "language": "shell",
-            "id": "9fe8ad4b-ef8a-43c2-bf58-6bce9d93f1c8-2"
+            "id": "ed3186e1-c299-47fc-be07-9d8e95977daf-2"
           }
         ]
       },
@@ -78,13 +78,13 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "447c9c16-d00a-4f00-93d2-acfb74b5900f",
+        "key": "28101543-c279-4c5d-8365-5ba7c332b238",
         "sequence": [
           {
             "body": "echo \"Bug if we get here\"",
             "language": "shell",
             "validate": "[ \"$FOO\" = \"2:3\" ]",
-            "id": "9fe8ad4b-ef8a-43c2-bf58-6bce9d93f1c8-3"
+            "id": "ed3186e1-c299-47fc-be07-9d8e95977daf-3"
           }
         ]
       },

--- a/test/inputs/21/wizard.json
+++ b/test/inputs/21/wizard.json
@@ -6,12 +6,12 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "16931bc0-5adf-4bd6-b7b6-35f0f72921c2",
+        "key": "9c9d27c3-49bb-40a6-b3dd-ee1e73b91bfa",
         "sequence": [
           {
             "body": "export FOO=3",
             "language": "shell",
-            "id": "b1fdf4e3-e97e-42f2-8f6c-3462beac6935-0"
+            "id": "c09c11a0-eace-4c2d-a86d-d79eddf2d2cf-0"
           }
         ]
       },
@@ -30,12 +30,12 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "ca3bc9ff-a7af-4c3f-bb87-1dba453e65e4",
+        "key": "b8d113b8-5b1c-4417-99a8-72b82f3c4857",
         "sequence": [
           {
             "body": "export FOO=2:$FOO",
             "language": "shell",
-            "id": "b1fdf4e3-e97e-42f2-8f6c-3462beac6935-1"
+            "id": "c09c11a0-eace-4c2d-a86d-d79eddf2d2cf-1"
           }
         ]
       },
@@ -54,12 +54,12 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "ee715524-17fb-4c4b-bf80-fd1e19c3f2cf",
+        "key": "021997c6-37da-43d9-9afa-50e35ea947a9",
         "sequence": [
           {
             "body": "echo \"This should be 2:3 --> $FOO\"",
             "language": "shell",
-            "id": "b1fdf4e3-e97e-42f2-8f6c-3462beac6935-2"
+            "id": "c09c11a0-eace-4c2d-a86d-d79eddf2d2cf-2"
           }
         ]
       },
@@ -78,13 +78,13 @@
       "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
       "filepath": "",
       "graph": {
-        "key": "89292f4f-0219-435e-80f3-61c9ba40ab7e",
+        "key": "59f3acf2-cfca-447d-aeba-f2b714c6bfb9",
         "sequence": [
           {
             "body": "echo \"Bug if we get here\"",
             "language": "shell",
             "validate": "[ \"$FOO\" = \"2:3\" ]",
-            "id": "b1fdf4e3-e97e-42f2-8f6c-3462beac6935-3"
+            "id": "c09c11a0-eace-4c2d-a86d-d79eddf2d2cf-3"
           }
         ]
       },

--- a/test/inputs/22/wizard-noaprioris.json
+++ b/test/inputs/22/wizard-noaprioris.json
@@ -3,7 +3,7 @@
     "graph": {
       "body": "print(\"PPP\")",
       "language": "python",
-      "id": "7e4e8e07-56bd-49dd-bfb3-9bf1d5fa632a-0"
+      "id": "2efe5433-70f6-402d-901e-138ff3fbfc11-0"
     },
     "step": {
       "content": "```python\nprint(\"PPP\")\n```"

--- a/test/inputs/22/wizard-noopt.json
+++ b/test/inputs/22/wizard-noopt.json
@@ -3,7 +3,7 @@
     "graph": {
       "body": "print(\"PPP\")",
       "language": "python",
-      "id": "f90030ce-6b27-4989-b38c-603b90eb6ac3-0"
+      "id": "61850d22-d82a-4472-9e36-2e82f45a16bf-0"
     },
     "step": {
       "content": "```python\nprint(\"PPP\")\n```"

--- a/test/inputs/22/wizard.json
+++ b/test/inputs/22/wizard.json
@@ -3,7 +3,7 @@
     "graph": {
       "body": "print(\"PPP\")",
       "language": "python",
-      "id": "b742d971-bcfa-43bb-be93-e1743986f58a-0"
+      "id": "29f33b65-7144-4bbb-aa81-0356898de1c0-0"
     },
     "step": {
       "content": "```python\nprint(\"PPP\")\n```"

--- a/test/inputs/23/wizard-darwin.json
+++ b/test/inputs/23/wizard-darwin.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "5e4d5677-e949-4c82-b572-b2f7749c5206",
+            "key": "2e9b795c-f6a5-4d97-b477-0cb91c19cfdc",
             "sequence": [
               {
                 "body": "pip install -U ray",
                 "language": "shell",
-                "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-0"
+                "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-0"
               }
             ]
           },
@@ -24,26 +24,26 @@
         {
           "member": 1,
           "graph": {
-            "key": "89d02be4-fb26-45df-a035-a66803ec5f95",
+            "key": "57dda5ae-9773-4ba4-a6ad-58bb00f9e96b",
             "sequence": [
               {
                 "key": "test/inputs/23/kubernetes/kubectl.md",
                 "title": "Install kubectl",
                 "filepath": "test/inputs/23/kubernetes/kubectl.md",
                 "graph": {
-                  "key": "f84c2e33-3dfe-4c4e-ba3b-a32d317da2c5",
+                  "key": "08d96af8-18b6-46cf-9871-7daa2d50e009",
                   "sequence": [
                     {
                       "key": "org.kubernetes-sigs.kui/choice/platform",
                       "title": "Install kubectl",
                       "filepath": "",
                       "graph": {
-                        "key": "178b0fb4-b9b4-4fc2-b2ce-2d3e9c7c4090",
+                        "key": "7b84b5a8-7a01-48a6-92ed-4697b7f5805f",
                         "sequence": [
                           {
                             "body": "brew install kubectl",
                             "language": "bash",
-                            "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-14"
+                            "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-14"
                           }
                         ]
                       },
@@ -58,19 +58,19 @@
                 "title": "Install Helm v3",
                 "filepath": "test/inputs/23/kubernetes/helm3.md",
                 "graph": {
-                  "key": "a99c24ed-d83e-4066-81e7-8e73c8fc1476",
+                  "key": "d3cbdb55-6493-4563-8f91-bc96c7a0fae1",
                   "sequence": [
                     {
                       "key": "org.kubernetes-sigs.kui/choice/platform",
                       "title": "Install Helm v3",
                       "filepath": "",
                       "graph": {
-                        "key": "b947e513-ec94-423c-8c42-9217c7c9d6d7",
+                        "key": "31960d59-a421-4332-aed7-2e0a90677dbb",
                         "sequence": [
                           {
                             "body": "brew install helm",
                             "language": "shell",
-                            "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-18"
+                            "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-18"
                           }
                         ]
                       },
@@ -85,26 +85,26 @@
                 "title": "Choose a Kubernetes context",
                 "filepath": "test/inputs/23/kubernetes/context.md",
                 "graph": {
-                  "key": "ba09f616-13fa-4e15-8165-3cba0e155063",
+                  "key": "8cd552ee-26c6-4f38-b807-e88e013fa03c",
                   "sequence": [
                     {
                       "key": "test/inputs/23/kubernetes/kubectl.md",
                       "title": "Install kubectl",
                       "filepath": "test/inputs/23/kubernetes/kubectl.md",
                       "graph": {
-                        "key": "9ed29527-0ee9-4277-9cba-d91001a83f74",
+                        "key": "0408a6d4-9278-4fb5-afbb-0d3eef0240c0",
                         "sequence": [
                           {
                             "key": "org.kubernetes-sigs.kui/choice/platform",
                             "title": "Install kubectl",
                             "filepath": "",
                             "graph": {
-                              "key": "3015470a-ab4d-4857-a6a4-61fd578aea2e",
+                              "key": "1d0832bc-9e57-4483-9484-a2ad23bdde59",
                               "sequence": [
                                 {
                                   "body": "brew install kubectl",
                                   "language": "bash",
-                                  "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-24"
+                                  "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-24"
                                 }
                               ]
                             },
@@ -123,12 +123,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "d488724e-b6d0-4fd1-8cc6-7df18c8f56e7",
+                            "key": "0ad07e4a-3ad5-4cea-a9a3-f843784e52f5",
                             "sequence": [
                               {
                                 "body": "kubectl config set-context \"\"",
                                 "language": "shell",
-                                "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-28"
+                                "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-28"
                               }
                             ]
                           },
@@ -143,7 +143,7 @@
               {
                 "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
                 "language": "shell",
-                "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-29"
+                "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-29"
               }
             ]
           },
@@ -178,16 +178,17 @@
       "group": "Example: Using Ray Tasks to Parallelize a Function####Example: Using Ray Actors to Parallelize a Class####Example: Creating and Transforming Datasets",
       "title": "Run a Ray Job",
       "source": "placeholder",
+      "provenance": ["test/inputs/23/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "552a9f15-666b-42ad-b157-87c012fddd6d",
+            "key": "a5054153-86cc-4582-905f-767e95f156a2",
             "sequence": [
               {
                 "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
                 "language": "python",
-                "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-30"
+                "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-30"
               }
             ]
           },
@@ -197,12 +198,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "33a2c733-32c0-4aea-8d77-11394b16e7ba",
+            "key": "991ae92a-5083-468a-bc9f-aef4726a56c3",
             "sequence": [
               {
                 "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
                 "language": "python",
-                "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-31"
+                "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-31"
               }
             ]
           },
@@ -212,33 +213,33 @@
         {
           "member": 2,
           "graph": {
-            "key": "c5f6403b-5f4d-4885-9357-8128f3c07c37",
+            "key": "461ec3dc-bbd2-4a93-baea-7ab525146ba2",
             "sequence": [
               {
                 "key": "Creating and Transforming Datasets",
                 "title": "Creating and Transforming Datasets",
                 "filepath": "",
                 "graph": {
-                  "key": "af948c6b-60f4-49f0-b033-566de658f292",
+                  "key": "4188b9f5-9092-4367-855f-6398243b076b",
                   "sequence": [
                     {
                       "key": "Prerequisites",
                       "title": "Prerequisites",
                       "filepath": "",
                       "graph": {
-                        "key": "56769328-b844-49c1-bb49-9e9ad39bd291",
+                        "key": "70410393-2e01-4c3b-bf58-182558fb3ba6",
                         "sequence": [
                           {
                             "key": "test/inputs/23/data.md",
                             "title": "Install Ray Data",
                             "filepath": "test/inputs/23/data.md",
                             "graph": {
-                              "key": "eb9dcdab-4567-4e68-9e0c-3e8e4cf491ab",
+                              "key": "cac4a339-7ca1-4837-ba38-c98ce671ef8f",
                               "sequence": [
                                 {
                                   "body": "pip install \"ray[data]\" dask",
                                   "language": "shell",
-                                  "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-32"
+                                  "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-32"
                                 }
                               ]
                             },
@@ -253,22 +254,23 @@
                       "title": "Main Tasks",
                       "filepath": "",
                       "graph": {
-                        "key": "746cc211-0f54-48f9-af60-c727025078df",
+                        "key": "ddf7a7a4-869f-4904-bbcf-f21bd182fd10",
                         "sequence": [
                           {
                             "group": "New Dataset from Range####New Dataset from File",
                             "title": "Main Tasks",
                             "source": "placeholder",
+                            "provenance": ["test/inputs/23/in.md"],
                             "choices": [
                               {
                                 "member": 0,
                                 "graph": {
-                                  "key": "9e498580-95f0-4e52-89e7-f7dad0b1b929",
+                                  "key": "ee357876-75eb-4d84-9a84-c7d7e2b63170",
                                   "sequence": [
                                     {
                                       "body": "import ray\n\n# Create a Dataset of Python objects.\nds = ray.data.range(10000)\n# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)\n\nds.take(5)\n# -> [0, 1, 2, 3, 4]\n\nds.count()\n# -> 10000\n\n# Create a Dataset of Arrow records.\nds = ray.data.from_items([{\"col1\": i, \"col2\": str(i)} for i in range(10000)])\n# -> Dataset(num_blocks=200, num_rows=10000, schema={col1: int64, col2: string})\n\nds.show(5)\n# -> {'col1': 0, 'col2': '0'}\n# -> {'col1': 1, 'col2': '1'}\n# -> {'col1': 2, 'col2': '2'}\n# -> {'col1': 3, 'col2': '3'}\n# -> {'col1': 4, 'col2': '4'}\n\nds.schema()\n# -> col1: int64\n# -> col2: string",
                                       "language": "python",
-                                      "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-33"
+                                      "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-33"
                                     }
                                   ]
                                 },
@@ -278,12 +280,12 @@
                               {
                                 "member": 1,
                                 "graph": {
-                                  "key": "0724930a-98d2-4f0c-a49b-d565a27c6fe3",
+                                  "key": "77739ee1-c741-493a-9225-daba79ebd037",
                                   "sequence": [
                                     {
                                       "body": "import ray\nimport pandas as pd\nimport dask.dataframe as dd\n\n# Create a Dataset from a list of Pandas DataFrame objects.\npdf = pd.DataFrame({\"one\": [1, 2, 3], \"two\": [\"a\", \"b\", \"c\"]})\nds = ray.data.from_pandas([pdf])\n\n# Create a Dataset from a Dask-on-Ray DataFrame.\ndask_df = dd.from_pandas(pdf, npartitions=10)\nds = ray.data.from_dask(dask_df)\n\n# Transform the dataset using .map()\nds = ray.data.range(10000)\nds = ds.map(lambda x: x * 2)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1123.54it/s]\n# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)\nds.take(5)\n# -> [0, 2, 4, 6, 8]\n\n# Transform the dataset using .filter()\nds.filter(lambda x: x > 5).take(5)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1859.63it/s]\n# -> [6, 8, 10, 12, 14]\n\n# Transform the dataset using .flat_map()\nds.flat_map(lambda x: [x, -x]).take(5)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1568.10it/s]\n# -> [0, 0, 2, -2, 4]",
                                       "language": "python",
-                                      "id": "94f3eb3e-3a5b-4a90-b6ab-4961d1b6c99c-34"
+                                      "id": "6a63a108-b5fe-4f5b-921d-1141d4678c07-34"
                                     }
                                   ]
                                 },

--- a/test/inputs/23/wizard-linux.json
+++ b/test/inputs/23/wizard-linux.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "e98cc3ad-2ae1-4c25-84d6-a9bba3410feb",
+            "key": "fdc74a88-7693-4e5d-8522-c51473c5c97c",
             "sequence": [
               {
                 "body": "pip install -U ray",
                 "language": "shell",
-                "id": "452091e0-c95f-4466-a53e-050b006caad6-0"
+                "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-0"
               }
             ]
           },
@@ -24,26 +24,26 @@
         {
           "member": 1,
           "graph": {
-            "key": "fa544aae-0957-45bb-8388-5f1157650d15",
+            "key": "1a72c4d0-1dea-47ea-9d98-121d2c711968",
             "sequence": [
               {
                 "key": "test/inputs/23/kubernetes/kubectl.md",
                 "title": "Install kubectl",
                 "filepath": "test/inputs/23/kubernetes/kubectl.md",
                 "graph": {
-                  "key": "abe45d33-b6cc-4041-92a8-f283b75e7e11",
+                  "key": "3b05eb2f-653d-438d-bd14-7a468cba3bf0",
                   "sequence": [
                     {
                       "key": "org.kubernetes-sigs.kui/choice/platform",
                       "title": "Install kubectl",
                       "filepath": "",
                       "graph": {
-                        "key": "afdc368a-95ce-4053-bb12-555cf52de804",
+                        "key": "dcd43c84-5104-44c4-abe1-145718c07c24",
                         "sequence": [
                           {
                             "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\"",
                             "language": "bash",
-                            "id": "452091e0-c95f-4466-a53e-050b006caad6-12"
+                            "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-12"
                           }
                         ]
                       },
@@ -58,19 +58,19 @@
                 "title": "Install Helm v3",
                 "filepath": "test/inputs/23/kubernetes/helm3.md",
                 "graph": {
-                  "key": "ce55b636-076b-49b5-8c9e-15b5023f2b34",
+                  "key": "1cb62503-002b-4775-a7bd-8477a1da5fb7",
                   "sequence": [
                     {
                       "key": "org.kubernetes-sigs.kui/choice/platform",
                       "title": "Install Helm v3",
                       "filepath": "",
                       "graph": {
-                        "key": "626dce6f-6ca5-4a64-9a50-f086a30c73ee",
+                        "key": "595f33cc-4062-47ab-b902-704b4cf2f022",
                         "sequence": [
                           {
                             "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                             "language": "shell",
-                            "id": "452091e0-c95f-4466-a53e-050b006caad6-20"
+                            "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-20"
                           }
                         ]
                       },
@@ -85,26 +85,26 @@
                 "title": "Choose a Kubernetes context",
                 "filepath": "test/inputs/23/kubernetes/context.md",
                 "graph": {
-                  "key": "32f57b08-d8ac-47ef-a84a-caa3a2ba123a",
+                  "key": "82002b14-4fa1-4625-ae48-a0ee5b87a6f7",
                   "sequence": [
                     {
                       "key": "test/inputs/23/kubernetes/kubectl.md",
                       "title": "Install kubectl",
                       "filepath": "test/inputs/23/kubernetes/kubectl.md",
                       "graph": {
-                        "key": "aa412a1c-ed0d-409e-b35a-6c165434e870",
+                        "key": "bf578506-baff-4c7f-814d-0b8b8a85682e",
                         "sequence": [
                           {
                             "key": "org.kubernetes-sigs.kui/choice/platform",
                             "title": "Install kubectl",
                             "filepath": "",
                             "graph": {
-                              "key": "0660442c-6795-40fa-8aef-d71920d2c646",
+                              "key": "6af09a53-dcd3-4c2b-b239-5e3794902a62",
                               "sequence": [
                                 {
                                   "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\"",
                                   "language": "bash",
-                                  "id": "452091e0-c95f-4466-a53e-050b006caad6-22"
+                                  "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-22"
                                 }
                               ]
                             },
@@ -123,12 +123,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "5b4ba918-2e2c-408b-bc63-bc89b2e73f68",
+                            "key": "f13d1765-0e43-456d-9f9c-1a15528d7cd1",
                             "sequence": [
                               {
                                 "body": "kubectl config set-context \"\"",
                                 "language": "shell",
-                                "id": "452091e0-c95f-4466-a53e-050b006caad6-28"
+                                "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-28"
                               }
                             ]
                           },
@@ -143,7 +143,7 @@
               {
                 "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
                 "language": "shell",
-                "id": "452091e0-c95f-4466-a53e-050b006caad6-29"
+                "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-29"
               }
             ]
           },
@@ -178,16 +178,17 @@
       "group": "Example: Using Ray Tasks to Parallelize a Function####Example: Using Ray Actors to Parallelize a Class####Example: Creating and Transforming Datasets",
       "title": "Run a Ray Job",
       "source": "placeholder",
+      "provenance": ["test/inputs/23/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "d601a326-7951-4155-b60c-953f53086c45",
+            "key": "9f1e21be-f734-45e7-b174-b92e5ef6adf4",
             "sequence": [
               {
                 "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
                 "language": "python",
-                "id": "452091e0-c95f-4466-a53e-050b006caad6-30"
+                "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-30"
               }
             ]
           },
@@ -197,12 +198,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "60ade020-cd11-4906-9a5a-d8b14980cc2b",
+            "key": "684f5555-18db-4652-b470-c049e0627964",
             "sequence": [
               {
                 "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
                 "language": "python",
-                "id": "452091e0-c95f-4466-a53e-050b006caad6-31"
+                "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-31"
               }
             ]
           },
@@ -212,33 +213,33 @@
         {
           "member": 2,
           "graph": {
-            "key": "947af661-55e7-4fb3-8e1f-a0a5c4321187",
+            "key": "c5a85844-8aa7-4a9b-8deb-a1c03d9b919b",
             "sequence": [
               {
                 "key": "Creating and Transforming Datasets",
                 "title": "Creating and Transforming Datasets",
                 "filepath": "",
                 "graph": {
-                  "key": "d3459887-8714-4ae7-a9ac-86cc0da75cba",
+                  "key": "3cd8c79d-fb6c-451a-b7cc-f023f0ae9c94",
                   "sequence": [
                     {
                       "key": "Prerequisites",
                       "title": "Prerequisites",
                       "filepath": "",
                       "graph": {
-                        "key": "9adb0e9e-7b79-47b7-9f3d-d50646d4d394",
+                        "key": "7f97bbb4-354c-4e09-85d0-dd5238fd6490",
                         "sequence": [
                           {
                             "key": "test/inputs/23/data.md",
                             "title": "Install Ray Data",
                             "filepath": "test/inputs/23/data.md",
                             "graph": {
-                              "key": "f92cfca4-7e1c-4097-8148-d2e6a34dfba5",
+                              "key": "4def2654-8977-4fa6-9152-df4228912b6d",
                               "sequence": [
                                 {
                                   "body": "pip install \"ray[data]\" dask",
                                   "language": "shell",
-                                  "id": "452091e0-c95f-4466-a53e-050b006caad6-32"
+                                  "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-32"
                                 }
                               ]
                             },
@@ -253,22 +254,23 @@
                       "title": "Main Tasks",
                       "filepath": "",
                       "graph": {
-                        "key": "32dfa4a8-6ca0-4386-89a4-74e70babeb0a",
+                        "key": "4f09c081-4eae-4e9b-a174-07c8580dd17d",
                         "sequence": [
                           {
                             "group": "New Dataset from Range####New Dataset from File",
                             "title": "Main Tasks",
                             "source": "placeholder",
+                            "provenance": ["test/inputs/23/in.md"],
                             "choices": [
                               {
                                 "member": 0,
                                 "graph": {
-                                  "key": "4c0470f2-5ee6-4482-a8ba-bc296e9ff29c",
+                                  "key": "0c89db90-f955-4ebe-9887-a3289edad7b9",
                                   "sequence": [
                                     {
                                       "body": "import ray\n\n# Create a Dataset of Python objects.\nds = ray.data.range(10000)\n# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)\n\nds.take(5)\n# -> [0, 1, 2, 3, 4]\n\nds.count()\n# -> 10000\n\n# Create a Dataset of Arrow records.\nds = ray.data.from_items([{\"col1\": i, \"col2\": str(i)} for i in range(10000)])\n# -> Dataset(num_blocks=200, num_rows=10000, schema={col1: int64, col2: string})\n\nds.show(5)\n# -> {'col1': 0, 'col2': '0'}\n# -> {'col1': 1, 'col2': '1'}\n# -> {'col1': 2, 'col2': '2'}\n# -> {'col1': 3, 'col2': '3'}\n# -> {'col1': 4, 'col2': '4'}\n\nds.schema()\n# -> col1: int64\n# -> col2: string",
                                       "language": "python",
-                                      "id": "452091e0-c95f-4466-a53e-050b006caad6-33"
+                                      "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-33"
                                     }
                                   ]
                                 },
@@ -278,12 +280,12 @@
                               {
                                 "member": 1,
                                 "graph": {
-                                  "key": "21dc4318-b189-450a-8a63-834d728066f1",
+                                  "key": "b7a93884-b72f-48cb-a11c-37e88a90a64f",
                                   "sequence": [
                                     {
                                       "body": "import ray\nimport pandas as pd\nimport dask.dataframe as dd\n\n# Create a Dataset from a list of Pandas DataFrame objects.\npdf = pd.DataFrame({\"one\": [1, 2, 3], \"two\": [\"a\", \"b\", \"c\"]})\nds = ray.data.from_pandas([pdf])\n\n# Create a Dataset from a Dask-on-Ray DataFrame.\ndask_df = dd.from_pandas(pdf, npartitions=10)\nds = ray.data.from_dask(dask_df)\n\n# Transform the dataset using .map()\nds = ray.data.range(10000)\nds = ds.map(lambda x: x * 2)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1123.54it/s]\n# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)\nds.take(5)\n# -> [0, 2, 4, 6, 8]\n\n# Transform the dataset using .filter()\nds.filter(lambda x: x > 5).take(5)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1859.63it/s]\n# -> [6, 8, 10, 12, 14]\n\n# Transform the dataset using .flat_map()\nds.flat_map(lambda x: [x, -x]).take(5)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1568.10it/s]\n# -> [0, 0, 2, -2, 4]",
                                       "language": "python",
-                                      "id": "452091e0-c95f-4466-a53e-050b006caad6-34"
+                                      "id": "3a5b6e44-9ef6-41b8-8713-b09868b64f6a-34"
                                     }
                                   ]
                                 },

--- a/test/inputs/23/wizard-noaprioris.json
+++ b/test/inputs/23/wizard-noaprioris.json
@@ -9,7 +9,7 @@
         {
           "member": 0,
           "graph": {
-            "key": "1f9544ec-ba4e-41e2-9383-4931878907c6",
+            "key": "dc64f192-985f-4561-8aaa-4b26d5935310",
             "sequence": [
               {
                 "group": "Intel####Apple Silicon",
@@ -20,12 +20,12 @@
                   {
                     "member": 0,
                     "graph": {
-                      "key": "c058fb15-2e55-455a-a2e2-cd2d4f73f07d",
+                      "key": "68879842-df68-4c95-a824-a8709fa682a5",
                       "sequence": [
                         {
                           "body": "pip install -U ray",
                           "language": "shell",
-                          "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-0"
+                          "id": "aa418ecc-6051-4523-835a-d478cdebcf56-0"
                         }
                       ]
                     },
@@ -35,14 +35,14 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "ca6409af-4bdc-40f2-9294-f4eac64f4dac",
+                      "key": "7f39ee6f-476a-4c29-a923-c41b9995c414",
                       "sequence": [
                         {
                           "key": "test/inputs/23/python/conda/install.md",
                           "title": "Conda: Installation",
                           "filepath": "test/inputs/23/python/conda/install.md",
                           "graph": {
-                            "key": "102c1b83-a832-45c6-ba6e-c7abf6330925",
+                            "key": "6a4e6a68-3c2b-4510-bc62-8abd0616d5de",
                             "sequence": [
                               {
                                 "group": "Install Miniconda####Install Anaconda",
@@ -53,7 +53,7 @@
                                   {
                                     "member": 0,
                                     "graph": {
-                                      "key": "48fa5775-fbda-404e-b7fa-e8079d38e839",
+                                      "key": "ecde3aa8-eecd-4a07-a513-a51e30985c04",
                                       "sequence": [
                                         {
                                           "group": "Windows####Linux####MacOS",
@@ -64,7 +64,7 @@
                                             {
                                               "member": 1,
                                               "graph": {
-                                                "key": "ffd997a0-5616-4c2c-a3a6-d8b0e6da2b3e",
+                                                "key": "31881e59-b2e9-459d-8223-452f6ef0207c",
                                                 "sequence": [
                                                   {
                                                     "group": "Intel####ARM64",
@@ -75,12 +75,12 @@
                                                       {
                                                         "member": 0,
                                                         "graph": {
-                                                          "key": "5ce97bf9-5ce1-4d82-b5da-1a99c5a34f37",
+                                                          "key": "290b4e19-c683-4142-8f94-75167ad150b9",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh\nbash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda",
                                                               "language": "shell",
-                                                              "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-1"
+                                                              "id": "aa418ecc-6051-4523-835a-d478cdebcf56-1"
                                                             }
                                                           ]
                                                         },
@@ -89,12 +89,12 @@
                                                       {
                                                         "member": 1,
                                                         "graph": {
-                                                          "key": "377b910d-96ad-43e9-91b3-18668fdc6898",
+                                                          "key": "30062ad7-ae4e-47a2-b7cc-b36beb8f8416",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh\nbash Miniconda3-latest-Linux-aarch64.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-2"
+                                                              "id": "aa418ecc-6051-4523-835a-d478cdebcf56-2"
                                                             }
                                                           ]
                                                         },
@@ -110,7 +110,7 @@
                                             {
                                               "member": 2,
                                               "graph": {
-                                                "key": "d75ac770-4a91-43d4-8d11-16cb9c1778d9",
+                                                "key": "1b3b0e84-e4ab-437f-930a-20c239ede967",
                                                 "sequence": [
                                                   {
                                                     "group": "Intel####Apple Silicon",
@@ -121,12 +121,12 @@
                                                       {
                                                         "member": 0,
                                                         "graph": {
-                                                          "key": "69900330-83e5-4f9d-ba06-5e6846e36d65",
+                                                          "key": "bec11732-a1d3-4976-b5c6-4193fef5daca",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh\nbash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-3"
+                                                              "id": "aa418ecc-6051-4523-835a-d478cdebcf56-3"
                                                             }
                                                           ]
                                                         },
@@ -136,12 +136,12 @@
                                                       {
                                                         "member": 1,
                                                         "graph": {
-                                                          "key": "87fbdd1c-ed94-4aa5-a7c6-08342a2e423b",
+                                                          "key": "9a48daa9-a04d-4a06-8dc6-3feb58225f22",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh\nbash Miniconda3-latest-MacOSX-arm64.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-4"
+                                                              "id": "aa418ecc-6051-4523-835a-d478cdebcf56-4"
                                                             }
                                                           ]
                                                         },
@@ -165,7 +165,7 @@
                                   {
                                     "member": 1,
                                     "graph": {
-                                      "key": "5eee237a-2a1e-40f7-a266-bf7b41743f95",
+                                      "key": "fcbb97ec-6e23-4353-80b5-76fd45d5f71f",
                                       "sequence": [
                                         {
                                           "group": "MacOS####Linux",
@@ -176,12 +176,12 @@
                                             {
                                               "member": 0,
                                               "graph": {
-                                                "key": "cac82e29-3b15-4806-81a5-c11a8b7ae848",
+                                                "key": "0daf9806-fdaa-45e0-b9d6-41fe41f2341d",
                                                 "sequence": [
                                                   {
                                                     "body": "curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-MacOSX-x86_64.sh\nbash Anaconda3-2021.11-MacOSX-x86_64.sh -b -p $HOME/miniconda",
                                                     "language": "shell",
-                                                    "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-5"
+                                                    "id": "aa418ecc-6051-4523-835a-d478cdebcf56-5"
                                                   }
                                                 ]
                                               },
@@ -190,7 +190,7 @@
                                             {
                                               "member": 1,
                                               "graph": {
-                                                "key": "7f2b9613-c002-4609-9ee5-4e5acdce06b6",
+                                                "key": "635df8d7-0844-4d01-b45f-46af7db9a0fd",
                                                 "sequence": [
                                                   {
                                                     "group": "x86####POWER8 and POWER9####AWS Graviton2/ARM64####IBM z/Linux and LinuxONE",
@@ -201,12 +201,12 @@
                                                       {
                                                         "member": 0,
                                                         "graph": {
-                                                          "key": "657fa49d-51c5-4f3d-82a7-5bb4a48ecc21",
+                                                          "key": "5ade077b-898d-4c89-b6e7-da93c22e00b4",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-x86_64.sh\nbash Anaconda3-2021.11-Linux-x86_64.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-6"
+                                                              "id": "aa418ecc-6051-4523-835a-d478cdebcf56-6"
                                                             }
                                                           ]
                                                         },
@@ -215,12 +215,12 @@
                                                       {
                                                         "member": 1,
                                                         "graph": {
-                                                          "key": "2a68c42d-88dd-4162-9731-8d2faeaadf76",
+                                                          "key": "71f19af5-8e0f-499e-ba9b-498d0a9f2325",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-ppc64le.sh\nbash Anaconda3-2021.11-Linux-ppc64le.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-7"
+                                                              "id": "aa418ecc-6051-4523-835a-d478cdebcf56-7"
                                                             }
                                                           ]
                                                         },
@@ -229,12 +229,12 @@
                                                       {
                                                         "member": 2,
                                                         "graph": {
-                                                          "key": "01a627ef-b2d3-4204-8b5d-79a34f9363bc",
+                                                          "key": "0e8b88e4-8486-4957-9df5-66b47b813915",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-aarch64.sh\nbash Anaconda3-2021.11-Linux-aarch64.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-8"
+                                                              "id": "aa418ecc-6051-4523-835a-d478cdebcf56-8"
                                                             }
                                                           ]
                                                         },
@@ -243,12 +243,12 @@
                                                       {
                                                         "member": 3,
                                                         "graph": {
-                                                          "key": "4920a635-a85c-458f-bbf7-cea275d7feb2",
+                                                          "key": "3c5b05d6-7e7e-4bed-8fbe-a66639697904",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-s390x.sh\nbash Anaconda3-2021.11-Linux-s390x.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-9"
+                                                              "id": "aa418ecc-6051-4523-835a-d478cdebcf56-9"
                                                             }
                                                           ]
                                                         },
@@ -272,7 +272,7 @@
                               {
                                 "body": "export PATH=~/miniconda/bin:$PATH",
                                 "language": "shell",
-                                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-10"
+                                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-10"
                               }
                             ]
                           },
@@ -281,7 +281,7 @@
                         {
                           "body": "conda activate\npip uninstall grpcio\nconda install grpcio\npip install ray",
                           "language": "shell",
-                          "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-11"
+                          "id": "aa418ecc-6051-4523-835a-d478cdebcf56-11"
                         }
                       ]
                     },
@@ -298,14 +298,14 @@
         {
           "member": 1,
           "graph": {
-            "key": "41d10fd9-b8d9-45ed-a28d-970d87edca41",
+            "key": "750d90cb-0d62-4465-928d-c486449bd012",
             "sequence": [
               {
                 "key": "test/inputs/23/kubernetes/kubectl.md",
                 "title": "Install kubectl",
                 "filepath": "test/inputs/23/kubernetes/kubectl.md",
                 "graph": {
-                  "key": "a7518a4f-9722-4b89-a85f-5ae48712d653",
+                  "key": "bdae31fb-32a2-42a0-9e61-9e533f86aced",
                   "sequence": [
                     {
                       "group": "Linux####Windows####MacOS",
@@ -316,12 +316,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "7fe6cfd8-4374-4e3c-a5de-aaa6a98b691c",
+                            "key": "59cfb04f-d35f-426c-8969-b7faf672c973",
                             "sequence": [
                               {
                                 "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\"",
                                 "language": "bash",
-                                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-12"
+                                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-12"
                               }
                             ]
                           },
@@ -331,12 +331,12 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "951e4fed-0302-4d0f-bb2b-0361ace5790f",
+                            "key": "86386cfc-6625-4cdc-9aea-72b5cefb044f",
                             "sequence": [
                               {
                                 "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/windows/amd64/kubectl.exe\"",
                                 "language": "bash",
-                                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-13"
+                                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-13"
                               }
                             ]
                           },
@@ -346,7 +346,7 @@
                         {
                           "member": 2,
                           "graph": {
-                            "key": "73f94fd4-6e11-4af8-820b-899e83094127",
+                            "key": "1fae9f55-c6aa-4792-9495-5ee02b38a9d4",
                             "sequence": [
                               {
                                 "group": "Homebrew####curl",
@@ -357,12 +357,12 @@
                                   {
                                     "member": 0,
                                     "graph": {
-                                      "key": "e9d619be-9fcd-482d-8ca5-68bc532349fe",
+                                      "key": "59f799a5-a569-48df-9ae2-90e3b11abb81",
                                       "sequence": [
                                         {
                                           "body": "brew install kubectl",
                                           "language": "bash",
-                                          "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-14"
+                                          "id": "aa418ecc-6051-4523-835a-d478cdebcf56-14"
                                         }
                                       ]
                                     },
@@ -372,7 +372,7 @@
                                   {
                                     "member": 1,
                                     "graph": {
-                                      "key": "d055b6b2-d5ba-45ae-8a3c-c83bf989ae34",
+                                      "key": "dcf45ac6-e2c3-43d6-aa43-955029b9b2b6",
                                       "sequence": [
                                         {
                                           "group": "Intel####Apple Silicon",
@@ -383,12 +383,12 @@
                                             {
                                               "member": 0,
                                               "graph": {
-                                                "key": "319622b7-f753-43bb-ac47-4c300937e07b",
+                                                "key": "e7f2ff3f-abc5-4264-8862-9b8fa209e358",
                                                 "sequence": [
                                                   {
                                                     "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256\"",
                                                     "language": "bash",
-                                                    "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-15"
+                                                    "id": "aa418ecc-6051-4523-835a-d478cdebcf56-15"
                                                   }
                                                 ]
                                               },
@@ -397,12 +397,12 @@
                                             {
                                               "member": 1,
                                               "graph": {
-                                                "key": "05805212-3f37-4dc6-86d8-80a40a0ada71",
+                                                "key": "54c49da9-8b78-4e74-aae6-087f13a4b998",
                                                 "sequence": [
                                                   {
                                                     "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl.sha256\"",
                                                     "language": "bash",
-                                                    "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-16"
+                                                    "id": "aa418ecc-6051-4523-835a-d478cdebcf56-16"
                                                   }
                                                 ]
                                               },
@@ -413,7 +413,7 @@
                                         {
                                           "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/amd64/kubectl\"\nAnd for macOS on Apple Silicon, type:\n    \ncurl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/arm64/kubectl\"",
                                           "language": "bash",
-                                          "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-17"
+                                          "id": "aa418ecc-6051-4523-835a-d478cdebcf56-17"
                                         }
                                       ]
                                     },
@@ -438,7 +438,7 @@
                 "title": "Install Helm v3",
                 "filepath": "test/inputs/23/kubernetes/helm3.md",
                 "graph": {
-                  "key": "29d99a83-9ec4-45bd-a39f-29a4a92e684e",
+                  "key": "7a3af3c1-6736-4ad3-9e4f-99dc4209d9f1",
                   "sequence": [
                     {
                       "group": "MacOS####Linux####Windows",
@@ -449,7 +449,7 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "52f8eb3e-3bbc-42a4-a3b1-567a41ea72f5",
+                            "key": "768eb89e-43e9-4b2a-abe5-55786c0f9914",
                             "sequence": [
                               {
                                 "group": "Homebrew####curl",
@@ -460,12 +460,12 @@
                                   {
                                     "member": 0,
                                     "graph": {
-                                      "key": "ef42fc93-d88f-4a48-bd84-fc244bf2f5e1",
+                                      "key": "11e4f12e-f060-47ed-ae19-abb4817fea4d",
                                       "sequence": [
                                         {
                                           "body": "brew install helm",
                                           "language": "shell",
-                                          "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-18"
+                                          "id": "aa418ecc-6051-4523-835a-d478cdebcf56-18"
                                         }
                                       ]
                                     },
@@ -474,12 +474,12 @@
                                   {
                                     "member": 1,
                                     "graph": {
-                                      "key": "9cea889c-85db-4bb7-909b-e5802e9199fe",
+                                      "key": "0bf65bef-6a2c-4652-95bc-2dbe777cdfd7",
                                       "sequence": [
                                         {
                                           "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                           "language": "shell",
-                                          "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-19"
+                                          "id": "aa418ecc-6051-4523-835a-d478cdebcf56-19"
                                         }
                                       ]
                                     },
@@ -494,12 +494,12 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "3c2f5ad0-e8c6-4ca9-a04f-2052e0097f0f",
+                            "key": "d8bf2fb6-22f0-4076-9273-24bc817569f5",
                             "sequence": [
                               {
                                 "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                 "language": "shell",
-                                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-20"
+                                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-20"
                               }
                             ]
                           },
@@ -508,12 +508,12 @@
                         {
                           "member": 2,
                           "graph": {
-                            "key": "b99a19e0-d5cf-47cb-b70c-1ca7a596237e",
+                            "key": "48a2603d-a5b5-4772-9699-cbaf1354456b",
                             "sequence": [
                               {
                                 "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                 "language": "shell",
-                                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-21"
+                                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-21"
                               }
                             ]
                           },
@@ -530,14 +530,14 @@
                 "title": "Choose a Kubernetes context",
                 "filepath": "test/inputs/23/kubernetes/context.md",
                 "graph": {
-                  "key": "1c823f94-2a98-4f49-8ae2-bcf9389196b0",
+                  "key": "986b3b0d-486a-4a2b-9426-43098a26de03",
                   "sequence": [
                     {
                       "key": "test/inputs/23/kubernetes/kubectl.md",
                       "title": "Install kubectl",
                       "filepath": "test/inputs/23/kubernetes/kubectl.md",
                       "graph": {
-                        "key": "a26db3a4-d845-4fd3-9526-972de00a5e1a",
+                        "key": "68181fdc-e1f8-4917-a296-34232e06fe78",
                         "sequence": [
                           {
                             "group": "Linux####Windows####MacOS",
@@ -548,12 +548,12 @@
                               {
                                 "member": 0,
                                 "graph": {
-                                  "key": "4868fae7-3db7-40e2-ac9c-efdea66019ad",
+                                  "key": "b79b516f-a683-47a5-ae4f-d49edd136e1b",
                                   "sequence": [
                                     {
                                       "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\"",
                                       "language": "bash",
-                                      "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-22"
+                                      "id": "aa418ecc-6051-4523-835a-d478cdebcf56-22"
                                     }
                                   ]
                                 },
@@ -563,12 +563,12 @@
                               {
                                 "member": 1,
                                 "graph": {
-                                  "key": "db9efebe-31d9-41da-a962-72f9f5c6b0e5",
+                                  "key": "8e66ca0a-b47b-4dca-a0f4-acd9dfbe6fbe",
                                   "sequence": [
                                     {
                                       "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/windows/amd64/kubectl.exe\"",
                                       "language": "bash",
-                                      "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-23"
+                                      "id": "aa418ecc-6051-4523-835a-d478cdebcf56-23"
                                     }
                                   ]
                                 },
@@ -578,7 +578,7 @@
                               {
                                 "member": 2,
                                 "graph": {
-                                  "key": "7ba02bba-8cb3-445e-9d48-5b2fad85e857",
+                                  "key": "260b8f20-ea60-44b1-bf16-6ad055e680d7",
                                   "sequence": [
                                     {
                                       "group": "Homebrew####curl",
@@ -589,12 +589,12 @@
                                         {
                                           "member": 0,
                                           "graph": {
-                                            "key": "396866ae-2d12-437f-a004-fda732c8b425",
+                                            "key": "8cd94334-94fd-4754-8a38-835cc81e0f03",
                                             "sequence": [
                                               {
                                                 "body": "brew install kubectl",
                                                 "language": "bash",
-                                                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-24"
+                                                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-24"
                                               }
                                             ]
                                           },
@@ -604,7 +604,7 @@
                                         {
                                           "member": 1,
                                           "graph": {
-                                            "key": "dbfe9c08-1d9a-4e9d-8b86-652aef48d1e4",
+                                            "key": "930e73c7-615f-4b75-a117-b78f3a6ca3f6",
                                             "sequence": [
                                               {
                                                 "group": "Intel####Apple Silicon",
@@ -615,12 +615,12 @@
                                                   {
                                                     "member": 0,
                                                     "graph": {
-                                                      "key": "f83173fa-a2cf-489d-bc83-a0911ec97ce2",
+                                                      "key": "fb8c1d35-c1b1-4378-a3df-133adbad47fb",
                                                       "sequence": [
                                                         {
                                                           "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256\"",
                                                           "language": "bash",
-                                                          "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-25"
+                                                          "id": "aa418ecc-6051-4523-835a-d478cdebcf56-25"
                                                         }
                                                       ]
                                                     },
@@ -629,12 +629,12 @@
                                                   {
                                                     "member": 1,
                                                     "graph": {
-                                                      "key": "e3798074-4a27-445f-97d5-58ea6a7e0c5e",
+                                                      "key": "bde8fb36-9e15-4db1-bb5d-8fcf24add0a9",
                                                       "sequence": [
                                                         {
                                                           "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl.sha256\"",
                                                           "language": "bash",
-                                                          "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-26"
+                                                          "id": "aa418ecc-6051-4523-835a-d478cdebcf56-26"
                                                         }
                                                       ]
                                                     },
@@ -645,7 +645,7 @@
                                               {
                                                 "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/amd64/kubectl\"\nAnd for macOS on Apple Silicon, type:\n    \ncurl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/arm64/kubectl\"",
                                                 "language": "bash",
-                                                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-27"
+                                                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-27"
                                               }
                                             ]
                                           },
@@ -674,12 +674,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "32fee7c2-3648-450b-bb3e-6ad2ae3e51c9",
+                            "key": "84b5e398-178e-4be3-b65f-156f2e580887",
                             "sequence": [
                               {
                                 "body": "kubectl config set-context \"\"",
                                 "language": "shell",
-                                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-28"
+                                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-28"
                               }
                             ]
                           },
@@ -694,7 +694,7 @@
               {
                 "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
                 "language": "shell",
-                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-29"
+                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-29"
               }
             ]
           },
@@ -729,16 +729,17 @@
       "group": "Example: Using Ray Tasks to Parallelize a Function####Example: Using Ray Actors to Parallelize a Class####Example: Creating and Transforming Datasets",
       "title": "Run a Ray Job",
       "source": "placeholder",
+      "provenance": ["test/inputs/23/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "7a0744e4-4d22-43ff-9b8b-7f85aed56d04",
+            "key": "771088d0-9c4b-4fb6-82c4-94f8376c31ec",
             "sequence": [
               {
                 "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
                 "language": "python",
-                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-30"
+                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-30"
               }
             ]
           },
@@ -748,12 +749,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "0589882d-8045-482e-b391-0ded76a4c00b",
+            "key": "cbf4edea-1f98-4691-b32a-79b2b303478b",
             "sequence": [
               {
                 "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
                 "language": "python",
-                "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-31"
+                "id": "aa418ecc-6051-4523-835a-d478cdebcf56-31"
               }
             ]
           },
@@ -763,33 +764,33 @@
         {
           "member": 2,
           "graph": {
-            "key": "a2aa016e-9244-43cd-bb44-b87533a30638",
+            "key": "6eedcb4d-a12c-4f35-a166-0f6a6a487d50",
             "sequence": [
               {
                 "key": "Creating and Transforming Datasets",
                 "title": "Creating and Transforming Datasets",
                 "filepath": "",
                 "graph": {
-                  "key": "71f14086-3adf-4685-ab61-a09ebe4fd2ae",
+                  "key": "62714773-54c8-43b3-8151-bcd3cb138a6c",
                   "sequence": [
                     {
                       "key": "Prerequisites",
                       "title": "Prerequisites",
                       "filepath": "",
                       "graph": {
-                        "key": "60a1935a-7e8c-4a0f-a0f8-329c09f51502",
+                        "key": "93fe0c4e-2d70-4b2d-ae9c-1ff2532e8e9b",
                         "sequence": [
                           {
                             "key": "test/inputs/23/data.md",
                             "title": "Install Ray Data",
                             "filepath": "test/inputs/23/data.md",
                             "graph": {
-                              "key": "6322379c-3655-4506-abe7-8f61bcf0cbbd",
+                              "key": "000b8160-4ad5-4b25-a6b2-08951221af57",
                               "sequence": [
                                 {
                                   "body": "pip install \"ray[data]\" dask",
                                   "language": "shell",
-                                  "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-32"
+                                  "id": "aa418ecc-6051-4523-835a-d478cdebcf56-32"
                                 }
                               ]
                             },
@@ -804,22 +805,23 @@
                       "title": "Main Tasks",
                       "filepath": "",
                       "graph": {
-                        "key": "7c51b5d9-9675-4953-952b-62871e709a9b",
+                        "key": "c1a4491a-689d-49e1-ada1-ef1ad2d7c2dd",
                         "sequence": [
                           {
                             "group": "New Dataset from Range####New Dataset from File",
                             "title": "Main Tasks",
                             "source": "placeholder",
+                            "provenance": ["test/inputs/23/in.md"],
                             "choices": [
                               {
                                 "member": 0,
                                 "graph": {
-                                  "key": "1a6384be-04e1-4678-b768-62f8c9ea962e",
+                                  "key": "52785816-07b3-4c9c-a412-b31ac75e1e34",
                                   "sequence": [
                                     {
                                       "body": "import ray\n\n# Create a Dataset of Python objects.\nds = ray.data.range(10000)\n# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)\n\nds.take(5)\n# -> [0, 1, 2, 3, 4]\n\nds.count()\n# -> 10000\n\n# Create a Dataset of Arrow records.\nds = ray.data.from_items([{\"col1\": i, \"col2\": str(i)} for i in range(10000)])\n# -> Dataset(num_blocks=200, num_rows=10000, schema={col1: int64, col2: string})\n\nds.show(5)\n# -> {'col1': 0, 'col2': '0'}\n# -> {'col1': 1, 'col2': '1'}\n# -> {'col1': 2, 'col2': '2'}\n# -> {'col1': 3, 'col2': '3'}\n# -> {'col1': 4, 'col2': '4'}\n\nds.schema()\n# -> col1: int64\n# -> col2: string",
                                       "language": "python",
-                                      "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-33"
+                                      "id": "aa418ecc-6051-4523-835a-d478cdebcf56-33"
                                     }
                                   ]
                                 },
@@ -829,12 +831,12 @@
                               {
                                 "member": 1,
                                 "graph": {
-                                  "key": "7a437dca-5a72-4948-9633-1d20dc0c7cdb",
+                                  "key": "27de5ae3-a62c-4290-a85f-08c35c8fdbd5",
                                   "sequence": [
                                     {
                                       "body": "import ray\nimport pandas as pd\nimport dask.dataframe as dd\n\n# Create a Dataset from a list of Pandas DataFrame objects.\npdf = pd.DataFrame({\"one\": [1, 2, 3], \"two\": [\"a\", \"b\", \"c\"]})\nds = ray.data.from_pandas([pdf])\n\n# Create a Dataset from a Dask-on-Ray DataFrame.\ndask_df = dd.from_pandas(pdf, npartitions=10)\nds = ray.data.from_dask(dask_df)\n\n# Transform the dataset using .map()\nds = ray.data.range(10000)\nds = ds.map(lambda x: x * 2)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1123.54it/s]\n# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)\nds.take(5)\n# -> [0, 2, 4, 6, 8]\n\n# Transform the dataset using .filter()\nds.filter(lambda x: x > 5).take(5)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1859.63it/s]\n# -> [6, 8, 10, 12, 14]\n\n# Transform the dataset using .flat_map()\nds.flat_map(lambda x: [x, -x]).take(5)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1568.10it/s]\n# -> [0, 0, 2, -2, 4]",
                                       "language": "python",
-                                      "id": "1605f629-ac85-43c5-9822-c03ca68f6ce5-34"
+                                      "id": "aa418ecc-6051-4523-835a-d478cdebcf56-34"
                                     }
                                   ]
                                 },

--- a/test/inputs/23/wizard-noopt.json
+++ b/test/inputs/23/wizard-noopt.json
@@ -9,7 +9,7 @@
         {
           "member": 0,
           "graph": {
-            "key": "4471887e-54c3-4aa8-8a19-5903fe489b40",
+            "key": "64d865bd-c32a-4b68-b83d-128993679ec2",
             "sequence": [
               {
                 "group": "Intel####Apple Silicon",
@@ -19,12 +19,12 @@
                   {
                     "member": 0,
                     "graph": {
-                      "key": "4864bfe1-66b5-412e-9e07-c00af9dde885",
+                      "key": "5ce4b6de-cbe8-422b-9aec-430b596b1fa3",
                       "sequence": [
                         {
                           "body": "pip install -U ray",
                           "language": "shell",
-                          "id": "205c1575-e21f-4398-bd17-8073651443d1-0"
+                          "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-0"
                         }
                       ]
                     },
@@ -34,14 +34,14 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "6b504cf7-a63c-4879-a037-ca4ee858f2c0",
+                      "key": "a63b817d-652f-4555-a459-f3fee662919a",
                       "sequence": [
                         {
                           "key": "test/inputs/23/python/conda/install.md",
                           "title": "Conda: Installation",
                           "filepath": "test/inputs/23/python/conda/install.md",
                           "graph": {
-                            "key": "91865f73-bc8d-4c43-8162-a17d7881b4d0",
+                            "key": "fa03119c-66f0-4e54-bcef-3c224a0584d2",
                             "sequence": [
                               {
                                 "group": "Install Miniconda####Install Anaconda",
@@ -52,7 +52,7 @@
                                   {
                                     "member": 0,
                                     "graph": {
-                                      "key": "ccc578c5-207e-44ab-9390-5d5ae783ea47",
+                                      "key": "21f653d8-52b6-449d-8011-a2ab41a88d4d",
                                       "sequence": [
                                         {
                                           "group": "Windows####Linux####MacOS",
@@ -62,7 +62,7 @@
                                             {
                                               "member": 1,
                                               "graph": {
-                                                "key": "a15dfbd1-979a-4a03-a98e-a1e171ca033e",
+                                                "key": "0f8032ee-660d-4b38-a702-91d6b4fab1eb",
                                                 "sequence": [
                                                   {
                                                     "group": "Intel####ARM64",
@@ -72,12 +72,12 @@
                                                       {
                                                         "member": 0,
                                                         "graph": {
-                                                          "key": "76737d22-c2bf-41d7-8372-2785da76a22d",
+                                                          "key": "7b427bd1-f64b-4562-b7ad-4a6a124e693a",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh\nbash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda",
                                                               "language": "shell",
-                                                              "id": "205c1575-e21f-4398-bd17-8073651443d1-1"
+                                                              "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-1"
                                                             }
                                                           ]
                                                         },
@@ -86,12 +86,12 @@
                                                       {
                                                         "member": 1,
                                                         "graph": {
-                                                          "key": "5577350f-ee4d-487f-ba2e-ced13ee1bf45",
+                                                          "key": "d6e0de37-7210-4b63-a3a3-19bf70ff6d32",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh\nbash Miniconda3-latest-Linux-aarch64.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "205c1575-e21f-4398-bd17-8073651443d1-2"
+                                                              "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-2"
                                                             }
                                                           ]
                                                         },
@@ -107,7 +107,7 @@
                                             {
                                               "member": 2,
                                               "graph": {
-                                                "key": "fb59e97e-38ba-4deb-8509-924a6b502879",
+                                                "key": "1fecdc90-01b3-47e9-8f17-a1cfab1b3b1e",
                                                 "sequence": [
                                                   {
                                                     "group": "Intel####Apple Silicon",
@@ -117,12 +117,12 @@
                                                       {
                                                         "member": 0,
                                                         "graph": {
-                                                          "key": "215466df-4b1a-4081-b5d0-f1e0920a4c8a",
+                                                          "key": "45bd2cc0-ca8b-46f0-88e3-78b4e0b8ef98",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh\nbash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "205c1575-e21f-4398-bd17-8073651443d1-3"
+                                                              "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-3"
                                                             }
                                                           ]
                                                         },
@@ -132,12 +132,12 @@
                                                       {
                                                         "member": 1,
                                                         "graph": {
-                                                          "key": "aa6158ad-9bb0-4b92-81d2-acc83e265a73",
+                                                          "key": "5e4cdb51-37d2-40b3-b3e5-5a874d622914",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh\nbash Miniconda3-latest-MacOSX-arm64.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "205c1575-e21f-4398-bd17-8073651443d1-4"
+                                                              "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-4"
                                                             }
                                                           ]
                                                         },
@@ -161,7 +161,7 @@
                                   {
                                     "member": 1,
                                     "graph": {
-                                      "key": "11a260d3-2e48-4287-8c6b-968eb431ce6d",
+                                      "key": "1e45697e-a1b1-480a-bb3f-1e7a61c62386",
                                       "sequence": [
                                         {
                                           "group": "MacOS####Linux",
@@ -171,12 +171,12 @@
                                             {
                                               "member": 0,
                                               "graph": {
-                                                "key": "eaa1d706-d927-4013-bf29-7d1e9d8f8a0d",
+                                                "key": "477425ab-33d0-437c-a6b3-825d4df7691b",
                                                 "sequence": [
                                                   {
                                                     "body": "curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-MacOSX-x86_64.sh\nbash Anaconda3-2021.11-MacOSX-x86_64.sh -b -p $HOME/miniconda",
                                                     "language": "shell",
-                                                    "id": "205c1575-e21f-4398-bd17-8073651443d1-5"
+                                                    "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-5"
                                                   }
                                                 ]
                                               },
@@ -185,7 +185,7 @@
                                             {
                                               "member": 1,
                                               "graph": {
-                                                "key": "3986e904-9457-4fc4-bfcc-c6435e83c784",
+                                                "key": "6b909331-b8c4-42c0-97af-c8d93186db24",
                                                 "sequence": [
                                                   {
                                                     "group": "x86####POWER8 and POWER9####AWS Graviton2/ARM64####IBM z/Linux and LinuxONE",
@@ -195,12 +195,12 @@
                                                       {
                                                         "member": 0,
                                                         "graph": {
-                                                          "key": "59b52135-f9d6-466e-9800-a6574de8c266",
+                                                          "key": "b495586f-be4c-448d-9f13-dd725805ca4f",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-x86_64.sh\nbash Anaconda3-2021.11-Linux-x86_64.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "205c1575-e21f-4398-bd17-8073651443d1-6"
+                                                              "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-6"
                                                             }
                                                           ]
                                                         },
@@ -209,12 +209,12 @@
                                                       {
                                                         "member": 1,
                                                         "graph": {
-                                                          "key": "1ada4c0e-661e-47b4-9cf7-b126b820c478",
+                                                          "key": "04957e64-e9e6-477d-9e62-d39965af4336",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-ppc64le.sh\nbash Anaconda3-2021.11-Linux-ppc64le.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "205c1575-e21f-4398-bd17-8073651443d1-7"
+                                                              "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-7"
                                                             }
                                                           ]
                                                         },
@@ -223,12 +223,12 @@
                                                       {
                                                         "member": 2,
                                                         "graph": {
-                                                          "key": "263359cd-11a5-4071-bd8a-73c9d9c73e7a",
+                                                          "key": "8db78a55-2071-49fc-b7c9-7f14a7e9b8c5",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-aarch64.sh\nbash Anaconda3-2021.11-Linux-aarch64.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "205c1575-e21f-4398-bd17-8073651443d1-8"
+                                                              "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-8"
                                                             }
                                                           ]
                                                         },
@@ -237,12 +237,12 @@
                                                       {
                                                         "member": 3,
                                                         "graph": {
-                                                          "key": "5682df61-1f01-4111-bc20-834fe6b00051",
+                                                          "key": "e9e7bac7-1afe-4417-8cb8-8322b68e8291",
                                                           "sequence": [
                                                             {
                                                               "body": "curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-s390x.sh\nbash Anaconda3-2021.11-Linux-s390x.sh -b -p $HOME/miniconda",
                                                               "language": "shell",
-                                                              "id": "205c1575-e21f-4398-bd17-8073651443d1-9"
+                                                              "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-9"
                                                             }
                                                           ]
                                                         },
@@ -266,7 +266,7 @@
                               {
                                 "body": "export PATH=~/miniconda/bin:$PATH",
                                 "language": "shell",
-                                "id": "205c1575-e21f-4398-bd17-8073651443d1-10"
+                                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-10"
                               }
                             ]
                           },
@@ -275,7 +275,7 @@
                         {
                           "body": "conda activate\npip uninstall grpcio\nconda install grpcio\npip install ray",
                           "language": "shell",
-                          "id": "205c1575-e21f-4398-bd17-8073651443d1-11"
+                          "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-11"
                         }
                       ]
                     },
@@ -292,14 +292,14 @@
         {
           "member": 1,
           "graph": {
-            "key": "83678de7-5faa-46f2-a811-df6257a2020f",
+            "key": "1e9d78cc-0d5c-4b0d-b162-f8116a5f0808",
             "sequence": [
               {
                 "key": "test/inputs/23/kubernetes/kubectl.md",
                 "title": "Install kubectl",
                 "filepath": "test/inputs/23/kubernetes/kubectl.md",
                 "graph": {
-                  "key": "bbdbe802-bcd8-4963-b4e9-498062ebf27f",
+                  "key": "92518ea5-3ba2-49cc-b912-035913b85e85",
                   "sequence": [
                     {
                       "group": "Linux####Windows####MacOS",
@@ -310,12 +310,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "a350fd17-c64f-4f98-85cb-658d5aca96ef",
+                            "key": "31836947-ec5a-4c14-b5f7-5aca74c411d4",
                             "sequence": [
                               {
                                 "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\"",
                                 "language": "bash",
-                                "id": "205c1575-e21f-4398-bd17-8073651443d1-12"
+                                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-12"
                               }
                             ]
                           },
@@ -325,12 +325,12 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "ae42bb5a-e7a7-4af9-88a6-8febc72d5954",
+                            "key": "624c14b4-4c13-493b-98a4-acab04036024",
                             "sequence": [
                               {
                                 "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/windows/amd64/kubectl.exe\"",
                                 "language": "bash",
-                                "id": "205c1575-e21f-4398-bd17-8073651443d1-13"
+                                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-13"
                               }
                             ]
                           },
@@ -340,7 +340,7 @@
                         {
                           "member": 2,
                           "graph": {
-                            "key": "a4d45d83-db0d-4ef8-b55d-38d44d5fb998",
+                            "key": "b3f0a860-9444-4383-af57-83fcee604c9c",
                             "sequence": [
                               {
                                 "group": "Homebrew####curl",
@@ -350,12 +350,12 @@
                                   {
                                     "member": 0,
                                     "graph": {
-                                      "key": "a24f5265-6b56-488b-a6f2-0418b8fb7c02",
+                                      "key": "7a246495-4008-4336-a470-adc5d886b8e7",
                                       "sequence": [
                                         {
                                           "body": "brew install kubectl",
                                           "language": "bash",
-                                          "id": "205c1575-e21f-4398-bd17-8073651443d1-14"
+                                          "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-14"
                                         }
                                       ]
                                     },
@@ -365,7 +365,7 @@
                                   {
                                     "member": 1,
                                     "graph": {
-                                      "key": "907ebd9f-604d-4cf9-bb93-b2e51b4b652b",
+                                      "key": "adf152ae-24b9-49a9-8610-fe6c85c8494d",
                                       "sequence": [
                                         {
                                           "group": "Intel####Apple Silicon",
@@ -375,12 +375,12 @@
                                             {
                                               "member": 0,
                                               "graph": {
-                                                "key": "17dd64c7-4831-4cd6-a0f3-8792bab64a1a",
+                                                "key": "36ac4f1d-e1ca-4e54-8c73-792d3c90f622",
                                                 "sequence": [
                                                   {
                                                     "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256\"",
                                                     "language": "bash",
-                                                    "id": "205c1575-e21f-4398-bd17-8073651443d1-15"
+                                                    "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-15"
                                                   }
                                                 ]
                                               },
@@ -389,12 +389,12 @@
                                             {
                                               "member": 1,
                                               "graph": {
-                                                "key": "25e3295a-1f83-4841-8d68-5a6d0a23f306",
+                                                "key": "fa15f7cc-26c6-4f28-9c69-7d263a19624b",
                                                 "sequence": [
                                                   {
                                                     "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl.sha256\"",
                                                     "language": "bash",
-                                                    "id": "205c1575-e21f-4398-bd17-8073651443d1-16"
+                                                    "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-16"
                                                   }
                                                 ]
                                               },
@@ -405,7 +405,7 @@
                                         {
                                           "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/amd64/kubectl\"\nAnd for macOS on Apple Silicon, type:\n    \ncurl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/arm64/kubectl\"",
                                           "language": "bash",
-                                          "id": "205c1575-e21f-4398-bd17-8073651443d1-17"
+                                          "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-17"
                                         }
                                       ]
                                     },
@@ -430,7 +430,7 @@
                 "title": "Install Helm v3",
                 "filepath": "test/inputs/23/kubernetes/helm3.md",
                 "graph": {
-                  "key": "99037ade-063e-413e-a592-7fa7675649de",
+                  "key": "82b7f8cd-1d5e-4684-927c-0fca0dcd44b3",
                   "sequence": [
                     {
                       "group": "MacOS####Linux####Windows",
@@ -441,7 +441,7 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "ec19f2bb-be5d-49bb-ab4c-a30a80ffb165",
+                            "key": "c6d1dc0e-5c6a-4804-9df1-0582017217a1",
                             "sequence": [
                               {
                                 "group": "Homebrew####curl",
@@ -451,12 +451,12 @@
                                   {
                                     "member": 0,
                                     "graph": {
-                                      "key": "220ad0b9-fb3a-4e15-94e2-dbf0ec803e85",
+                                      "key": "10852f3a-dc0f-426a-8e93-57f1b1af0411",
                                       "sequence": [
                                         {
                                           "body": "brew install helm",
                                           "language": "shell",
-                                          "id": "205c1575-e21f-4398-bd17-8073651443d1-18"
+                                          "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-18"
                                         }
                                       ]
                                     },
@@ -465,12 +465,12 @@
                                   {
                                     "member": 1,
                                     "graph": {
-                                      "key": "f57c2de4-804e-4af1-acca-6dcafa8e495b",
+                                      "key": "1d403fc7-cce0-4faa-a7a5-a6250d2cd301",
                                       "sequence": [
                                         {
                                           "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                           "language": "shell",
-                                          "id": "205c1575-e21f-4398-bd17-8073651443d1-19"
+                                          "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-19"
                                         }
                                       ]
                                     },
@@ -485,12 +485,12 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "3d13f983-935f-497a-aa24-d24df768f0c7",
+                            "key": "c8c88f62-12fd-45a3-858d-063bfd7d7491",
                             "sequence": [
                               {
                                 "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                 "language": "shell",
-                                "id": "205c1575-e21f-4398-bd17-8073651443d1-20"
+                                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-20"
                               }
                             ]
                           },
@@ -499,12 +499,12 @@
                         {
                           "member": 2,
                           "graph": {
-                            "key": "270afc6d-a8b4-4470-a230-d77a4562c54d",
+                            "key": "051fa801-535b-4061-a727-0d05a56b820e",
                             "sequence": [
                               {
                                 "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                                 "language": "shell",
-                                "id": "205c1575-e21f-4398-bd17-8073651443d1-21"
+                                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-21"
                               }
                             ]
                           },
@@ -521,14 +521,14 @@
                 "title": "Choose a Kubernetes context",
                 "filepath": "test/inputs/23/kubernetes/context.md",
                 "graph": {
-                  "key": "c45cb8e1-03fb-4bf2-9607-8e7e02fa217e",
+                  "key": "e541cc0c-bca2-4470-ad5e-9679d9a4fa33",
                   "sequence": [
                     {
                       "key": "test/inputs/23/kubernetes/kubectl.md",
                       "title": "Install kubectl",
                       "filepath": "test/inputs/23/kubernetes/kubectl.md",
                       "graph": {
-                        "key": "83f87b4f-f16f-488b-922c-cc76c23d73f7",
+                        "key": "ae178c9c-b7e6-46c8-961b-6fc94d863d25",
                         "sequence": [
                           {
                             "group": "Linux####Windows####MacOS",
@@ -539,12 +539,12 @@
                               {
                                 "member": 0,
                                 "graph": {
-                                  "key": "239dbd2b-09dd-41ee-8599-51a91b8c70a5",
+                                  "key": "5ee7f4cf-948a-46ea-add8-b3f249ee06e8",
                                   "sequence": [
                                     {
                                       "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl\"",
                                       "language": "bash",
-                                      "id": "205c1575-e21f-4398-bd17-8073651443d1-22"
+                                      "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-22"
                                     }
                                   ]
                                 },
@@ -554,12 +554,12 @@
                               {
                                 "member": 1,
                                 "graph": {
-                                  "key": "8ea16b60-1fe1-4872-a4d2-0d97cbcb9e10",
+                                  "key": "fb2ceb60-ed08-4352-8664-929bd80231a2",
                                   "sequence": [
                                     {
                                       "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/windows/amd64/kubectl.exe\"",
                                       "language": "bash",
-                                      "id": "205c1575-e21f-4398-bd17-8073651443d1-23"
+                                      "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-23"
                                     }
                                   ]
                                 },
@@ -569,7 +569,7 @@
                               {
                                 "member": 2,
                                 "graph": {
-                                  "key": "bde1b075-a2ed-44af-93b1-cf4481135476",
+                                  "key": "81903a52-796c-4e10-9900-9d16db4f54c8",
                                   "sequence": [
                                     {
                                       "group": "Homebrew####curl",
@@ -579,12 +579,12 @@
                                         {
                                           "member": 0,
                                           "graph": {
-                                            "key": "be71b3b0-5bdc-4953-abcb-d17306f8da70",
+                                            "key": "7b6a0ecd-5634-4fb7-95de-d278c73150a4",
                                             "sequence": [
                                               {
                                                 "body": "brew install kubectl",
                                                 "language": "bash",
-                                                "id": "205c1575-e21f-4398-bd17-8073651443d1-24"
+                                                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-24"
                                               }
                                             ]
                                           },
@@ -594,7 +594,7 @@
                                         {
                                           "member": 1,
                                           "graph": {
-                                            "key": "bc7dd5f2-ce99-4c87-8302-a9fc638a9953",
+                                            "key": "572f02b1-aa48-44e9-bfcf-01ec3de59c86",
                                             "sequence": [
                                               {
                                                 "group": "Intel####Apple Silicon",
@@ -604,12 +604,12 @@
                                                   {
                                                     "member": 0,
                                                     "graph": {
-                                                      "key": "894df14b-9a77-41bb-bb78-4a32aacf0f71",
+                                                      "key": "a4acb5ad-0096-4ea3-8d06-fd26cb9f9442",
                                                       "sequence": [
                                                         {
                                                           "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl.sha256\"",
                                                           "language": "bash",
-                                                          "id": "205c1575-e21f-4398-bd17-8073651443d1-25"
+                                                          "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-25"
                                                         }
                                                       ]
                                                     },
@@ -618,12 +618,12 @@
                                                   {
                                                     "member": 1,
                                                     "graph": {
-                                                      "key": "851ee0bf-e72f-4784-98a6-641646787c22",
+                                                      "key": "385d8dfc-e6f2-4192-bf2a-85c3bfcde9ba",
                                                       "sequence": [
                                                         {
                                                           "body": "curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/arm64/kubectl.sha256\"",
                                                           "language": "bash",
-                                                          "id": "205c1575-e21f-4398-bd17-8073651443d1-26"
+                                                          "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-26"
                                                         }
                                                       ]
                                                     },
@@ -634,7 +634,7 @@
                                               {
                                                 "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/amd64/kubectl\"\nAnd for macOS on Apple Silicon, type:\n    \ncurl -LO \"https://dl.k8s.io/release/v1.23.0/bin/darwin/arm64/kubectl\"",
                                                 "language": "bash",
-                                                "id": "205c1575-e21f-4398-bd17-8073651443d1-27"
+                                                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-27"
                                               }
                                             ]
                                           },
@@ -663,12 +663,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "1ed2656e-da6a-44ab-ad7a-62b5f6fef61e",
+                            "key": "ab7f8cfe-ea12-4b7c-a9b5-c720a6a24225",
                             "sequence": [
                               {
                                 "body": "kubectl config set-context \"\"",
                                 "language": "shell",
-                                "id": "205c1575-e21f-4398-bd17-8073651443d1-28"
+                                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-28"
                               }
                             ]
                           },
@@ -683,7 +683,7 @@
               {
                 "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
                 "language": "shell",
-                "id": "205c1575-e21f-4398-bd17-8073651443d1-29"
+                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-29"
               }
             ]
           },
@@ -718,16 +718,17 @@
       "group": "Example: Using Ray Tasks to Parallelize a Function####Example: Using Ray Actors to Parallelize a Class####Example: Creating and Transforming Datasets",
       "title": "Run a Ray Job",
       "source": "placeholder",
+      "provenance": ["test/inputs/23/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "9e9cace1-59b6-4e01-abea-7a5a1e8c27b9",
+            "key": "0c3d2694-3b5d-461a-8b4c-4b208edaa2bf",
             "sequence": [
               {
                 "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
                 "language": "python",
-                "id": "205c1575-e21f-4398-bd17-8073651443d1-30"
+                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-30"
               }
             ]
           },
@@ -737,12 +738,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "7f802c9f-eec8-4898-9834-ee564886831f",
+            "key": "89fdcd6f-484d-486f-9c6c-7a656d05f316",
             "sequence": [
               {
                 "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
                 "language": "python",
-                "id": "205c1575-e21f-4398-bd17-8073651443d1-31"
+                "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-31"
               }
             ]
           },
@@ -752,19 +753,19 @@
         {
           "member": 2,
           "graph": {
-            "key": "b24d3844-510c-408b-a9d9-95f2e3bce344",
+            "key": "d049e069-32db-47fc-8dab-62b58119eef9",
             "sequence": [
               {
                 "key": "test/inputs/23/data.md",
                 "title": "Install Ray Data",
                 "filepath": "test/inputs/23/data.md",
                 "graph": {
-                  "key": "c759dacb-0bb2-4acc-a2cd-23dd7a56bfeb",
+                  "key": "b8a44ecf-4374-4df3-b8e6-29fe8670abbb",
                   "sequence": [
                     {
                       "body": "pip install \"ray[data]\" dask",
                       "language": "shell",
-                      "id": "205c1575-e21f-4398-bd17-8073651443d1-32"
+                      "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-32"
                     }
                   ]
                 },
@@ -774,16 +775,17 @@
                 "group": "New Dataset from Range####New Dataset from File",
                 "title": "Creating and Transforming Datasets",
                 "source": "placeholder",
+                "provenance": ["test/inputs/23/in.md"],
                 "choices": [
                   {
                     "member": 0,
                     "graph": {
-                      "key": "2b531a4c-1ed9-482f-ace7-d354c890b09e",
+                      "key": "3ec18e15-4d00-48d5-9cd7-594e30cd5b71",
                       "sequence": [
                         {
                           "body": "import ray\n\n# Create a Dataset of Python objects.\nds = ray.data.range(10000)\n# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)\n\nds.take(5)\n# -> [0, 1, 2, 3, 4]\n\nds.count()\n# -> 10000\n\n# Create a Dataset of Arrow records.\nds = ray.data.from_items([{\"col1\": i, \"col2\": str(i)} for i in range(10000)])\n# -> Dataset(num_blocks=200, num_rows=10000, schema={col1: int64, col2: string})\n\nds.show(5)\n# -> {'col1': 0, 'col2': '0'}\n# -> {'col1': 1, 'col2': '1'}\n# -> {'col1': 2, 'col2': '2'}\n# -> {'col1': 3, 'col2': '3'}\n# -> {'col1': 4, 'col2': '4'}\n\nds.schema()\n# -> col1: int64\n# -> col2: string",
                           "language": "python",
-                          "id": "205c1575-e21f-4398-bd17-8073651443d1-33"
+                          "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-33"
                         }
                       ]
                     },
@@ -793,12 +795,12 @@
                   {
                     "member": 1,
                     "graph": {
-                      "key": "f2b8d190-f0a2-47ae-9b6a-41ef26cf5cc3",
+                      "key": "5d451095-471f-43ed-a9e5-92ac5c60eaec",
                       "sequence": [
                         {
                           "body": "import ray\nimport pandas as pd\nimport dask.dataframe as dd\n\n# Create a Dataset from a list of Pandas DataFrame objects.\npdf = pd.DataFrame({\"one\": [1, 2, 3], \"two\": [\"a\", \"b\", \"c\"]})\nds = ray.data.from_pandas([pdf])\n\n# Create a Dataset from a Dask-on-Ray DataFrame.\ndask_df = dd.from_pandas(pdf, npartitions=10)\nds = ray.data.from_dask(dask_df)\n\n# Transform the dataset using .map()\nds = ray.data.range(10000)\nds = ds.map(lambda x: x * 2)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1123.54it/s]\n# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)\nds.take(5)\n# -> [0, 2, 4, 6, 8]\n\n# Transform the dataset using .filter()\nds.filter(lambda x: x > 5).take(5)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1859.63it/s]\n# -> [6, 8, 10, 12, 14]\n\n# Transform the dataset using .flat_map()\nds.flat_map(lambda x: [x, -x]).take(5)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1568.10it/s]\n# -> [0, 0, 2, -2, 4]",
                           "language": "python",
-                          "id": "205c1575-e21f-4398-bd17-8073651443d1-34"
+                          "id": "c7521bd3-c13f-42b1-b078-2f4a788fbcc1-34"
                         }
                       ]
                     },

--- a/test/inputs/23/wizard-win32.json
+++ b/test/inputs/23/wizard-win32.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "53c12191-ece0-423c-9135-e668f4f8cffd",
+            "key": "d7fdbdbb-3afb-463e-ba47-7b3e757f5bfa",
             "sequence": [
               {
                 "body": "pip install -U ray",
                 "language": "shell",
-                "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-0"
+                "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-0"
               }
             ]
           },
@@ -24,26 +24,26 @@
         {
           "member": 1,
           "graph": {
-            "key": "4801f854-8517-484b-bc86-2ec774eb00bb",
+            "key": "d6c460a9-d1ab-4dd0-88e0-624c2543d759",
             "sequence": [
               {
                 "key": "test/inputs/23/kubernetes/kubectl.md",
                 "title": "Install kubectl",
                 "filepath": "test/inputs/23/kubernetes/kubectl.md",
                 "graph": {
-                  "key": "474fa394-550f-4364-8f39-713632e8ec0a",
+                  "key": "895a1987-fa12-4742-84ec-f2da7acaeb5e",
                   "sequence": [
                     {
                       "key": "org.kubernetes-sigs.kui/choice/platform",
                       "title": "Install kubectl",
                       "filepath": "",
                       "graph": {
-                        "key": "e56ab1cd-95c7-4cc1-a2b3-d598a8b92616",
+                        "key": "848291da-2401-49cb-8d90-a1b5515a47b1",
                         "sequence": [
                           {
                             "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/windows/amd64/kubectl.exe\"",
                             "language": "bash",
-                            "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-13"
+                            "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-13"
                           }
                         ]
                       },
@@ -58,19 +58,19 @@
                 "title": "Install Helm v3",
                 "filepath": "test/inputs/23/kubernetes/helm3.md",
                 "graph": {
-                  "key": "dcdb5538-7b37-4585-860c-a2752993758f",
+                  "key": "861d556f-3187-4c37-be80-f9324f515a87",
                   "sequence": [
                     {
                       "key": "org.kubernetes-sigs.kui/choice/platform",
                       "title": "Install Helm v3",
                       "filepath": "",
                       "graph": {
-                        "key": "35b38178-408e-4459-8ade-a148022bbbd5",
+                        "key": "60473f01-c35f-4858-abe2-0dcc233b2314",
                         "sequence": [
                           {
                             "body": "bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)",
                             "language": "shell",
-                            "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-21"
+                            "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-21"
                           }
                         ]
                       },
@@ -85,26 +85,26 @@
                 "title": "Choose a Kubernetes context",
                 "filepath": "test/inputs/23/kubernetes/context.md",
                 "graph": {
-                  "key": "6c113c04-4aca-47dd-a5c8-fa79c8e03dc8",
+                  "key": "f1167b01-4a21-4b50-bdb5-d7d3b5cbf105",
                   "sequence": [
                     {
                       "key": "test/inputs/23/kubernetes/kubectl.md",
                       "title": "Install kubectl",
                       "filepath": "test/inputs/23/kubernetes/kubectl.md",
                       "graph": {
-                        "key": "b17faf2f-78e0-4dc8-ba42-14f099826564",
+                        "key": "03aef135-1147-4e4c-8c63-ed6333aca768",
                         "sequence": [
                           {
                             "key": "org.kubernetes-sigs.kui/choice/platform",
                             "title": "Install kubectl",
                             "filepath": "",
                             "graph": {
-                              "key": "cd00efc2-ddb4-4138-aa4a-f1a0658989ae",
+                              "key": "f8faa3f6-d714-4daf-8dc8-13608e44808c",
                               "sequence": [
                                 {
                                   "body": "curl -LO \"https://dl.k8s.io/release/v1.23.0/bin/windows/amd64/kubectl.exe\"",
                                   "language": "bash",
-                                  "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-23"
+                                  "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-23"
                                 }
                               ]
                             },
@@ -123,12 +123,12 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "3e739408-5128-4217-9cde-6a939601e14e",
+                            "key": "79032fc9-782f-4c15-88a3-4b75330ccc08",
                             "sequence": [
                               {
                                 "body": "kubectl config set-context \"\"",
                                 "language": "shell",
-                                "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-28"
+                                "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-28"
                               }
                             ]
                           },
@@ -143,7 +143,7 @@
               {
                 "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
                 "language": "shell",
-                "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-29"
+                "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-29"
               }
             ]
           },
@@ -178,16 +178,17 @@
       "group": "Example: Using Ray Tasks to Parallelize a Function####Example: Using Ray Actors to Parallelize a Class####Example: Creating and Transforming Datasets",
       "title": "Run a Ray Job",
       "source": "placeholder",
+      "provenance": ["test/inputs/23/in.md"],
       "choices": [
         {
           "member": 0,
           "graph": {
-            "key": "6e18510d-4f20-43c3-8038-0da569c4fc85",
+            "key": "690f3106-a1c7-46c3-8611-8a7dcaa265e5",
             "sequence": [
               {
                 "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
                 "language": "python",
-                "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-30"
+                "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-30"
               }
             ]
           },
@@ -197,12 +198,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "356edeca-a7f4-4213-bbdf-5b45537c2dcb",
+            "key": "ea720a38-5a64-4ea5-983b-90229987089d",
             "sequence": [
               {
                 "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
                 "language": "python",
-                "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-31"
+                "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-31"
               }
             ]
           },
@@ -212,33 +213,33 @@
         {
           "member": 2,
           "graph": {
-            "key": "29a023d5-333d-4eaa-8878-2d1eb36a2c21",
+            "key": "7ab9adab-e030-4600-a2eb-bfa406d559f7",
             "sequence": [
               {
                 "key": "Creating and Transforming Datasets",
                 "title": "Creating and Transforming Datasets",
                 "filepath": "",
                 "graph": {
-                  "key": "6e720198-63cc-4a7b-b8d8-8067ac890740",
+                  "key": "1c9252eb-983e-4b5b-8861-dafe8c283a0d",
                   "sequence": [
                     {
                       "key": "Prerequisites",
                       "title": "Prerequisites",
                       "filepath": "",
                       "graph": {
-                        "key": "a48b3d89-1a9c-46c6-966e-954341e69442",
+                        "key": "06434bbe-8b8c-4a56-bdae-623168db198b",
                         "sequence": [
                           {
                             "key": "test/inputs/23/data.md",
                             "title": "Install Ray Data",
                             "filepath": "test/inputs/23/data.md",
                             "graph": {
-                              "key": "60f821b2-cb09-4a6a-9957-6f86ad355ce6",
+                              "key": "adfaf3d3-24dd-4286-86f6-f24c879d46d9",
                               "sequence": [
                                 {
                                   "body": "pip install \"ray[data]\" dask",
                                   "language": "shell",
-                                  "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-32"
+                                  "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-32"
                                 }
                               ]
                             },
@@ -253,22 +254,23 @@
                       "title": "Main Tasks",
                       "filepath": "",
                       "graph": {
-                        "key": "47a9ae11-7dd3-4e2b-b995-85683250658d",
+                        "key": "fee2ba09-691f-4da1-8321-2830cad24f02",
                         "sequence": [
                           {
                             "group": "New Dataset from Range####New Dataset from File",
                             "title": "Main Tasks",
                             "source": "placeholder",
+                            "provenance": ["test/inputs/23/in.md"],
                             "choices": [
                               {
                                 "member": 0,
                                 "graph": {
-                                  "key": "c06324b2-d9bf-4a1d-8202-fb365d2d0bdb",
+                                  "key": "f1a311cc-763f-4709-b8c4-50352e624494",
                                   "sequence": [
                                     {
                                       "body": "import ray\n\n# Create a Dataset of Python objects.\nds = ray.data.range(10000)\n# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)\n\nds.take(5)\n# -> [0, 1, 2, 3, 4]\n\nds.count()\n# -> 10000\n\n# Create a Dataset of Arrow records.\nds = ray.data.from_items([{\"col1\": i, \"col2\": str(i)} for i in range(10000)])\n# -> Dataset(num_blocks=200, num_rows=10000, schema={col1: int64, col2: string})\n\nds.show(5)\n# -> {'col1': 0, 'col2': '0'}\n# -> {'col1': 1, 'col2': '1'}\n# -> {'col1': 2, 'col2': '2'}\n# -> {'col1': 3, 'col2': '3'}\n# -> {'col1': 4, 'col2': '4'}\n\nds.schema()\n# -> col1: int64\n# -> col2: string",
                                       "language": "python",
-                                      "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-33"
+                                      "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-33"
                                     }
                                   ]
                                 },
@@ -278,12 +280,12 @@
                               {
                                 "member": 1,
                                 "graph": {
-                                  "key": "5f720dba-6d97-4c9d-a4b8-03c65d6c8763",
+                                  "key": "9d1a1ea2-1885-4037-a4ab-981e34e32ec4",
                                   "sequence": [
                                     {
                                       "body": "import ray\nimport pandas as pd\nimport dask.dataframe as dd\n\n# Create a Dataset from a list of Pandas DataFrame objects.\npdf = pd.DataFrame({\"one\": [1, 2, 3], \"two\": [\"a\", \"b\", \"c\"]})\nds = ray.data.from_pandas([pdf])\n\n# Create a Dataset from a Dask-on-Ray DataFrame.\ndask_df = dd.from_pandas(pdf, npartitions=10)\nds = ray.data.from_dask(dask_df)\n\n# Transform the dataset using .map()\nds = ray.data.range(10000)\nds = ds.map(lambda x: x * 2)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1123.54it/s]\n# -> Dataset(num_blocks=200, num_rows=10000, schema=<class 'int'>)\nds.take(5)\n# -> [0, 2, 4, 6, 8]\n\n# Transform the dataset using .filter()\nds.filter(lambda x: x > 5).take(5)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1859.63it/s]\n# -> [6, 8, 10, 12, 14]\n\n# Transform the dataset using .flat_map()\nds.flat_map(lambda x: [x, -x]).take(5)\n# -> Map Progress: 100%|████████████████████| 200/200 [00:00<00:00, 1568.10it/s]\n# -> [0, 0, 2, -2, 4]",
                                       "language": "python",
-                                      "id": "838fb7a3-49c8-4da1-b390-6b064f1dec84-34"
+                                      "id": "808e236f-4da3-4602-8f40-ad6f9ddb6dbf-34"
                                     }
                                   ]
                                 },

--- a/test/inputs/3/wizard-noaprioris.json
+++ b/test/inputs/3/wizard-noaprioris.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "de0a8778-b1fe-49b0-b87e-c65a425c0dde",
+            "key": "ef0d56c8-178a-434a-91f6-9d3a1269b2ca",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "c98fe7fd-f596-47b5-9b0b-4bb0e66f79f8-1"
+                "id": "9efcc014-3045-4caa-acf2-2a0440a7fb6a-1"
               }
             ]
           },
@@ -47,25 +47,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "f33b6b2d-af44-4584-8a1e-057d674f13d3",
+            "key": "5b965b0a-921d-4397-91af-76a45b24c16f",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "c98fe7fd-f596-47b5-9b0b-4bb0e66f79f8-2"
+                "id": "9efcc014-3045-4caa-acf2-2a0440a7fb6a-2"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "c98fe7fd-f596-47b5-9b0b-4bb0e66f79f8-3"
+                "id": "9efcc014-3045-4caa-acf2-2a0440a7fb6a-3"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "c98fe7fd-f596-47b5-9b0b-4bb0e66f79f8-4"
+                "id": "9efcc014-3045-4caa-acf2-2a0440a7fb6a-4"
               }
             ]
           },
@@ -74,13 +74,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "b91e75b4-8171-4c62-866b-1d3badab813a",
+            "key": "e8798635-76ce-446a-ad46-07ab3c4fdafb",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "c98fe7fd-f596-47b5-9b0b-4bb0e66f79f8-5"
+                "id": "9efcc014-3045-4caa-acf2-2a0440a7fb6a-5"
               }
             ]
           },

--- a/test/inputs/3/wizard-noopt.json
+++ b/test/inputs/3/wizard-noopt.json
@@ -5,13 +5,13 @@
       "title": "importa.md",
       "filepath": "",
       "graph": {
-        "key": "257363de-c8b3-4306-b0f6-2d4d51123fa0",
+        "key": "91e63ca6-1a14-4d5b-91b0-8cc11e1c3777",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-0"
+            "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-0"
           }
         ]
       },
@@ -32,12 +32,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "8994939a-c84d-4694-9cd5-6adb89a11749",
+            "key": "19cba5c2-b886-4bc8-89c0-8196feda2b16",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-1"
+                "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-1"
               }
             ]
           },
@@ -70,25 +70,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "504dc2bd-d4a5-41c0-9923-4ad90aa640f9",
+            "key": "87fd1137-48cd-4445-87b1-819f851af70e",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-2"
+                "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-2"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-3"
+                "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-3"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-4"
+                "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-4"
               }
             ]
           },
@@ -97,13 +97,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "6a17de68-0db3-4377-a9f4-ffe76d7b847d",
+            "key": "b57037cd-30af-4d53-952e-a3ee3e0a6dcd",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-5"
+                "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-5"
               }
             ]
           },
@@ -139,14 +139,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "6038476c-40ff-4f7e-b4a5-852cda1decf7",
+            "key": "181059c1-6750-41d7-9dd2-c36c8aaedc4a",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "cdc97a06-ee5f-4a99-9fe2-e4a83f7ad782",
+                  "key": "6ca471a0-8b22-41a4-aac8-4597aa09be04",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -157,25 +157,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "d9313068-5ab7-4dba-8e97-817112b6bc2a",
+                            "key": "4afa9403-a31d-4bd3-af6f-c875f54e457a",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-6"
+                                "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-6"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-7"
+                                "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-7"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-8"
+                                "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-8"
                               }
                             ]
                           },
@@ -184,13 +184,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "1ee5f61b-f566-468a-929e-d68ff243e1e8",
+                            "key": "3829c35e-1e77-4417-9751-5dd9db6c2b37",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-9"
+                                "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-9"
                               }
                             ]
                           },
@@ -210,20 +210,20 @@
         {
           "member": 1,
           "graph": {
-            "key": "1bec8c22-86ed-4982-bd2d-8da5e35011d3",
+            "key": "c8a989c4-8c8a-405d-8e86-cf3974dd7801",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importc.md",
                 "title": "importc.md",
                 "filepath": "test/inputs/snippets/importc.md",
                 "graph": {
-                  "key": "a6994cd1-2d0a-4f17-83a8-a2eae8be3b2c",
+                  "key": "5f6c6751-7472-4aac-8fba-b86b17615ac1",
                   "sequence": [
                     {
                       "body": "echo CCC",
                       "language": "bash",
                       "validate": true,
-                      "id": "6a2cc6f5-f9ae-4b5c-98ec-8dc1af14bc96-10"
+                      "id": "c2dfad11-4c36-414d-b681-d221f1f516b4-10"
                     }
                   ]
                 },

--- a/test/inputs/3/wizard.json
+++ b/test/inputs/3/wizard.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "c242586e-bb1b-49e2-bdf0-cec9e7bf21f6",
+            "key": "a08c4fe3-c676-45c8-8340-581597f013dd",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "f62e6ba0-2e99-4d45-bc6d-72fa8fd92f9e-1"
+                "id": "5e114d97-18aa-4624-8040-5e561940541a-1"
               }
             ]
           },
@@ -47,25 +47,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "cf060f74-2d11-49e2-9c9d-77079d90303a",
+            "key": "d5996b2c-07a6-4228-887f-549bf776343a",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "f62e6ba0-2e99-4d45-bc6d-72fa8fd92f9e-2"
+                "id": "5e114d97-18aa-4624-8040-5e561940541a-2"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "f62e6ba0-2e99-4d45-bc6d-72fa8fd92f9e-3"
+                "id": "5e114d97-18aa-4624-8040-5e561940541a-3"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "f62e6ba0-2e99-4d45-bc6d-72fa8fd92f9e-4"
+                "id": "5e114d97-18aa-4624-8040-5e561940541a-4"
               }
             ]
           },
@@ -74,13 +74,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "9ac42edc-e35c-40b8-9645-ca2e0fd54843",
+            "key": "2606f33f-cbe3-40a6-8c44-6713c6d1eefe",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "f62e6ba0-2e99-4d45-bc6d-72fa8fd92f9e-5"
+                "id": "5e114d97-18aa-4624-8040-5e561940541a-5"
               }
             ]
           },

--- a/test/inputs/4/wizard-noaprioris.json
+++ b/test/inputs/4/wizard-noaprioris.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "79ff4f2c-5714-440a-8e17-da3bbf892bc0",
+            "key": "3a0e72bc-d7ed-4bfe-8e5e-2ac60316d062",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "cee74335-5758-494b-974e-b7839cdcb0a6-1"
+                "id": "38d96122-8080-44f5-ae90-e8e3549e8ab4-1"
               }
             ]
           },
@@ -47,14 +47,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "ecd56024-6337-4bcc-9c8a-0071e155657b",
+            "key": "b9974081-a983-4274-826c-efb7de2a2e91",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "02383303-0f4d-4d40-b3e9-c3265c48132c",
+                  "key": "42f5ab7f-440a-4177-b2d2-79d5ee9dac11",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -65,25 +65,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "6e99e12a-c516-4447-81c9-845b0f0879f1",
+                            "key": "81e33062-ced2-4f17-b231-81797cabf639",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "cee74335-5758-494b-974e-b7839cdcb0a6-2"
+                                "id": "38d96122-8080-44f5-ae90-e8e3549e8ab4-2"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "cee74335-5758-494b-974e-b7839cdcb0a6-3"
+                                "id": "38d96122-8080-44f5-ae90-e8e3549e8ab4-3"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "cee74335-5758-494b-974e-b7839cdcb0a6-4"
+                                "id": "38d96122-8080-44f5-ae90-e8e3549e8ab4-4"
                               }
                             ]
                           },
@@ -92,13 +92,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "f36cbf77-ae41-4802-8ee7-5718c8a20bb1",
+                            "key": "9c2e6d47-30e2-4344-a3c8-c6e5acb2a1c3",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "cee74335-5758-494b-974e-b7839cdcb0a6-5"
+                                "id": "38d96122-8080-44f5-ae90-e8e3549e8ab4-5"
                               }
                             ]
                           },
@@ -118,12 +118,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "85dc8587-094d-4f40-8957-847a2aea22b4",
+            "key": "6f7e2b4d-21f0-4177-a921-97701e937a4c",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "cee74335-5758-494b-974e-b7839cdcb0a6-6"
+                "id": "38d96122-8080-44f5-ae90-e8e3549e8ab4-6"
               }
             ]
           },

--- a/test/inputs/4/wizard-noopt.json
+++ b/test/inputs/4/wizard-noopt.json
@@ -5,13 +5,13 @@
       "title": "importa.md",
       "filepath": "",
       "graph": {
-        "key": "ff7339b6-ff15-4de2-991b-2a965e7a5be3",
+        "key": "05f4ad94-7a48-4518-88fc-06495f877e57",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "ebe68888-85b5-4d29-8ff8-c058a1d6d88f-0"
+            "id": "feb13c07-1334-4fa3-a2b5-415b06d5f873-0"
           }
         ]
       },
@@ -32,12 +32,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "23e76316-11c0-47d5-a712-abd452cb18ea",
+            "key": "7d035bc8-a9b1-43cc-bd3b-1023be979c96",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "ebe68888-85b5-4d29-8ff8-c058a1d6d88f-1"
+                "id": "feb13c07-1334-4fa3-a2b5-415b06d5f873-1"
               }
             ]
           },
@@ -69,14 +69,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "e2b8fad2-78bc-4aaa-9c60-bfaca34b636e",
+            "key": "67f576da-43ef-4bd2-a67b-191fcf9eca52",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "17a6ec70-3ece-4b04-806f-a9efe6c47906",
+                  "key": "6b1ada2c-03fd-444a-9ce4-f468a1bd00a2",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -87,25 +87,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "efaa3bf1-1856-48b8-a004-e2f33329a77f",
+                            "key": "5c0296fb-fe6f-4572-9af9-9c5a48e92807",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "ebe68888-85b5-4d29-8ff8-c058a1d6d88f-2"
+                                "id": "feb13c07-1334-4fa3-a2b5-415b06d5f873-2"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "ebe68888-85b5-4d29-8ff8-c058a1d6d88f-3"
+                                "id": "feb13c07-1334-4fa3-a2b5-415b06d5f873-3"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "ebe68888-85b5-4d29-8ff8-c058a1d6d88f-4"
+                                "id": "feb13c07-1334-4fa3-a2b5-415b06d5f873-4"
                               }
                             ]
                           },
@@ -114,13 +114,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "23f062af-f4b9-4521-9dfe-0fe85bdc91ba",
+                            "key": "7a079363-c803-4223-8bde-134c5f834508",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "ebe68888-85b5-4d29-8ff8-c058a1d6d88f-5"
+                                "id": "feb13c07-1334-4fa3-a2b5-415b06d5f873-5"
                               }
                             ]
                           },
@@ -140,12 +140,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "0d0cf103-7637-4e3e-818b-b8df9c12c32b",
+            "key": "27644b36-219f-42b6-9367-78c707d1400c",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "ebe68888-85b5-4d29-8ff8-c058a1d6d88f-6"
+                "id": "feb13c07-1334-4fa3-a2b5-415b06d5f873-6"
               }
             ]
           },

--- a/test/inputs/4/wizard.json
+++ b/test/inputs/4/wizard.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "cea9efc0-1f73-4793-8784-a082a8da4762",
+            "key": "ad50fd77-b196-4fa4-9cda-6cd01fd5e551",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "59d7c4c1-12b4-4ee9-8f4a-09d64388b938-1"
+                "id": "3c2406c5-7045-4a2a-b5b0-69223a6ccf86-1"
               }
             ]
           },
@@ -47,14 +47,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "00b920eb-8b99-4f68-9346-c4c0303b87be",
+            "key": "8b4ea430-49f6-454e-897d-a728f6242409",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "445f0fe2-f5ba-43cf-bb44-8a77eced3a42",
+                  "key": "4aa0b11f-8391-4def-9806-d7efc01100ed",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -65,25 +65,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "a925c00d-1673-4777-8955-006c49b3e4cc",
+                            "key": "0e06d0e3-aaef-479f-ae6d-2a3fd6c282b5",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "59d7c4c1-12b4-4ee9-8f4a-09d64388b938-2"
+                                "id": "3c2406c5-7045-4a2a-b5b0-69223a6ccf86-2"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "59d7c4c1-12b4-4ee9-8f4a-09d64388b938-3"
+                                "id": "3c2406c5-7045-4a2a-b5b0-69223a6ccf86-3"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "59d7c4c1-12b4-4ee9-8f4a-09d64388b938-4"
+                                "id": "3c2406c5-7045-4a2a-b5b0-69223a6ccf86-4"
                               }
                             ]
                           },
@@ -92,13 +92,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "7d07801b-1b0f-4f98-9fdf-96a8c6625263",
+                            "key": "4d05835d-1bdc-4c57-945e-4c87e781e41a",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "59d7c4c1-12b4-4ee9-8f4a-09d64388b938-5"
+                                "id": "3c2406c5-7045-4a2a-b5b0-69223a6ccf86-5"
                               }
                             ]
                           },
@@ -118,12 +118,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "98e40c29-b60a-4daf-83f7-42217ecf961b",
+            "key": "34a1910c-6759-41df-8a06-497979e1c989",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "59d7c4c1-12b4-4ee9-8f4a-09d64388b938-6"
+                "id": "3c2406c5-7045-4a2a-b5b0-69223a6ccf86-6"
               }
             ]
           },

--- a/test/inputs/5/wizard-noaprioris.json
+++ b/test/inputs/5/wizard-noaprioris.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "808dadc2-94b4-441b-8d16-4b7679b17761",
+            "key": "3ac8b69f-c22b-45cc-85d4-4dca23cdb12a",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "fb2a27c2-7600-45e9-b7cd-30e462ecd80c-1"
+                "id": "af86b9f0-7a42-4108-a8c0-3b6b1c017929-1"
               }
             ]
           },
@@ -47,14 +47,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "d9756205-ad9f-4ef8-bd96-5c497242e7b2",
+            "key": "c7d8206b-2fa8-4adf-9fe8-8566a4f714a0",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "65104182-88e5-4dff-bbde-75b221f577c9",
+                  "key": "bfbf4c7e-d95c-4240-88ac-4b229b8acbf8",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -65,25 +65,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "aad4cb1f-bc91-484b-a2fb-c6a3a00de70f",
+                            "key": "afd4282d-da01-46ec-b803-d5dc0a956faa",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "fb2a27c2-7600-45e9-b7cd-30e462ecd80c-2"
+                                "id": "af86b9f0-7a42-4108-a8c0-3b6b1c017929-2"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "fb2a27c2-7600-45e9-b7cd-30e462ecd80c-3"
+                                "id": "af86b9f0-7a42-4108-a8c0-3b6b1c017929-3"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "fb2a27c2-7600-45e9-b7cd-30e462ecd80c-4"
+                                "id": "af86b9f0-7a42-4108-a8c0-3b6b1c017929-4"
                               }
                             ]
                           },
@@ -92,13 +92,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "44b8d616-5049-498a-baba-7c1576cd47b5",
+                            "key": "f19a250e-68a6-462b-b01c-fbc259ef75d0",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "fb2a27c2-7600-45e9-b7cd-30e462ecd80c-5"
+                                "id": "af86b9f0-7a42-4108-a8c0-3b6b1c017929-5"
                               }
                             ]
                           },
@@ -118,12 +118,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "2b561f90-469d-478a-9be4-9e82d3cae9d0",
+            "key": "71d65716-b7cb-41c0-b4f1-ba0aedf4a3be",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "fb2a27c2-7600-45e9-b7cd-30e462ecd80c-6"
+                "id": "af86b9f0-7a42-4108-a8c0-3b6b1c017929-6"
               }
             ]
           },
@@ -133,14 +133,14 @@
         {
           "member": 2,
           "graph": {
-            "key": "60d01554-43ea-4208-8625-3ec30470ca81",
+            "key": "3f05690d-f216-426d-9065-1b44f748572a",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "3d8b54fb-f668-47cb-8cb0-928db85b6500",
+                  "key": "15c2534f-1f22-4a55-a1ce-befac2dfefd2",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -151,25 +151,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "375ae3f1-455a-4163-a0c5-fc417d6c91dc",
+                            "key": "0b2906c1-203e-4921-9c7e-bb1f795626cc",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "fb2a27c2-7600-45e9-b7cd-30e462ecd80c-7"
+                                "id": "af86b9f0-7a42-4108-a8c0-3b6b1c017929-7"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "fb2a27c2-7600-45e9-b7cd-30e462ecd80c-8"
+                                "id": "af86b9f0-7a42-4108-a8c0-3b6b1c017929-8"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "fb2a27c2-7600-45e9-b7cd-30e462ecd80c-9"
+                                "id": "af86b9f0-7a42-4108-a8c0-3b6b1c017929-9"
                               }
                             ]
                           },
@@ -178,13 +178,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "a6a1cd77-d988-4534-adc0-8b0df59b6305",
+                            "key": "ad8fdf65-17d5-4a65-8f89-c719fa4e2d5b",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "fb2a27c2-7600-45e9-b7cd-30e462ecd80c-10"
+                                "id": "af86b9f0-7a42-4108-a8c0-3b6b1c017929-10"
                               }
                             ]
                           },

--- a/test/inputs/5/wizard-noopt.json
+++ b/test/inputs/5/wizard-noopt.json
@@ -5,13 +5,13 @@
       "title": "importa.md",
       "filepath": "",
       "graph": {
-        "key": "7391d566-0710-471b-be3c-854eedbd1117",
+        "key": "cb0f8643-b189-4c5f-a3fb-589a259e631a",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-0"
+            "id": "a635559c-1723-4a43-b61f-4dfbc11063de-0"
           }
         ]
       },
@@ -32,12 +32,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "980ddcfa-fe78-4a1d-a706-05fb4bbe213b",
+            "key": "16336630-ea65-48a1-ab8a-70f2652910bd",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-1"
+                "id": "a635559c-1723-4a43-b61f-4dfbc11063de-1"
               }
             ]
           },
@@ -69,14 +69,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "99fcc234-964d-4880-91bb-c01622c1ad4a",
+            "key": "460e165a-3de9-4572-8504-a981c0386fcf",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "c5519460-7089-4a19-897e-b0db31fe8b36",
+                  "key": "8188fb7f-e573-4a75-b172-e008ea4e4e55",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -87,25 +87,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "46965fca-62c1-43a1-869e-da1c17796462",
+                            "key": "a47c4ffd-d43e-4b6e-b7fa-aa39ef57de73",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-2"
+                                "id": "a635559c-1723-4a43-b61f-4dfbc11063de-2"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-3"
+                                "id": "a635559c-1723-4a43-b61f-4dfbc11063de-3"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-4"
+                                "id": "a635559c-1723-4a43-b61f-4dfbc11063de-4"
                               }
                             ]
                           },
@@ -114,13 +114,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "abd3c200-dac2-4c39-84f3-69583dba4772",
+                            "key": "4cfc3b5b-2951-4ff4-b25f-fe6a1ac8feb9",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-5"
+                                "id": "a635559c-1723-4a43-b61f-4dfbc11063de-5"
                               }
                             ]
                           },
@@ -140,12 +140,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "5fbde9be-b2ae-4ebf-8418-28968e9b5c0e",
+            "key": "9e48086a-47ae-4fd7-b722-d0e0a99405a2",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-6"
+                "id": "a635559c-1723-4a43-b61f-4dfbc11063de-6"
               }
             ]
           },
@@ -155,14 +155,14 @@
         {
           "member": 2,
           "graph": {
-            "key": "2793d678-24e9-4392-8d62-117aa4acb768",
+            "key": "a6c5771c-099a-420d-8696-7e60b17c60bc",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "41d178fb-aeb9-4baa-8006-fd3f459c548f",
+                  "key": "6de974d9-3e6e-4f8a-81ff-a64b86cd0f8b",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -173,25 +173,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "df519f5e-29ba-436c-94dd-1e9af83c7f23",
+                            "key": "a0f0bda1-dc3b-4587-aa7d-66039109e1d8",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-7"
+                                "id": "a635559c-1723-4a43-b61f-4dfbc11063de-7"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-8"
+                                "id": "a635559c-1723-4a43-b61f-4dfbc11063de-8"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-9"
+                                "id": "a635559c-1723-4a43-b61f-4dfbc11063de-9"
                               }
                             ]
                           },
@@ -200,13 +200,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "9f20db30-13e6-48e4-a784-891eb6189b96",
+                            "key": "b1479367-2e12-4724-a95e-81a6b9af79d3",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "cda8a70e-9a47-4017-a3ae-ebf1b7911841-10"
+                                "id": "a635559c-1723-4a43-b61f-4dfbc11063de-10"
                               }
                             ]
                           },

--- a/test/inputs/5/wizard.json
+++ b/test/inputs/5/wizard.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "773fb9da-7683-46f7-b656-2c53b595f2f4",
+            "key": "63287d7e-448f-41c9-b6ac-723ba1e42e32",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "35ba60e8-caf3-4bd6-aa72-c31e15eb564b-1"
+                "id": "6551aa76-00e7-47f3-8519-1336796be28e-1"
               }
             ]
           },
@@ -47,14 +47,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "8815a459-3128-4a43-8f12-9108723e380b",
+            "key": "7b25bcf9-5d75-40d7-ac20-320e5a48260b",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "fd6b6463-1c61-498c-b6eb-547e4d430e55",
+                  "key": "964db46d-3b24-4b3f-971c-bd90919dc44a",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -65,25 +65,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "982d60df-0ec8-448e-8fb3-ff6d8f11b9df",
+                            "key": "800e5422-b6a6-4fbd-9af8-fd613ef25764",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "35ba60e8-caf3-4bd6-aa72-c31e15eb564b-2"
+                                "id": "6551aa76-00e7-47f3-8519-1336796be28e-2"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "35ba60e8-caf3-4bd6-aa72-c31e15eb564b-3"
+                                "id": "6551aa76-00e7-47f3-8519-1336796be28e-3"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "35ba60e8-caf3-4bd6-aa72-c31e15eb564b-4"
+                                "id": "6551aa76-00e7-47f3-8519-1336796be28e-4"
                               }
                             ]
                           },
@@ -92,13 +92,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "ce976570-8261-43d7-85f1-21d26b80ee32",
+                            "key": "ccd99b0a-31f4-4f98-8b8d-87a2539fc928",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "35ba60e8-caf3-4bd6-aa72-c31e15eb564b-5"
+                                "id": "6551aa76-00e7-47f3-8519-1336796be28e-5"
                               }
                             ]
                           },
@@ -118,12 +118,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "0eb8ca09-122e-46a2-aeae-d3e097b7c36b",
+            "key": "1667cdde-a81b-4e97-911c-a97f3ce207e0",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "35ba60e8-caf3-4bd6-aa72-c31e15eb564b-6"
+                "id": "6551aa76-00e7-47f3-8519-1336796be28e-6"
               }
             ]
           },
@@ -133,14 +133,14 @@
         {
           "member": 2,
           "graph": {
-            "key": "1dd974bb-5377-44e7-8284-16fc7e01dd03",
+            "key": "02dc963d-5c26-486b-ab14-f4d2f8afd296",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "49284eef-dd84-478f-b3a1-e1827f0321e9",
+                  "key": "d1f9b183-0f29-4e4f-853d-33a9b2155206",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -151,25 +151,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "a89dff15-361a-46b0-bacd-98388019ddab",
+                            "key": "2e952732-b942-47cc-aa10-47a16cef2135",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "35ba60e8-caf3-4bd6-aa72-c31e15eb564b-7"
+                                "id": "6551aa76-00e7-47f3-8519-1336796be28e-7"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "35ba60e8-caf3-4bd6-aa72-c31e15eb564b-8"
+                                "id": "6551aa76-00e7-47f3-8519-1336796be28e-8"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "35ba60e8-caf3-4bd6-aa72-c31e15eb564b-9"
+                                "id": "6551aa76-00e7-47f3-8519-1336796be28e-9"
                               }
                             ]
                           },
@@ -178,13 +178,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "974fbf55-304c-42ea-8ab1-59b67085055f",
+                            "key": "c89b954d-d471-401d-b84a-06f61e440540",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "35ba60e8-caf3-4bd6-aa72-c31e15eb564b-10"
+                                "id": "6551aa76-00e7-47f3-8519-1336796be28e-10"
                               }
                             ]
                           },

--- a/test/inputs/6/wizard-noaprioris.json
+++ b/test/inputs/6/wizard-noaprioris.json
@@ -9,25 +9,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "a6d10fd0-b9ac-408b-a861-293291c4ac5a",
+            "key": "1632279e-ee3c-4180-87bc-1367490dfac6",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "fab35748-5051-46f3-9516-6b6baa0d8c40-0"
+                "id": "ed278146-21d6-4ba3-833a-1f0198ce21f5-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "fab35748-5051-46f3-9516-6b6baa0d8c40-1"
+                "id": "ed278146-21d6-4ba3-833a-1f0198ce21f5-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "fab35748-5051-46f3-9516-6b6baa0d8c40-2"
+                "id": "ed278146-21d6-4ba3-833a-1f0198ce21f5-2"
               }
             ]
           },
@@ -36,13 +36,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "03e7bb60-d06e-4965-a933-d7a1e0273a54",
+            "key": "09ad4bc9-fa18-4da6-9986-5ef695ef734f",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "fab35748-5051-46f3-9516-6b6baa0d8c40-3"
+                "id": "ed278146-21d6-4ba3-833a-1f0198ce21f5-3"
               }
             ]
           },
@@ -79,12 +79,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "3967bc20-1907-4963-9e3a-c77db8bae0ba",
+            "key": "c268d0e3-4419-4669-8501-d7d3db3fd3db",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "fab35748-5051-46f3-9516-6b6baa0d8c40-5"
+                "id": "ed278146-21d6-4ba3-833a-1f0198ce21f5-5"
               }
             ]
           },
@@ -117,12 +117,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "2b80bc62-11c0-4a00-9c35-37acdef566b9",
+            "key": "ce85fc99-8a6e-4c16-830c-193572aa3400",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "fab35748-5051-46f3-9516-6b6baa0d8c40-10"
+                "id": "ed278146-21d6-4ba3-833a-1f0198ce21f5-10"
               }
             ]
           },

--- a/test/inputs/6/wizard-noopt.json
+++ b/test/inputs/6/wizard-noopt.json
@@ -9,25 +9,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "b0cd2d39-7f1a-409d-8429-d213660ccbaf",
+            "key": "f7eb7dd5-9fab-4ba3-ba48-b5246f820b71",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-0"
+                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-1"
+                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-2"
+                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-2"
               }
             ]
           },
@@ -36,13 +36,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "320cc37b-1f9d-47c3-8356-c2fe13f4e8ba",
+            "key": "3250f0bf-5182-403a-8120-679a823c6531",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-3"
+                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-3"
               }
             ]
           },
@@ -75,13 +75,13 @@
       "title": "importa.md",
       "filepath": "",
       "graph": {
-        "key": "76cedd7c-3a2e-42a6-a5eb-d55d9c72bfff",
+        "key": "c5b9d762-7bfc-4c39-872f-c115a91f1574",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-4"
+            "id": "72db12c8-8f73-4338-a386-d2e359a50a40-4"
           }
         ]
       },
@@ -102,12 +102,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "11016b46-e5cd-4839-9b82-0ff6ba346a07",
+            "key": "2a1943ec-0ad4-40cf-8ed0-addff2c80c23",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-5"
+                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-5"
               }
             ]
           },
@@ -139,14 +139,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "4a217d24-aca7-457e-9ce6-c105c75a9601",
+            "key": "962feb3e-8686-4abb-9036-53aa0de2bcb6",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "709b646a-2dbf-4dcd-8e08-b6c64d6f0855",
+                  "key": "3eb81a18-b90b-4fef-a464-dbcac6ff18cf",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -157,25 +157,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "e114a4ef-5648-426d-998f-aec21a09d5ec",
+                            "key": "d8e4701b-d072-428c-9b5e-60e9307b14ef",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-6"
+                                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-6"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-7"
+                                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-7"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-8"
+                                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-8"
                               }
                             ]
                           },
@@ -184,13 +184,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "5b026722-c636-4cd7-9c73-58ace3031be3",
+                            "key": "442c2fa0-16ec-4ac1-98f5-aa82082521d1",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-9"
+                                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-9"
                               }
                             ]
                           },
@@ -210,12 +210,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "4fba5faf-3ad7-4b02-b9e8-2e4ee52cc5a9",
+            "key": "cc1110df-c18b-436e-93eb-f497086813b8",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-10"
+                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-10"
               }
             ]
           },
@@ -225,14 +225,14 @@
         {
           "member": 2,
           "graph": {
-            "key": "85e3afc2-6099-49d3-adbd-0c8eef7504b1",
+            "key": "cc88a9f7-02fd-4fb5-aec6-1a2e251b7687",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "1f9d42ce-2f20-4bf3-8b71-ae17d4f8c101",
+                  "key": "5a708f90-1423-4985-8f0a-c2efbc20c50b",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -243,25 +243,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "e6cf4634-3968-4f8d-a0d2-74bd993c1c1b",
+                            "key": "676f64c8-1b60-4018-bff3-0736fb91a1e8",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-11"
+                                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-11"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-12"
+                                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-12"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-13"
+                                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-13"
                               }
                             ]
                           },
@@ -270,13 +270,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "dea61320-1c2f-499a-aa3b-e3ebd7afb605",
+                            "key": "e6cdf0f1-43c4-4fb5-9d69-ff37dccea36d",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "74d1ac2a-ab1a-47ff-bad9-9b8cda6f4087-14"
+                                "id": "72db12c8-8f73-4338-a386-d2e359a50a40-14"
                               }
                             ]
                           },

--- a/test/inputs/6/wizard.json
+++ b/test/inputs/6/wizard.json
@@ -9,25 +9,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "e59ff49d-c102-4e44-922d-de9d5ba10f11",
+            "key": "4e3a9fe9-ce9a-4b43-80e3-2214f77dfc55",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0cb76107-1657-417d-9b5b-7c4bfad6061d-0"
+                "id": "6df51182-3b49-47d5-9048-09c3042a37e3-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0cb76107-1657-417d-9b5b-7c4bfad6061d-1"
+                "id": "6df51182-3b49-47d5-9048-09c3042a37e3-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0cb76107-1657-417d-9b5b-7c4bfad6061d-2"
+                "id": "6df51182-3b49-47d5-9048-09c3042a37e3-2"
               }
             ]
           },
@@ -36,13 +36,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "1098db00-b0b8-4c11-8885-b1c63f96f85c",
+            "key": "d621bcb0-69f1-4d9f-9278-132e58f5d332",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "0cb76107-1657-417d-9b5b-7c4bfad6061d-3"
+                "id": "6df51182-3b49-47d5-9048-09c3042a37e3-3"
               }
             ]
           },
@@ -79,12 +79,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "fc40778d-607e-4032-8d04-c00cd50fcdb2",
+            "key": "743d3f2f-31a1-4959-a3ca-51e21a5a2e10",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "0cb76107-1657-417d-9b5b-7c4bfad6061d-5"
+                "id": "6df51182-3b49-47d5-9048-09c3042a37e3-5"
               }
             ]
           },
@@ -117,12 +117,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "ac6311e9-05fa-4f49-9c5b-94c28f267db1",
+            "key": "ba973ae3-7448-4924-9afc-b5f1093fb436",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "0cb76107-1657-417d-9b5b-7c4bfad6061d-10"
+                "id": "6df51182-3b49-47d5-9048-09c3042a37e3-10"
               }
             ]
           },

--- a/test/inputs/7/wizard-noaprioris.json
+++ b/test/inputs/7/wizard-noaprioris.json
@@ -9,25 +9,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "c4f3135b-679d-412c-9d35-431d53ef4921",
+            "key": "68c9e1bb-dd89-4251-8846-265ec3fdb2ca",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "682eaf5f-6236-456a-805e-34aa00165e3c-0"
+                "id": "59da53e6-b331-4c7c-9d8e-2bd419c46ba2-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "682eaf5f-6236-456a-805e-34aa00165e3c-1"
+                "id": "59da53e6-b331-4c7c-9d8e-2bd419c46ba2-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "682eaf5f-6236-456a-805e-34aa00165e3c-2"
+                "id": "59da53e6-b331-4c7c-9d8e-2bd419c46ba2-2"
               }
             ]
           },
@@ -36,13 +36,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "38647942-a341-4af0-90c8-131f3ffbf0c4",
+            "key": "488e8b0f-754b-4fbb-84b2-b9572ddd92fe",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "682eaf5f-6236-456a-805e-34aa00165e3c-3"
+                "id": "59da53e6-b331-4c7c-9d8e-2bd419c46ba2-3"
               }
             ]
           },
@@ -79,12 +79,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "7a219f3d-1beb-4c41-aa63-9836d14c41b4",
+            "key": "ca502f85-1f74-4291-aabf-904bfbe3702e",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "682eaf5f-6236-456a-805e-34aa00165e3c-5"
+                "id": "59da53e6-b331-4c7c-9d8e-2bd419c46ba2-5"
               }
             ]
           },
@@ -117,12 +117,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "1994cf4e-d961-4935-bf1f-8ff483be8c9b",
+            "key": "37d5b1c4-b181-422f-a389-6ed44da81b38",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "682eaf5f-6236-456a-805e-34aa00165e3c-10"
+                "id": "59da53e6-b331-4c7c-9d8e-2bd419c46ba2-10"
               }
             ]
           },

--- a/test/inputs/7/wizard-noopt.json
+++ b/test/inputs/7/wizard-noopt.json
@@ -9,25 +9,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "999059d1-3ac3-48f6-aba5-03cd6a871681",
+            "key": "53a7cd28-9926-4192-a885-858fe63007fa",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-0"
+                "id": "434daa65-a039-41da-b87d-20a19e099c71-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-1"
+                "id": "434daa65-a039-41da-b87d-20a19e099c71-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-2"
+                "id": "434daa65-a039-41da-b87d-20a19e099c71-2"
               }
             ]
           },
@@ -36,13 +36,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "0b4a28f7-3999-4c30-b89c-b275880e6a6b",
+            "key": "0932fe9f-1f05-455f-b40f-f69bfc084322",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-3"
+                "id": "434daa65-a039-41da-b87d-20a19e099c71-3"
               }
             ]
           },
@@ -75,13 +75,13 @@
       "title": "importa.md",
       "filepath": "",
       "graph": {
-        "key": "0c2f654a-9c54-44a7-a791-1d62573b4efc",
+        "key": "3295c7b1-4c9d-41f1-8d4c-09c0f603d2ae",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-4"
+            "id": "434daa65-a039-41da-b87d-20a19e099c71-4"
           }
         ]
       },
@@ -102,12 +102,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "9365f17c-245d-47fd-9eea-92a7881e28be",
+            "key": "edbe775f-092f-40a9-a604-fe7686948bb4",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-5"
+                "id": "434daa65-a039-41da-b87d-20a19e099c71-5"
               }
             ]
           },
@@ -139,14 +139,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "fbc543af-f317-4d61-8153-a9403b868933",
+            "key": "2068f81b-6de9-44c8-bb75-e00d4ec34178",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "195d1429-f745-4009-9955-2b8bcd73f8bd",
+                  "key": "bbad5854-c73d-4fdb-b523-b51b9c6c9f7a",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -157,25 +157,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "7741964f-bb9b-4ce8-a7cf-f1dcb74d2541",
+                            "key": "9c43badc-6730-46c6-aedc-d8dbf118443f",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-6"
+                                "id": "434daa65-a039-41da-b87d-20a19e099c71-6"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-7"
+                                "id": "434daa65-a039-41da-b87d-20a19e099c71-7"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-8"
+                                "id": "434daa65-a039-41da-b87d-20a19e099c71-8"
                               }
                             ]
                           },
@@ -184,13 +184,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "f4a0b0a8-3a60-46e9-9211-8413ac476393",
+                            "key": "02bf68a1-5c49-4755-8296-bc025c22adbf",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-9"
+                                "id": "434daa65-a039-41da-b87d-20a19e099c71-9"
                               }
                             ]
                           },
@@ -210,12 +210,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "69d483f1-1d6d-41cc-9b4e-14fd612817ca",
+            "key": "1ef8ace6-c17d-40fb-aad1-bd8991ceba2a",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-10"
+                "id": "434daa65-a039-41da-b87d-20a19e099c71-10"
               }
             ]
           },
@@ -225,14 +225,14 @@
         {
           "member": 2,
           "graph": {
-            "key": "4bd9625e-9ddc-4166-b996-f37a55dabb12",
+            "key": "239ade8a-e395-4aa6-8bb1-8446b7e9f455",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "0ea93a89-c081-4caf-a6ee-832793435815",
+                  "key": "9c69ddda-e97b-4e4d-9b36-ab2c949689eb",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -243,25 +243,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "827cdf0b-dcf8-4397-943f-ce5a9aa6235d",
+                            "key": "8f1d9f5d-40cb-4d82-8669-e3a0f27029b5",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-11"
+                                "id": "434daa65-a039-41da-b87d-20a19e099c71-11"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-12"
+                                "id": "434daa65-a039-41da-b87d-20a19e099c71-12"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-13"
+                                "id": "434daa65-a039-41da-b87d-20a19e099c71-13"
                               }
                             ]
                           },
@@ -270,13 +270,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "3fce7b14-c35c-4724-b09a-3dcd4fd7f65d",
+                            "key": "2d29d92e-7ea4-449b-b3fd-c274ffddb05f",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "6e0547d9-4ae0-4c1f-a518-e9be52fe8b2f-14"
+                                "id": "434daa65-a039-41da-b87d-20a19e099c71-14"
                               }
                             ]
                           },

--- a/test/inputs/7/wizard.json
+++ b/test/inputs/7/wizard.json
@@ -9,25 +9,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "df2c4214-98fb-4f56-a388-2e366f61e527",
+            "key": "7117e26f-bba4-4f50-aa55-9eb4a6f81e61",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "3673b786-cabf-48e6-bf32-776c21d2783c-0"
+                "id": "20a0b7de-0354-432d-ae84-48b55537b484-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "3673b786-cabf-48e6-bf32-776c21d2783c-1"
+                "id": "20a0b7de-0354-432d-ae84-48b55537b484-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "3673b786-cabf-48e6-bf32-776c21d2783c-2"
+                "id": "20a0b7de-0354-432d-ae84-48b55537b484-2"
               }
             ]
           },
@@ -36,13 +36,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "137d2b78-7972-4d53-b4cd-dd7f6bbcd9ac",
+            "key": "e8287946-4133-4084-a0ca-974c4bb9909e",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "3673b786-cabf-48e6-bf32-776c21d2783c-3"
+                "id": "20a0b7de-0354-432d-ae84-48b55537b484-3"
               }
             ]
           },
@@ -79,12 +79,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "c45aa08c-dccf-456f-ad97-91b015ceef54",
+            "key": "85ea4464-721c-46d1-81f3-f390b322baeb",
             "sequence": [
               {
                 "body": "echo EEE",
                 "language": "bash",
-                "id": "3673b786-cabf-48e6-bf32-776c21d2783c-5"
+                "id": "20a0b7de-0354-432d-ae84-48b55537b484-5"
               }
             ]
           },
@@ -117,12 +117,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "fb6f7ccd-14f0-4319-bb4a-6eaa5fc85eb1",
+            "key": "d546c5c1-f7d6-484e-bbf1-42c4a451060d",
             "sequence": [
               {
                 "body": "echo XXX",
                 "language": "bash",
-                "id": "3673b786-cabf-48e6-bf32-776c21d2783c-10"
+                "id": "20a0b7de-0354-432d-ae84-48b55537b484-10"
               }
             ]
           },

--- a/test/inputs/8/wizard-noaprioris.json
+++ b/test/inputs/8/wizard-noaprioris.json
@@ -9,25 +9,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "111679a8-e8ba-465f-b9a5-8deb42976076",
+            "key": "cbd6776c-2778-47e8-88a4-879e91a23e4d",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "ddaacac6-141e-414c-86d7-fa2a69638c9a-0"
+                "id": "7b2d451f-7d43-43c1-81c8-a70f9b65e842-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "ddaacac6-141e-414c-86d7-fa2a69638c9a-1"
+                "id": "7b2d451f-7d43-43c1-81c8-a70f9b65e842-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "ddaacac6-141e-414c-86d7-fa2a69638c9a-2"
+                "id": "7b2d451f-7d43-43c1-81c8-a70f9b65e842-2"
               }
             ]
           },
@@ -36,13 +36,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "56a3b453-4c8d-4287-87d7-a6f3708013eb",
+            "key": "f114c152-7cb0-4f5b-873a-af6403e6db12",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "ddaacac6-141e-414c-86d7-fa2a69638c9a-3"
+                "id": "7b2d451f-7d43-43c1-81c8-a70f9b65e842-3"
               }
             ]
           },

--- a/test/inputs/8/wizard-noopt.json
+++ b/test/inputs/8/wizard-noopt.json
@@ -9,14 +9,14 @@
         {
           "member": 0,
           "graph": {
-            "key": "d06c7f4d-bace-4d08-92f5-0e9bdeb10727",
+            "key": "0a53951b-1b6d-4808-be4f-bf37e9fc54b0",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "1330ae41-7a2e-41bd-b9eb-5c979040b6c8",
+                  "key": "09941970-80d0-4a7f-ba4f-e6d7f64e06d7",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -27,25 +27,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "471a0f41-a59a-4091-b85d-4aae86acbd69",
+                            "key": "3bb0131a-0c7c-4137-befb-f813e79cec1e",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-0"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-0"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-1"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-1"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-2"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-2"
                               }
                             ]
                           },
@@ -54,13 +54,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "accb8c64-284b-4f33-bbe3-642933018589",
+                            "key": "ca51cc76-6190-414c-bae6-eacec77ba46d",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-3"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-3"
                               }
                             ]
                           },
@@ -79,14 +79,14 @@
         {
           "member": 1,
           "graph": {
-            "key": "2511b350-39be-4a02-9ca5-7fddf463e22c",
+            "key": "fd9afd6a-eb11-49c9-9f82-eadca19388bf",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "97053e71-6fc2-45f5-95c6-d3ff333c6917",
+                  "key": "01dddd55-52ed-4d43-85ea-1a8599e7f954",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -97,25 +97,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "4b85aab1-e0d3-4946-935e-644730de523c",
+                            "key": "c0d22227-5910-442c-bea9-db699cedb5a8",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-4"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-4"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-5"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-5"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-6"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-6"
                               }
                             ]
                           },
@@ -124,13 +124,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "c123db01-5631-4589-8fb6-943361b2c567",
+                            "key": "5131016a-ff7a-4c96-99ca-b4213c211be0",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-7"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-7"
                               }
                             ]
                           },
@@ -149,14 +149,14 @@
         {
           "member": 2,
           "graph": {
-            "key": "e4085af2-52ba-4f1f-83dd-15f4b63250eb",
+            "key": "2e831889-9572-4a7a-80d9-355b3096bc55",
             "sequence": [
               {
                 "key": "test/inputs/snippets/importd.md",
                 "title": "DDD",
                 "filepath": "test/inputs/snippets/importd.md",
                 "graph": {
-                  "key": "ba252981-3b69-4af4-81fd-8cd44b97d01f",
+                  "key": "5f561a6e-ec11-42bf-bc28-0089ecf6e22e",
                   "sequence": [
                     {
                       "group": "SubTab1####SubTab2",
@@ -167,25 +167,25 @@
                         {
                           "member": 0,
                           "graph": {
-                            "key": "8d3eec41-f4a8-4a0b-beac-19685ffdbc00",
+                            "key": "a32f14d7-e40e-4367-8a31-905f2d69e6d5",
                             "sequence": [
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-8"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-8"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-9"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-9"
                               },
                               {
                                 "body": "echo AAA",
                                 "language": "bash",
                                 "validate": true,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-10"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-10"
                               }
                             ]
                           },
@@ -194,13 +194,13 @@
                         {
                           "member": 1,
                           "graph": {
-                            "key": "fb7e2bc1-3df9-431b-8c77-a1ef0c268238",
+                            "key": "2e9084e6-fc8a-471c-a99c-140891db03fa",
                             "sequence": [
                               {
                                 "body": "echo BBB",
                                 "language": "bash",
                                 "validate": false,
-                                "id": "d3362b45-a728-4c66-ac54-fa8b62b7fce2-11"
+                                "id": "6d2a71ec-c648-4495-bc86-9b2d6deedcd4-11"
                               }
                             ]
                           },

--- a/test/inputs/8/wizard.json
+++ b/test/inputs/8/wizard.json
@@ -9,25 +9,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "c5d12a74-39fa-4bbe-ae9a-954e10cc797b",
+            "key": "7cdbacef-9177-46dd-82ee-b7051a359654",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "67b1924a-d015-450f-aadb-137a3519d1fa-0"
+                "id": "37e6754a-92f9-4e36-9425-323a5c689eda-0"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "67b1924a-d015-450f-aadb-137a3519d1fa-1"
+                "id": "37e6754a-92f9-4e36-9425-323a5c689eda-1"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "67b1924a-d015-450f-aadb-137a3519d1fa-2"
+                "id": "37e6754a-92f9-4e36-9425-323a5c689eda-2"
               }
             ]
           },
@@ -36,13 +36,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "9dcd2a6e-76df-4ece-b5db-8c34e979044d",
+            "key": "ee0b4c37-805e-4554-a3f5-638098f43740",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "67b1924a-d015-450f-aadb-137a3519d1fa-3"
+                "id": "37e6754a-92f9-4e36-9425-323a5c689eda-3"
               }
             ]
           },

--- a/test/inputs/9/wizard-darwin.json
+++ b/test/inputs/9/wizard-darwin.json
@@ -5,12 +5,12 @@
       "title": "importg.md",
       "filepath": "",
       "graph": {
-        "key": "8602230b-c842-47e3-b0b6-18111bc9bf6d",
+        "key": "263f29e7-f5be-4f53-a3fc-2d659e924db4",
         "sequence": [
           {
             "body": "echo MMM",
             "language": "bash",
-            "id": "6a0f37ae-8d8e-4315-8112-50769fd48bcb-0"
+            "id": "c7b90bbe-01f7-492c-9369-9d9bc13812e5-0"
           }
         ]
       },
@@ -31,25 +31,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "145643a2-4c15-4498-97d0-9c10b819251a",
+            "key": "7c37d277-9d88-4f7a-9fcd-79ba69797e68",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "6a0f37ae-8d8e-4315-8112-50769fd48bcb-4"
+                "id": "c7b90bbe-01f7-492c-9369-9d9bc13812e5-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "6a0f37ae-8d8e-4315-8112-50769fd48bcb-5"
+                "id": "c7b90bbe-01f7-492c-9369-9d9bc13812e5-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "6a0f37ae-8d8e-4315-8112-50769fd48bcb-6"
+                "id": "c7b90bbe-01f7-492c-9369-9d9bc13812e5-6"
               }
             ]
           },
@@ -58,13 +58,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "0d255872-9225-470a-8122-0c04950918ef",
+            "key": "19b3c92d-0869-47b1-b0f3-bce04c7d53dc",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "6a0f37ae-8d8e-4315-8112-50769fd48bcb-7"
+                "id": "c7b90bbe-01f7-492c-9369-9d9bc13812e5-7"
               }
             ]
           },

--- a/test/inputs/9/wizard-linux.json
+++ b/test/inputs/9/wizard-linux.json
@@ -5,12 +5,12 @@
       "title": "importg.md",
       "filepath": "",
       "graph": {
-        "key": "e2ec7294-47dd-45cb-a072-2ce7cdca2b98",
+        "key": "6d815f82-e0c9-4f64-bbf9-70994fcaa815",
         "sequence": [
           {
             "body": "echo LLL",
             "language": "bash",
-            "id": "3c5f43dc-bf9f-4a20-bb61-07b221e9cf2d-1"
+            "id": "72e27c5d-0c77-4ffc-a49f-9aa7c8090efb-1"
           }
         ]
       },
@@ -31,25 +31,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "1d1b9d8c-4c20-4eaf-b648-17ec1d534be0",
+            "key": "89938c04-94e6-4905-8659-ea2912cd8e12",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "3c5f43dc-bf9f-4a20-bb61-07b221e9cf2d-4"
+                "id": "72e27c5d-0c77-4ffc-a49f-9aa7c8090efb-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "3c5f43dc-bf9f-4a20-bb61-07b221e9cf2d-5"
+                "id": "72e27c5d-0c77-4ffc-a49f-9aa7c8090efb-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "3c5f43dc-bf9f-4a20-bb61-07b221e9cf2d-6"
+                "id": "72e27c5d-0c77-4ffc-a49f-9aa7c8090efb-6"
               }
             ]
           },
@@ -58,13 +58,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "687170fc-4e6e-4aea-9069-6c64419395cb",
+            "key": "cff8bdc1-90ef-4cc4-ad9e-b77c724b6c7f",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "3c5f43dc-bf9f-4a20-bb61-07b221e9cf2d-7"
+                "id": "72e27c5d-0c77-4ffc-a49f-9aa7c8090efb-7"
               }
             ]
           },

--- a/test/inputs/9/wizard-noaprioris.json
+++ b/test/inputs/9/wizard-noaprioris.json
@@ -9,12 +9,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "a004f74e-80a2-4474-9c28-d5f5b2f256c7",
+            "key": "0cf59175-fc58-49c8-abb0-855ad7a18a00",
             "sequence": [
               {
                 "body": "echo MMM",
                 "language": "bash",
-                "id": "8071920f-e4a8-4ccd-98e8-33932b472761-0"
+                "id": "46c152d3-7641-475d-88b6-a20d8a801c70-0"
               }
             ]
           },
@@ -23,12 +23,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "3b5d9a68-abb5-4e43-8678-9e44ea42cefe",
+            "key": "937691cc-ce90-47cf-9c27-68de2688823f",
             "sequence": [
               {
                 "body": "echo LLL",
                 "language": "bash",
-                "id": "8071920f-e4a8-4ccd-98e8-33932b472761-1"
+                "id": "46c152d3-7641-475d-88b6-a20d8a801c70-1"
               }
             ]
           },
@@ -37,12 +37,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "7f479808-c54f-4d2d-8d72-9c740da6374b",
+            "key": "123a48ec-3a5d-4f35-b089-786661305342",
             "sequence": [
               {
                 "body": "echo WWW",
                 "language": "bash",
-                "id": "8071920f-e4a8-4ccd-98e8-33932b472761-2"
+                "id": "46c152d3-7641-475d-88b6-a20d8a801c70-2"
               }
             ]
           },
@@ -85,25 +85,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "1ecbd992-f206-47a0-955e-1f03a00ba9d7",
+            "key": "14b3493f-62a4-44e4-b441-161d105e1e88",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "8071920f-e4a8-4ccd-98e8-33932b472761-4"
+                "id": "46c152d3-7641-475d-88b6-a20d8a801c70-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "8071920f-e4a8-4ccd-98e8-33932b472761-5"
+                "id": "46c152d3-7641-475d-88b6-a20d8a801c70-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "8071920f-e4a8-4ccd-98e8-33932b472761-6"
+                "id": "46c152d3-7641-475d-88b6-a20d8a801c70-6"
               }
             ]
           },
@@ -112,13 +112,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "b2b369e7-a84d-456b-95f0-7302eb5d7169",
+            "key": "6d3253e5-a72b-40a0-8fb1-e88887585f3a",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "8071920f-e4a8-4ccd-98e8-33932b472761-7"
+                "id": "46c152d3-7641-475d-88b6-a20d8a801c70-7"
               }
             ]
           },

--- a/test/inputs/9/wizard-noopt.json
+++ b/test/inputs/9/wizard-noopt.json
@@ -8,12 +8,12 @@
         {
           "member": 0,
           "graph": {
-            "key": "0c09f21c-efd4-46cb-a705-27f527658adf",
+            "key": "c9a5fda4-66c6-48a6-9d52-e4ee365caafb",
             "sequence": [
               {
                 "body": "echo MMM",
                 "language": "bash",
-                "id": "2045d361-b5f3-4cd5-aecf-10a01aa8d134-0"
+                "id": "85e83316-46c4-4970-8afd-d10bcc01da95-0"
               }
             ]
           },
@@ -22,12 +22,12 @@
         {
           "member": 1,
           "graph": {
-            "key": "eaeeeb68-d970-485b-b169-e15433b72306",
+            "key": "6423504b-2f82-4619-9e68-cc8e2d6abcd4",
             "sequence": [
               {
                 "body": "echo LLL",
                 "language": "bash",
-                "id": "2045d361-b5f3-4cd5-aecf-10a01aa8d134-1"
+                "id": "85e83316-46c4-4970-8afd-d10bcc01da95-1"
               }
             ]
           },
@@ -36,12 +36,12 @@
         {
           "member": 2,
           "graph": {
-            "key": "581bd410-8998-4d8f-8868-673ce85db5d2",
+            "key": "3ca7dbfd-1888-4c81-849a-e39dd105ee4f",
             "sequence": [
               {
                 "body": "echo WWW",
                 "language": "bash",
-                "id": "2045d361-b5f3-4cd5-aecf-10a01aa8d134-2"
+                "id": "85e83316-46c4-4970-8afd-d10bcc01da95-2"
               }
             ]
           },
@@ -79,13 +79,13 @@
       "title": "importa.md",
       "filepath": "",
       "graph": {
-        "key": "f6db9454-822b-43c3-a06b-9f96bc1fb588",
+        "key": "6ebb13f5-d1ab-4217-81a9-df308b1cffa3",
         "sequence": [
           {
             "body": "echo AAA",
             "language": "bash",
             "validate": true,
-            "id": "2045d361-b5f3-4cd5-aecf-10a01aa8d134-3"
+            "id": "85e83316-46c4-4970-8afd-d10bcc01da95-3"
           }
         ]
       },
@@ -106,25 +106,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "b2fc311f-0ba1-4df5-a0e1-5aaba004560a",
+            "key": "9286a5ef-5b13-4b26-8a0a-929cc6c55c49",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "2045d361-b5f3-4cd5-aecf-10a01aa8d134-4"
+                "id": "85e83316-46c4-4970-8afd-d10bcc01da95-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "2045d361-b5f3-4cd5-aecf-10a01aa8d134-5"
+                "id": "85e83316-46c4-4970-8afd-d10bcc01da95-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "2045d361-b5f3-4cd5-aecf-10a01aa8d134-6"
+                "id": "85e83316-46c4-4970-8afd-d10bcc01da95-6"
               }
             ]
           },
@@ -133,13 +133,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "f4bc7c4c-79e9-4daf-9bbb-f46fca491cf7",
+            "key": "d224206f-285a-4b7a-b1f1-a5b52deec070",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "2045d361-b5f3-4cd5-aecf-10a01aa8d134-7"
+                "id": "85e83316-46c4-4970-8afd-d10bcc01da95-7"
               }
             ]
           },

--- a/test/inputs/9/wizard-win32.json
+++ b/test/inputs/9/wizard-win32.json
@@ -5,12 +5,12 @@
       "title": "importg.md",
       "filepath": "",
       "graph": {
-        "key": "7d975657-f8b2-4dac-abc1-4bab9080ffe0",
+        "key": "ced26ffe-bb1c-4f37-a4d4-9b2ab794a6ad",
         "sequence": [
           {
             "body": "echo WWW",
             "language": "bash",
-            "id": "0f20ab65-98cd-497e-889a-05d66d532b2d-2"
+            "id": "e42cf29c-bbd0-4a1d-998f-3370cd9a68ea-2"
           }
         ]
       },
@@ -31,25 +31,25 @@
         {
           "member": 0,
           "graph": {
-            "key": "b2fd1e43-7085-4dbd-9146-cd37dc5a4129",
+            "key": "c71ea9a9-a066-4eed-97f7-64b3219d1f7b",
             "sequence": [
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0f20ab65-98cd-497e-889a-05d66d532b2d-4"
+                "id": "e42cf29c-bbd0-4a1d-998f-3370cd9a68ea-4"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0f20ab65-98cd-497e-889a-05d66d532b2d-5"
+                "id": "e42cf29c-bbd0-4a1d-998f-3370cd9a68ea-5"
               },
               {
                 "body": "echo AAA",
                 "language": "bash",
                 "validate": true,
-                "id": "0f20ab65-98cd-497e-889a-05d66d532b2d-6"
+                "id": "e42cf29c-bbd0-4a1d-998f-3370cd9a68ea-6"
               }
             ]
           },
@@ -58,13 +58,13 @@
         {
           "member": 1,
           "graph": {
-            "key": "70bc920f-17e7-4441-8f3e-a0da838be694",
+            "key": "b1a8a90f-f55f-4fe0-a25c-4074e3f5be13",
             "sequence": [
               {
                 "body": "echo BBB",
                 "language": "bash",
                 "validate": false,
-                "id": "0f20ab65-98cd-497e-889a-05d66d532b2d-7"
+                "id": "e42cf29c-bbd0-4a1d-998f-3370cd9a68ea-7"
               }
             ]
           },


### PR DESCRIPTION
e.g. if you want to veto validated choices at the top-level, not in a nested import