### PR TITLE
chore: downgrade env-paths 3.0.0 -> 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "cli-highlight": "^2.1.11",
         "debug": "^4.3.4",
         "enquirer": "^2.3.6",
-        "env-paths": "^3.0.0",
+        "env-paths": "^2.2.1",
         "expand-home-dir": "^0.0.3",
         "figures": "^4.0.1",
         "front-matter": "^4.0.2",
@@ -3521,14 +3521,11 @@
       }
     },
     "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/err-code": {
@@ -10845,9 +10842,9 @@
       "dev": true
     },
     "env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "err-code": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "cli-highlight": "^2.1.11",
     "debug": "^4.3.4",
     "enquirer": "^2.3.6",
-    "env-paths": "^3.0.0",
+    "env-paths": "^2.2.1",
     "expand-home-dir": "^0.0.3",
     "figures": "^4.0.1",
     "front-matter": "^4.0.2",


### PR DESCRIPTION
sigh, env-paths 3.0.0 uses `import x from 'node:os'` which webpack isn't happy with (yet)

https://github.com/webpack/webpack/issues/14166