### PR TITLE
feat: collect pip depenendencies for ray-submit

### DIFF
--- a/src/exec/options.ts
+++ b/src/exec/options.ts
@@ -19,10 +19,11 @@ import { Memos } from "../memoization"
 /** Environment variable state that might be mutated by the guidebook itself */
 export type Env = Pick<Memos, "env">
 
-export type ExecOptions = Partial<Env> & {
-  /** Do not emit to console */
-  quiet?: boolean
+export type ExecOptions = Partial<Env> &
+  Partial<Pick<Memos, "dependencies">> & {
+    /** Do not emit to console */
+    quiet?: boolean
 
-  /** Capture stdout here */
-  capture?: string
-}
+    /** Capture stdout here */
+    capture?: string
+  }

--- a/src/memoization/index.ts
+++ b/src/memoization/index.ts
@@ -28,6 +28,9 @@ export interface Memos {
 
   /** Any captured environment variable assignments. For example, a guidebook may want to update via `export FOO=bar` */
   env: typeof process.env
+
+  /** Any collected dependencies that need to be injected into the runtime */
+  dependencies: Record<string, string[]>
 }
 
 /** Default implementation of `Memos` */
@@ -40,6 +43,9 @@ export class Memoizer implements Memos {
 
   /** Any captured environment variable assignments. For example, a guidebook may want to update via `export FOO=bar` */
   public readonly env = {}
+
+  /** Any collected dependencies that need to be injected into the runtime */
+  public dependencies = {}
 }
 
 /** Percolate up any memoized status */


### PR DESCRIPTION
This PR only collects pip dependencies surfaced via `pip-show` validation. In the future, I think we can bridge this into the `pip install` code blocks by automatically inferring a validator from the code block?

and TODO: requirements.txt?