### PR TITLE
chore: use terser to optimize builds

### DIFF
--- a/bin/terser.sh
+++ b/bin/terser.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# TODO windows
+
+for file in ./dist/*.*js; do
+    T=$(mktemp)
+    (npx terser --compress --mangle -- $file > $T && mv $T $file) &
+done
+
+wait
+ls -lh ./dist/*.*js | awk '{printf "%-5s %s", $5, $NF "\n"}'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:test": "cross-env-shell tsc --project test",
     "test": "cross-env npm run build:test && cross-env concurrently --raw -n TYPES,TESTS 'tsc --noEmit' 'node --no-warnings --experimental-specifier-resolution=node test/dist'",
     "format": "cross-env prettier --write '**/*.{scss,css,html,js,json,md,ts,tsx}'",
-    "prepack": "npm run build && npm test",
+    "prepack": "npm run build && ./bin/terser.sh && npm test",
     "prepare": "cross-env husky install"
   },
   "keywords": [


### PR DESCRIPTION
I don't really get parcel. It seems so buggy. Yet another bug is that it doesn't seem to optimize our builds, despite the docs claiming this is the default for "production" builds (i.e. those outputs of `terser build`.

And if I try to use a `targets`... I can get optimized builds (by explicitly specifying `optimize: true` in the target), but then i don't get a type declaration... sigh.

So this PR uses terser explicitly in our `build` script target.