### PR TITLE
feat: add "build" and "mirror" commands to allow for static/ahead-of-time inlining and fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist
 node_modules
 *.tgz
 .parcel-cache
+
+# mirrored guidebook store
+store

--- a/bin/madwizard.js
+++ b/bin/madwizard.js
@@ -1,16 +1,27 @@
-#!/usr/bin/env -S node --experimental-specifier-resolution=node --no-warnings
+#!/usr/bin/env -S node --experimental-specifier-resolution=node --no-warnings --experimental-import-meta-resolve
 
 /* eslint-env node */
 /* ^^^ rather than add env: node globally in package.json */
+
+import { dirname, join } from "path"
+import { createRequire } from "module"
+const require = createRequire(import.meta.url)
 
 /**
  * This is a front-end to the CLI module.
  */
 
 const isNpx = process.env.npm_command === "exec"
+const madwizard = isNpx ? "madwizard" : ".."
 
-import(isNpx ? "madwizard" : "..")
-  .then((_) => _.cli(process.argv.slice(1)))
+const store =
+  process.env.MWSTORE === "git"
+    ? "https://github.com/guidebooks/store/blob/main/guidebooks"
+    : process.env.MWSTORE || join(dirname(require.resolve(madwizard)), "store")
+const argv = process.argv.slice(1).concat(["--store=" + store])
+
+import(madwizard)
+  .then((_) => _.cli(argv))
   .catch((err) => {
     if (process.env.DEBUG) {
       console.log(err)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "js-yaml": "^4.1.0",
         "make-fetch-happen": "^10.1.3",
         "mdast-util-to-markdown": "^1.3.0",
+        "mkdirp": "^1.0.4",
         "ora": "^6.1.0",
         "remark-directive": "^2.0.1",
         "remark-frontmatter": "^4.0.1",
@@ -40,7 +41,8 @@
         "which": "^2.0.2"
       },
       "bin": {
-        "madwizard": "bin/madwizard.js"
+        "madwizard": "bin/madwizard.js",
+        "mw": "bin/madwizard.js"
       },
       "devDependencies": {
         "@parcel/packager-ts": "^2.5.0",
@@ -51,6 +53,7 @@
         "@types/js-yaml": "^4.0.5",
         "@types/json-diff": "^0.7.0",
         "@types/make-fetch-happen": "^9.0.2",
+        "@types/mkdirp": "^1.0.2",
         "@types/needle": "^2.5.3",
         "@types/node": "^17.0.32",
         "@types/tmp": "^0.2.3",
@@ -1839,6 +1842,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
+    },
+    "node_modules/@types/mkdirp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
+      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",
@@ -9359,6 +9371,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
+    },
+    "@types/mkdirp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
+      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/ms": {
       "version": "0.7.31",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build:test": "cross-env-shell tsc --project test",
     "test": "cross-env npm run build:test && cross-env concurrently --raw -n TYPES,TESTS 'tsc --noEmit' 'node --no-warnings --experimental-specifier-resolution=node test/dist'",
     "format": "cross-env prettier --write '**/*.{scss,css,html,js,json,md,ts,tsx}'",
-    "prepack": "npm run build && ./bin/terser.sh && npm test",
+    "mirror": "T=$(mktemp -d); (cd $T && git clone --depth=1 git@github.com:guidebooks/store.git) && echo \"mirror stage in $T/store\" && ./bin/madwizard.js mirror $T/store/guidebooks ./dist/store",
+    "prepack": "npm run build && ./bin/terser.sh && npm run mirror && npm test",
     "prepare": "cross-env husky install"
   },
   "keywords": [
@@ -84,6 +85,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/json-diff": "^0.7.0",
     "@types/make-fetch-happen": "^9.0.2",
+    "@types/mkdirp": "^1.0.2",
     "@types/needle": "^2.5.3",
     "@types/node": "^17.0.32",
     "@types/tmp": "^0.2.3",
@@ -121,6 +123,7 @@
     "js-yaml": "^4.1.0",
     "make-fetch-happen": "^10.1.3",
     "mdast-util-to-markdown": "^1.3.0",
+    "mkdirp": "^1.0.4",
     "ora": "^6.1.0",
     "remark-directive": "^2.0.1",
     "remark-frontmatter": "^4.0.1",

--- a/src/fe/MadWizardOptions.ts
+++ b/src/fe/MadWizardOptions.ts
@@ -22,6 +22,9 @@ interface DisplayOptions {
 }
 
 interface FetchOptions {
+  /** Base URI of Guidebook store? */
+  store: string
+
   /**
    * Path to an mkdocs.yml config. This may be used to assist in
    * finding snippet content when parsing markdown.

--- a/src/fe/cli/tasks.ts
+++ b/src/fe/cli/tasks.ts
@@ -28,11 +28,11 @@ export function isDebugTask(task: Task): task is DebugTask {
 }
 
 /** The type definining the valid Tasks to run via the CLI client */
-export type Task = "plan" | "guide" | "run" | "json" | "version" | "vetoes" | DebugTask
+export type Task = "plan" | "guide" | "run" | "json" | "version" | "vetoes" | "build" | "mirror" | DebugTask
 
 /** @return the list of valid Tasks to run via the CLI client */
 export function validTasks(): Task[] {
-  const normalTasks: Task[] = ["plan", "guide", "run", "json", "version", "vetoes"]
+  const normalTasks: Task[] = ["plan", "guide", "run", "json", "version", "vetoes", "build", "mirror"]
   return normalTasks.concat(validDebugTasks())
 }
 

--- a/src/parser/markdown/index.ts
+++ b/src/parser/markdown/index.ts
@@ -23,8 +23,8 @@ import remarkParse from "remark-parse"
 import remarkRehype from "remark-rehype"
 import { unified, PluggableList } from "unified"
 
-import { madwizardRead } from "./fetch"
 import { MadWizardOptions } from "../../"
+import { madwizardRead, fetcherFor } from "./fetch"
 
 import { CodeBlockProps } from "../../codeblock"
 import { ChoiceState, newChoiceState } from "../../choices"
@@ -102,7 +102,7 @@ async function parse(
       .use(remarkRehype, { allowDangerousHtml: true })
       .use(rehypePlugins(uuid, choices, blocks, madwizardOptions, input.path))
 
-    const fetcher = (filepath: string) => reader(new VFile({ path: filepath })).then((_) => _.value.toString())
+    const fetcher = fetcherFor(reader)
 
     debug("fetch start")
     const sourcePriorToInlining = input.value.toString()
@@ -137,7 +137,7 @@ export async function blockify(
 ) {
   const file =
     typeof input === "string"
-      ? await reader(new VFile({ path: toRawGithubUserContent(expandHomeDir(input)) }), true)
+      ? await reader(new VFile({ path: toRawGithubUserContent(expandHomeDir(input)) }), madwizardOptions.store, true)
       : new VFile(input)
   return parse(file, choices, uuid, reader, madwizardOptions)
 }

--- a/src/parser/markdown/snippets/index.ts
+++ b/src/parser/markdown/snippets/index.ts
@@ -29,8 +29,6 @@ import { MadWizardOptions } from "../../.."
 import { hasImports } from "../frontmatter/KuiFrontmatter"
 import { tryFrontmatter } from "../frontmatter/frontmatter-parser"
 
-const debug = Debug("madwizard/fetch/snippets")
-
 const RE_DOCS_URL = /^(https:\/\/([^/]+\/){4}docs)/
 
 const RE_INCLUDE = /^(\s*){%\s+include "([^"]+)"\s+%}/
@@ -62,7 +60,7 @@ function dirname(a: string) {
   }
 }
 
-function join(a: string, b: string) {
+export function join(a: string, b: string) {
   if (isUrl(a)) {
     const url = new URL(a)
     url.pathname = pathJoin(url.pathname, b)
@@ -175,6 +173,8 @@ function inlineSnippets(opts: Options & InternalOptions) {
     snippetMemo = {},
     altBasePaths = Promise.resolve([]),
   } = opts
+
+  const debug = Debug("madwizard/fetch/snippets")
 
   const _fetchRecursively = async (
     _snippetFileName: string,

--- a/src/parser/markdown/snippets/inliner.ts
+++ b/src/parser/markdown/snippets/inliner.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { writeFile } from "fs"
+import { dirname, join } from "path"
+
+import inlineSnippets from "."
+import { fetcherFor } from "../fetch"
+
+/**
+ * Fetch and inline all content in the given
+ * `${srcDir}/${srcRelPath}`, and emit to `${targetDir}/${srcRelPath}`
+ *
+ * @param {String} srcDir Directory enclosing source content
+ * @param {String} srcRelPath Path inside of srcDir to process
+ * @param {String} targetDir Enclosing directory for generated content
+ */
+export async function inliner(srcDir: string, srcRelPath: string, targetDir: string) {
+  const srcFilePath = join(srcDir, srcRelPath)
+  const fetcher = fetcherFor()
+  const data = await fetcher(srcFilePath)
+  const inlined = await inlineSnippets({ fetcher })(data, srcFilePath)
+
+  const mkdirp = (await import("mkdirp")).default
+  const targetPath = join(targetDir, srcRelPath)
+  await mkdirp(dirname(targetPath))
+  await new Promise<void>((resolve, reject) => {
+    writeFile(targetPath, inlined, (err) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
+}

--- a/src/parser/markdown/snippets/mirror.ts
+++ b/src/parser/markdown/snippets/mirror.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from "path"
+import { readdir } from "fs"
+import { oraPromise } from "ora"
+
+import { inliner } from "./inliner"
+
+export async function mirror(srcDir: string, targetDir: string, srcRelPath = "") {
+  // Debug.enable("madwizard/fetch/snippets")
+
+  const srcFilePath = join(srcDir, srcRelPath)
+  await new Promise<void>((resolve, reject) => {
+    readdir(srcFilePath, { withFileTypes: true }, async (err, files) => {
+      if (err) {
+        reject(err)
+      } else {
+        await Promise.all(
+          files.map(async (entry) => {
+            const relpath = join(srcRelPath, entry.name)
+
+            if (entry.isFile() && /\.md$/.test(entry.name)) {
+              await oraPromise(inliner(srcDir, relpath, targetDir), `Processing ${relpath}`)
+            } else if (entry.isDirectory()) {
+              await mirror(srcDir, targetDir, relpath)
+            }
+          })
+        )
+
+        resolve()
+      }
+    })
+  })
+}


### PR DESCRIPTION
build and mirror: these allow for static/ahead-of-time fetching
and inlining of content. This can be helpful to allow shipping
"frozen" forms of content with a build, and capturing remote
content at the same time. By inlining the content ("build", and
mirror calls build over a directory tree), you can also amortize
the cost of many file reads/remote fetches per run.

this PR adds the `--store=xxx` option to the CLI, and the matching `store` option to `MadWizardOptions`. it updates the `mw` front-end to default to using the prebuilt store, but this can be overridden by running `mw` with `MWSTORE=/some/other/path`,

and if you set `MWSTORE=git` it will use https://github.com/guidebooks/store