### PR TITLE
feat: update --veto=xxx to interpret xxx has a regular expression

### DIFF
--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -52,7 +52,7 @@ export async function cli<Writer extends (msg: string) => boolean>(
 
   const vetoIdx = _argv.findIndex((_) => new RegExp("^--veto=").test(_))
   const vetoStr = vetoIdx < 0 ? undefined : _argv[vetoIdx].slice(_argv[vetoIdx].indexOf("=") + 1)
-  const veto = !vetoStr ? undefined : new Set(vetoStr.split(/,/))
+  const veto = !vetoStr ? undefined : new RegExp(vetoStr)
 
   const mkdocsIdx = _argv.findIndex((_) => new RegExp("^--mkdocs=").test(_))
   const mkdocs = mkdocsIdx < 0 ? undefined : _argv[mkdocsIdx].slice(_argv[mkdocsIdx].indexOf("=") + 1)

--- a/src/graph/collapseValidated.ts
+++ b/src/graph/collapseValidated.ts
@@ -51,7 +51,7 @@ export default async function collapseValidated<
     ) {
       // then this optimization has been disabled
       return graph
-    } else if (options.veto && hasProvenance(graph) && graph.provenance.find((_) => options.veto.has(_))) {
+    } else if (options.veto && hasProvenance(graph) && graph.provenance.find((_) => options.veto.test(_))) {
       Debug("madwizard/graph/optimize/collapse-validated")("veto", extractTitle(graph))
       // then this optimization has been vetoed
       return graph

--- a/src/graph/compile.ts
+++ b/src/graph/compile.ts
@@ -61,7 +61,7 @@ export interface CompilerOptions {
    * truth, and thus not needing user input. By vetoing one of these a
    * prioris, users will be prompted to redo this choice.
    */
-  veto: Set<string>
+  veto: RegExp
 
   /**
    * Should we expand choice groups with dynamic expansion?

--- a/src/graph/vetoes.ts
+++ b/src/graph/vetoes.ts
@@ -42,6 +42,6 @@ export async function vetoesFromBlocks(blocks: CodeBlockProps[], choices: Choice
 
 export async function vetoesToString(blocks: CodeBlockProps[], choices: ChoiceState, options: MadWizardOptions = {}) {
   return (await vetoesFromBlocks(blocks, choices, Object.assign({}, options, { optimize: false })))
-    .map((_) => (options.veto && options.veto.has(_) ? `${_} ${chalk.red("[VETOED]")}` : _))
+    .map((_) => (options.veto && options.veto.test(_) ? `${_} ${chalk.red("[VETOED]")}` : _))
     .join(EOL)
 }

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -40,7 +40,7 @@ const options: { suffix: string; options: Options }[] = [
     options: (input: string) => {
       try {
         return {
-          veto: new Set(readFileSync(join(input, "veto.txt")).toString().trim().split(/,/)),
+          veto: new RegExp(readFileSync(join(input, "veto.txt")).toString().trim()),
         }
       } catch (err) {
         if (err.code === "ENOENT") {


### PR DESCRIPTION
rather than a comma-separated list of literals. this will help with wildcard vetoing, and with vetoing in a more host-agnostic fashion (is the file local? on a web site?)