### PR TITLE
fix: clients that request base64 code blocks may OOM

### DIFF
--- a/src/parser/markdown/rehype-code-indexer/index.ts
+++ b/src/parser/markdown/rehype-code-indexer/index.ts
@@ -164,7 +164,12 @@ export function rehypeCodeIndexer(uuid: string, filepath: string, codeblocks?: C
 
                 const dumpCodeBlockProps = !base64
                   ? () => Object.assign({ body, language }, attributes)
-                  : () => Buffer.from(JSON.stringify(Object.assign({ body, language }, attributes))).toString("base64")
+                  : () =>
+                      Buffer.from(
+                        JSON.stringify(Object.assign({ body, language }, attributes), (key, value) =>
+                          key === "nesting" || key === "source" ? undefined : value
+                        )
+                      ).toString("base64")
 
                 let codeBlockProps = dumpCodeBlockProps()
 


### PR DESCRIPTION
oof, we are serializing way too much. we can exclude source and nesting attributes, or... rather, we need to, to avoid gigantic serialized blobs. e.g. 350MB versus 128 bytes