### PR TITLE
fix: source attribute of graph was bogus

### DIFF
--- a/src/codeblock/CodeBlockProps.ts
+++ b/src/codeblock/CodeBlockProps.ts
@@ -16,6 +16,7 @@
 
 import { FormElement } from "./form"
 import { SupportedLanguage } from "./language"
+import { Something } from "../parser/markdown/util/toMarkdownString"
 
 export * from "./form"
 
@@ -67,7 +68,7 @@ export interface Description {
 }
 
 export type Source = {
-  source: () => string
+  source: Something
 }
 
 /**

--- a/src/graph/compile.ts
+++ b/src/graph/compile.ts
@@ -17,7 +17,19 @@
 import Debug from "debug"
 import { CodeBlockProps } from "../codeblock"
 import { ChoiceState, expand } from "../choices"
-import { Choice, Graph, SubTask, TitledSteps, emptySequence, extractTitle, parallel, seq, sequence, subtask } from "."
+import {
+  Choice,
+  Graph,
+  SubTask,
+  TitledSteps,
+  emptySequence,
+  extractTitle,
+  hasSource,
+  parallel,
+  seq,
+  sequence,
+  subtask,
+} from "."
 
 import { Memos } from "../memoization"
 import { ValidateOptions } from "./validate"
@@ -339,7 +351,14 @@ export async function compile(
     debug("optimizing done")
 
     if (title && !extractTitle(optimized)) {
-      return subtask(title, title, description, "", sequence([optimized]))
+      return subtask(
+        title,
+        title,
+        description,
+        "",
+        sequence([optimized]),
+        hasSource(unoptimized) ? unoptimized.source : undefined
+      )
     } else {
       return optimized
     }

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -207,7 +207,7 @@ export function subtask<T extends Unordered | Ordered = Unordered>(
   description: string,
   filepath: string,
   graph: Sequence<T>,
-  source: Source["source"] = () => "",
+  source: Source["source"],
   barrier = false,
   validate?: Validatable["validate"]
 ): SubTask<Unordered> {
@@ -223,8 +223,12 @@ export function subtask<T extends Unordered | Ordered = Unordered>(
   }
 }
 
-export function withTitle(block: LeafNode, { title, description }: Title & Partial<Description>, barrier = false) {
-  return subtask(title, title, description, "", seq(block), undefined, barrier)
+export function withTitle(
+  block: LeafNode,
+  { title, description, source }: Title & Partial<Description> & Partial<Source>,
+  barrier = false
+) {
+  return subtask(title, title, description, "", seq(block), source, barrier)
 }
 
 export function asSubTask(step: TitledStep): SubTask {
@@ -361,7 +365,7 @@ ${graph.body}
 }
 
 export function hasSource(graph: Graph): graph is Graph & Source {
-  return typeof (graph as any).source === "string"
+  return typeof (graph as any).source !== "undefined"
 }
 
 export function hasKey(graph: Graph): graph is Graph & Key {

--- a/src/graph/provenance.ts
+++ b/src/graph/provenance.ts
@@ -33,11 +33,13 @@ export function hasProvenance(graph: Graph): graph is Graph & Provenance {
 }
 
 export function provenanceOfFilepath(filepath: string) {
-  const match = filepath.match(/^https:\/\/raw.githubusercontent.com\/guidebooks\/store\/main\/guidebooks\/(.+)\..+$/)
-  if (match) {
-    return match[1].replace(/\/index$/, "")
-  } else {
-    return relative(process.cwd(), filepath)
+  if (filepath) {
+    const match = filepath.match(/^https:\/\/raw.githubusercontent.com\/guidebooks\/store\/main\/guidebooks\/(.+)\..+$/)
+    if (match) {
+      return match[1].replace(/\/index$/, "")
+    } else {
+      return relative(process.cwd(), filepath)
+    }
   }
 }
 

--- a/src/wizard/index.ts
+++ b/src/wizard/index.ts
@@ -19,6 +19,7 @@ import Debug from "debug"
 import { Choices, ChoiceState } from "../choices"
 import { Memos, statusOf } from "../memoization"
 import { Barrier, FormElement } from "../codeblock"
+import { toMarkdownString } from "../parser/markdown/util/toMarkdownString"
 
 import {
   Graph,
@@ -34,7 +35,7 @@ import {
   findChoiceFrontier,
 } from "../graph"
 
-type Markdown = string
+type Markdown = string | (() => string)
 
 export type Tile = Partial<FormElement> & {
   title: string
@@ -100,7 +101,7 @@ function wizardStepForPrereq<T, G extends Graph<T>>(
       name: extractTitle(graph) || "Executing a step",
       description: extractDescription(graph),
       barrier: isBarrier(graph),
-      content: hasSource(graph) ? graph.source() : isLeafNode(graph) ? bodySource(graph) : "",
+      content: hasSource(graph) ? () => toMarkdownString(graph.source) : isLeafNode(graph) ? bodySource(graph) : "",
     },
   }
 }

--- a/test/inputs/10/wizard-darwin.json
+++ b/test/inputs/10/wizard-darwin.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importgg.md",
-      "content": ""
+      "name": "importgg.md"
     }
   },
   {

--- a/test/inputs/10/wizard-linux.json
+++ b/test/inputs/10/wizard-linux.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importgg.md",
-      "content": ""
+      "name": "importgg.md"
     }
   },
   {

--- a/test/inputs/10/wizard-noopt.json
+++ b/test/inputs/10/wizard-noopt.json
@@ -92,8 +92,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importaa.md",
-      "content": ""
+      "name": "importaa.md"
     }
   },
   {

--- a/test/inputs/10/wizard-win32.json
+++ b/test/inputs/10/wizard-win32.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importgg.md",
-      "content": ""
+      "name": "importgg.md"
     }
   },
   {

--- a/test/inputs/11/wizard.json
+++ b/test/inputs/11/wizard.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "Text versus HTML?",
-      "content": ""
+      "name": "Text versus HTML?"
     }
   }
 ]

--- a/test/inputs/13/wizard-noaprioris.json
+++ b/test/inputs/13/wizard-noaprioris.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "H1",
-      "content": ""
+      "name": "H1"
     }
   }
 ]

--- a/test/inputs/13/wizard-noopt.json
+++ b/test/inputs/13/wizard-noopt.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "H1",
-      "content": ""
+      "name": "H1"
     }
   }
 ]

--- a/test/inputs/13/wizard.json
+++ b/test/inputs/13/wizard.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "H1",
-      "content": ""
+      "name": "H1"
     }
   }
 ]

--- a/test/inputs/17/wizard-noaprioris.json
+++ b/test/inputs/17/wizard-noaprioris.json
@@ -19,8 +19,7 @@
     },
     "step": {
       "name": "barrier.md",
-      "barrier": true,
-      "content": ""
+      "barrier": true
     }
   },
   {

--- a/test/inputs/17/wizard-noopt.json
+++ b/test/inputs/17/wizard-noopt.json
@@ -18,8 +18,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importa.md",
-      "content": ""
+      "name": "importa.md"
     }
   },
   {
@@ -42,8 +41,7 @@
     },
     "step": {
       "name": "barrier.md",
-      "barrier": true,
-      "content": ""
+      "barrier": true
     }
   },
   {

--- a/test/inputs/17/wizard.json
+++ b/test/inputs/17/wizard.json
@@ -19,8 +19,7 @@
     },
     "step": {
       "name": "barrier.md",
-      "barrier": true,
-      "content": ""
+      "barrier": true
     }
   },
   {

--- a/test/inputs/20/wizard-noaprioris.json
+++ b/test/inputs/20/wizard-noaprioris.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "a.md",
-      "content": ""
+      "name": "a.md"
     }
   },
   {

--- a/test/inputs/20/wizard.json
+++ b/test/inputs/20/wizard.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "a.md",
-      "content": ""
+      "name": "a.md"
     }
   },
   {

--- a/test/inputs/21/wizard-noaprioris.json
+++ b/test/inputs/21/wizard-noaprioris.json
@@ -19,8 +19,7 @@
     },
     "step": {
       "name": "Export an env var",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   },
   {
@@ -43,8 +42,7 @@
     },
     "step": {
       "name": "Export an env var",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   },
   {
@@ -67,8 +65,7 @@
     },
     "step": {
       "name": "Then use it",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   },
   {
@@ -92,8 +89,7 @@
     },
     "step": {
       "name": "Propagation check",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   }
 ]

--- a/test/inputs/21/wizard-noopt.json
+++ b/test/inputs/21/wizard-noopt.json
@@ -19,8 +19,7 @@
     },
     "step": {
       "name": "Export an env var",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   },
   {
@@ -43,8 +42,7 @@
     },
     "step": {
       "name": "Export an env var",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   },
   {
@@ -67,8 +65,7 @@
     },
     "step": {
       "name": "Then use it",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   },
   {
@@ -92,8 +89,7 @@
     },
     "step": {
       "name": "Propagation check",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   }
 ]

--- a/test/inputs/21/wizard.json
+++ b/test/inputs/21/wizard.json
@@ -19,8 +19,7 @@
     },
     "step": {
       "name": "Export an env var",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   },
   {
@@ -43,8 +42,7 @@
     },
     "step": {
       "name": "Export an env var",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   },
   {
@@ -67,8 +65,7 @@
     },
     "step": {
       "name": "Then use it",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   },
   {
@@ -92,8 +89,7 @@
     },
     "step": {
       "name": "Propagation check",
-      "description": "This should be valid, if FOO is propagated correctly to the validator.\n",
-      "content": ""
+      "description": "This should be valid, if FOO is propagated correctly to the validator.\n"
     }
   }
 ]

--- a/test/inputs/24/wizard-noaprioris.json
+++ b/test/inputs/24/wizard-noaprioris.json
@@ -19,8 +19,7 @@
     },
     "step": {
       "name": "Using Default Exec",
-      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n",
-      "content": ""
+      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n"
     }
   },
   {
@@ -43,8 +42,7 @@
     },
     "step": {
       "name": "Using Default Exec (again)",
-      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n",
-      "content": ""
+      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n"
     }
   },
   {
@@ -66,8 +64,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "Using Custom Exec",
-      "content": ""
+      "name": "Using Custom Exec"
     }
   }
 ]

--- a/test/inputs/24/wizard-noopt.json
+++ b/test/inputs/24/wizard-noopt.json
@@ -19,8 +19,7 @@
     },
     "step": {
       "name": "Using Default Exec",
-      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n",
-      "content": ""
+      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n"
     }
   },
   {
@@ -43,8 +42,7 @@
     },
     "step": {
       "name": "Using Default Exec (again)",
-      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n",
-      "content": ""
+      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n"
     }
   },
   {
@@ -66,8 +64,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "Using Custom Exec",
-      "content": ""
+      "name": "Using Custom Exec"
     }
   }
 ]

--- a/test/inputs/24/wizard.json
+++ b/test/inputs/24/wizard.json
@@ -19,8 +19,7 @@
     },
     "step": {
       "name": "Using Default Exec",
-      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n",
-      "content": ""
+      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n"
     }
   },
   {
@@ -43,8 +42,7 @@
     },
     "step": {
       "name": "Using Default Exec (again)",
-      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n",
-      "content": ""
+      "description": "Again, to make sure there are no bugs with executing the same body in a different code block.\n"
     }
   },
   {
@@ -66,8 +64,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "Using Custom Exec",
-      "content": ""
+      "name": "Using Custom Exec"
     }
   }
 ]

--- a/test/inputs/25/wizard-noaprioris.json
+++ b/test/inputs/25/wizard-noaprioris.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "a.md",
-      "content": ""
+      "name": "a.md"
     }
   },
   {

--- a/test/inputs/25/wizard.json
+++ b/test/inputs/25/wizard.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "a.md",
-      "content": ""
+      "name": "a.md"
     }
   },
   {

--- a/test/inputs/3/wizard-noopt.json
+++ b/test/inputs/3/wizard-noopt.json
@@ -18,8 +18,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importa.md",
-      "content": ""
+      "name": "importa.md"
     }
   },
   {

--- a/test/inputs/4/wizard-noopt.json
+++ b/test/inputs/4/wizard-noopt.json
@@ -18,8 +18,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importa.md",
-      "content": ""
+      "name": "importa.md"
     }
   },
   {

--- a/test/inputs/5/wizard-noopt.json
+++ b/test/inputs/5/wizard-noopt.json
@@ -18,8 +18,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importa.md",
-      "content": ""
+      "name": "importa.md"
     }
   },
   {

--- a/test/inputs/6/wizard-noopt.json
+++ b/test/inputs/6/wizard-noopt.json
@@ -88,8 +88,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importa.md",
-      "content": ""
+      "name": "importa.md"
     }
   },
   {

--- a/test/inputs/7/wizard-noopt.json
+++ b/test/inputs/7/wizard-noopt.json
@@ -88,8 +88,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importa.md",
-      "content": ""
+      "name": "importa.md"
     }
   },
   {

--- a/test/inputs/9/wizard-darwin.json
+++ b/test/inputs/9/wizard-darwin.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importg.md",
-      "content": ""
+      "name": "importg.md"
     }
   },
   {

--- a/test/inputs/9/wizard-linux.json
+++ b/test/inputs/9/wizard-linux.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importg.md",
-      "content": ""
+      "name": "importg.md"
     }
   },
   {

--- a/test/inputs/9/wizard-noopt.json
+++ b/test/inputs/9/wizard-noopt.json
@@ -92,8 +92,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importa.md",
-      "content": ""
+      "name": "importa.md"
     }
   },
   {

--- a/test/inputs/9/wizard-win32.json
+++ b/test/inputs/9/wizard-win32.json
@@ -17,8 +17,7 @@
       "source": "placeholder"
     },
     "step": {
-      "name": "importg.md",
-      "content": ""
+      "name": "importg.md"
     }
   },
   {


### PR DESCRIPTION
We were trying to use a () => actualLogic() to delay the heavy expense of turning a subtree of the source AST back into a markdown string. This doesn't seem to work well. Let's just preserve the actual AST...