### PR TITLE
fix: refactor to push more cli-specific imports into the dynamic cli path

### DIFF
--- a/src/exec/Executor.ts
+++ b/src/exec/Executor.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import { VFile } from "vfile"
+export type Executor = (cmdline: string) => Promise<string>
 
-export type Reader = (file: VFile, store?: string, searchStore?: boolean) => Promise<VFile>
-
-export function fetcherFor(reader: Reader) {
-  return (filepath: string) => reader(new VFile({ path: filepath })).then((_) => _.value.toString())
+export type ExecutorOptions = {
+  exec: Executor
 }

--- a/src/exec/custom.ts
+++ b/src/exec/custom.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import { write } from "fs"
 import { basename } from "path"
-import { dir as tmpDir, file as tmpFile } from "tmp"
 
 import shellItOut from "./shell"
 import { ExecOptions } from "./options"
@@ -45,6 +43,8 @@ export default async function execAsCustom(
   opts: ExecOptions,
   exec: CustomExecutable["exec"]
 ): Promise<"success"> {
+  const [{ write }, { dir: tmpDir, file: tmpFile }] = await Promise.all([import("fs"), import("tmp")])
+
   return new Promise<"success">((resolve, reject) => {
     tmpDir((err, dir, cleanupCallback1) => {
       if (err) {

--- a/src/exec/index.ts
+++ b/src/exec/index.ts
@@ -53,3 +53,13 @@ export async function shellExec(
     throw new Error("Unable to execute body in unsupported language: " + language)
   }
 }
+
+export async function shellExecToString(
+  cmdline: string | boolean,
+  language?: SupportedLanguage,
+  exec?: CustomExecutable["exec"]
+): Promise<string> {
+  const opts = { capture: "", throwErrors: true }
+  await shellExec(cmdline, opts, language, exec)
+  return opts.capture
+}

--- a/src/exec/python.ts
+++ b/src/exec/python.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import { write } from "fs"
-import { file as tmpFile } from "tmp"
-
 import shellItOut from "./shell"
 import { ExecOptions } from "./options"
 
 /** Execute a python script in a subprocess */
-export default function pythonItOut(cmdline: string | boolean, opts: ExecOptions) {
+export default async function pythonItOut(cmdline: string | boolean, opts: ExecOptions) {
+  const [{ write }, { file: tmpFile }] = await Promise.all([import("fs"), import("tmp")])
+
   return new Promise<"success">((resolve, reject) => {
     tmpFile({ postfix: ".py" }, (err, filepath, fd, cleanupCallback) => {
       if (err) {

--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -22,12 +22,6 @@ import { DebugTask, isDebugTask, isValidTask } from "./tasks"
 
 import { MadWizardOptions } from "../MadWizardOptions"
 
-import { parse } from "../../parser"
-import { version } from "../../version"
-import { wizardify } from "../../wizard"
-import { newChoiceState } from "../../choices"
-import { compile, order, vetoesToString } from "../../graph"
-
 function assertExhaustive(value: never, message = "Reached unexpected case in exhaustive switch"): never {
   throw new Error(message)
 }
@@ -41,6 +35,22 @@ export async function cli<Writer extends (msg: string) => boolean>(
   write: Writer,
   providedOptions: MadWizardOptions = {}
 ) {
+  const [
+    { parse },
+    { version },
+    { wizardify },
+    { newChoiceState },
+    { madwizardRead },
+    { compile, order, vetoesToString },
+  ] = await Promise.all([
+    import("../../parser"),
+    import("../../version"),
+    import("../../wizard"),
+    import("../../choices"),
+    import("./madwizardRead"),
+    import("../../graph"),
+  ])
+
   // TODO replace this with yargs or something like that
   const argv = _argv.filter((_, idx) => !/^-/.test(_) && (idx === 0 || !/^--/.test(_argv[idx - 1])))
 
@@ -116,7 +126,7 @@ export async function cli<Writer extends (msg: string) => boolean>(
     return
   }
 
-  const { blocks } = await parse(input, choices, undefined, undefined, options)
+  const { blocks } = await parse(input, madwizardRead, choices, undefined, options)
 
   switch (task) {
     case "version":

--- a/src/fe/cli/madwizardRead.ts
+++ b/src/fe/cli/madwizardRead.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { VFile } from "vfile"
+import envPaths from "env-paths"
+
+import fetch from "make-fetch-happen"
+import { read as vfileRead } from "to-vfile"
+
+import { join } from "../../parser/markdown/snippets"
+import { toRawGithubUserContent } from "../../parser/markdown/snippets/urls"
+
+export async function get(uri: string) {
+  return fetch(uri, { cachePath: envPaths("madwizard").cache })
+}
+
+/** Fetch the contents of the given `VFile` */
+export async function madwizardRead(
+  file: VFile,
+  store = "https://github.com/guidebooks/store/blob/main/guidebooks",
+  searchStore = false
+): Promise<VFile> {
+  if (/^https?:/.test(file.path)) {
+    // remote fetch
+    const res = await get(file.path)
+    file.value = (await res.buffer()).toString()
+    if (res.status !== 200) {
+      throw new Error(file.value)
+    } else {
+      return file
+    }
+  } else {
+    try {
+      // try reading from the local filesystem
+      return await vfileRead(file)
+    } catch (err) {
+      if (!searchStore) {
+        throw err
+      }
+
+      // see if the path is in the guidebooks store
+      const ext = /\..+$/.test(file.path) ? "" : ".md"
+      const base = join(store, file.path)
+
+      try {
+        const path = toRawGithubUserContent(`${base}${ext}`)
+        return await madwizardRead(new VFile({ path }))
+      } catch (err2) {
+        try {
+          const path = toRawGithubUserContent(`${base}/index${ext}`)
+          return await madwizardRead(new VFile({ path }))
+        } catch (err3) {
+          console.error("!!!!!!", err3)
+          throw err
+        }
+      }
+    }
+  }
+}

--- a/src/graph/compile.ts
+++ b/src/graph/compile.ts
@@ -17,6 +17,7 @@
 import Debug from "debug"
 import { CodeBlockProps } from "../codeblock"
 import { ChoiceState, expand } from "../choices"
+import { ExecutorOptions } from "../exec/Executor"
 import {
   Choice,
   Graph,
@@ -100,7 +101,7 @@ export interface CompilerOptions {
       }
 }
 
-export type CompileOptions = Partial<CompilerOptions> & ValidateOptions & Partial<Memos>
+export type CompileOptions = Partial<CompilerOptions> & ValidateOptions & Partial<Memos> & Partial<ExecutorOptions>
 
 /** Take a list of code blocks and arrange them into a control flow dag */
 export async function compile(

--- a/src/graph/validate.ts
+++ b/src/graph/validate.ts
@@ -16,7 +16,7 @@
 
 import { Memos } from "../memoization"
 import { Validatable } from "../codeblock"
-import { ExecOptions, shellExec } from "../exec"
+import { ExecOptions } from "../exec"
 import { Status, Graph, isSequence, isParallel, isChoice, isTitledSteps, isSubTask, isValidatable } from "."
 
 export type ValidationExecutor = (cmdline: string, opts?: ExecOptions) => "success" | Promise<"success">
@@ -69,7 +69,11 @@ export async function doValidate(
   }
 
   try {
-    await (opts.validator || shellExec)(validate, { quiet: true, env: opts.env, dependencies: opts.dependencies })
+    await (opts.validator || (await import("../exec").then((_) => _.shellExec)))(validate, {
+      quiet: true,
+      env: opts.env,
+      dependencies: opts.dependencies,
+    })
     return "success"
   } catch (err) {
     if (opts.throwErrors) {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -17,7 +17,7 @@
 import { VFileCompatible } from "vfile"
 import { extname as pathExtname } from "path"
 
-import { madwizardRead } from "./markdown"
+import { Reader } from "./markdown/fetch"
 import { ChoiceState, MadWizardOptions } from "../../"
 
 export * from "./markdown"
@@ -38,14 +38,14 @@ function extname(input: VFileCompatible) {
 /** Parse the given `input` into a `Graph` syntax tree. */
 export async function parse(
   input: VFileCompatible,
+  reader: Reader,
   choices?: ChoiceState,
   uuid?: string,
-  reader?: typeof madwizardRead,
   madwizardOptions?: MadWizardOptions
 ) {
   const ext = extname(input)
   if (ext === ".md" || !ext) {
-    return await import("./markdown").then((_) => _.blockify(input, choices, uuid, reader, madwizardOptions))
+    return await import("./markdown").then((_) => _.blockify(input, reader, choices, uuid, madwizardOptions))
   } else {
     throw new Error(`Unsupported file type: ${String(input)}`)
   }

--- a/src/parser/markdown/index.ts
+++ b/src/parser/markdown/index.ts
@@ -24,7 +24,7 @@ import remarkRehype from "remark-rehype"
 import { unified, PluggableList } from "unified"
 
 import { MadWizardOptions } from "../../"
-import { madwizardRead, fetcherFor } from "./fetch"
+import { Reader, fetcherFor } from "./fetch"
 
 import { CodeBlockProps } from "../../codeblock"
 import { ChoiceState, newChoiceState } from "../../choices"
@@ -85,9 +85,9 @@ const rehypePlugins = (
 /** Parse the given `input` into a `Graph` syntax tree. */
 async function parse(
   input: VFile,
+  reader: Reader,
   choices: ChoiceState = newChoiceState(),
   uuid = v4(),
-  reader = madwizardRead,
   madwizardOptions: MadWizardOptions = {}
 ) {
   const debug = Debug("madwizard/timing/parser:markdown")
@@ -130,14 +130,14 @@ async function parse(
 /** Parse the given `input` into a `Graph` syntax tree. */
 export async function blockify(
   input: VFileCompatible,
+  reader: Reader,
   choices?: ChoiceState,
   uuid?: string,
-  reader = madwizardRead,
   madwizardOptions?: MadWizardOptions
 ) {
   const file =
     typeof input === "string"
       ? await reader(new VFile({ path: toRawGithubUserContent(expandHomeDir(input)) }), madwizardOptions.store, true)
       : new VFile(input)
-  return parse(file, choices, uuid, reader, madwizardOptions)
+  return parse(file, reader, choices, uuid, madwizardOptions)
 }

--- a/src/parser/markdown/snippets/inliner.ts
+++ b/src/parser/markdown/snippets/inliner.ts
@@ -19,6 +19,7 @@ import { dirname, join } from "path"
 
 import inlineSnippets from "."
 import { fetcherFor } from "../fetch"
+import { madwizardRead } from "../../../fe/cli/madwizardRead"
 
 /**
  * Fetch and inline all content in the given
@@ -30,7 +31,7 @@ import { fetcherFor } from "../fetch"
  */
 export async function inliner(srcDir: string, srcRelPath: string, targetDir: string) {
   const srcFilePath = join(srcDir, srcRelPath)
-  const fetcher = fetcherFor()
+  const fetcher = fetcherFor(madwizardRead)
   const data = await fetcher(srcFilePath)
   const inlined = await inlineSnippets({ fetcher })(data, srcFilePath)
 


### PR DESCRIPTION
This helps with browser integration.

This PR also enables clients to pass in an executor, e.g. for group expansion.