### PR TITLE
feat: allow imports to reliably use stort shortform relative paths

### DIFF
--- a/src/parser/markdown/fetch.ts
+++ b/src/parser/markdown/fetch.ts
@@ -18,6 +18,7 @@ import { VFile } from "vfile"
 
 export type Reader = (file: VFile, store?: string, searchStore?: boolean) => Promise<VFile>
 
-export function fetcherFor(reader: Reader) {
-  return (filepath: string) => reader(new VFile({ cwd: process.cwd(), path: filepath })).then((_) => _.value.toString())
+export function fetcherFor(reader: Reader, store?: string, searchStore?: boolean) {
+  return (filepath: string) =>
+    reader(new VFile({ cwd: process.cwd(), path: filepath }), store, searchStore).then((_) => _.value.toString())
 }

--- a/src/parser/markdown/index.ts
+++ b/src/parser/markdown/index.ts
@@ -103,7 +103,7 @@ async function parse(
       .use(remarkRehype, { allowDangerousHtml: true })
       .use(rehypePlugins(uuid, choices, blocks, madwizardOptions, input.path))
 
-    const fetcher = fetcherFor(reader)
+    const fetcher = fetcherFor(reader, madwizardOptions.store, true)
 
     debug("fetch start")
     const sourcePriorToInlining = input.value.toString()

--- a/test/inputs/10/in.md
+++ b/test/inputs/10/in.md
@@ -1,8 +1,8 @@
 ---
 imports:
-    - importgg.md
-    - importaa.md
-    - importdd.md
+    - ../snippets/importgg.md
+    - ../snippets/importaa.md
+    - ../snippets/importdd.md
 ---
 
 ::imports

--- a/test/inputs/12/in.md
+++ b/test/inputs/12/in.md
@@ -3,5 +3,5 @@ codeblocks:
     - match: AAA
       validate: echo true
 imports:
-    - snippet.md
+    - ./snippet.md
 ---

--- a/test/inputs/17/in.md
+++ b/test/inputs/17/in.md
@@ -1,8 +1,8 @@
 ---
 imports:
-    - importa.md
-    - barrier.md
-    - importe.md
+    - ../snippets/importa.md
+    - ../snippets/barrier.md
+    - ../snippets/importe.md
 ---
 
 ```shell

--- a/test/inputs/18/in.md
+++ b/test/inputs/18/in.md
@@ -1,4 +1,4 @@
 ---
 imports:
-    - snippet.md
+    - ./snippet.md
 ---

--- a/test/inputs/18/snippet.md
+++ b/test/inputs/18/snippet.md
@@ -1,7 +1,7 @@
 # Conditional Imports of Validated Code Blocks
 
 === "Tab1"
-    :import{importa.md}
+    :import{../snippets/importa.md}
 
 === "Tab2"
-    :import{importe.md}
+    :import{../snippets/importe.md}

--- a/test/inputs/19/in.md
+++ b/test/inputs/19/in.md
@@ -24,7 +24,7 @@
         === "Apple Silicon"
             If you are running on Apple Silicon/ARM hardware.
         
-            :import{conda.md}
+            :import{./snippets/conda.md}
 
         
             ```shell
@@ -35,4 +35,4 @@
             ```
         
 === "Kubernetes Install"
-    --8<-- "kubernetes.md"
+    --8<-- "./snippets/kubernetes.md"

--- a/test/inputs/19/snippets/conda.md
+++ b/test/inputs/19/snippets/conda.md
@@ -1,6 +1,6 @@
 # Conda: Installation
 
---8<-- "what-is-conda.md"
+--8<-- "./what-is-conda.md"
 
 ## Installation Method
 

--- a/test/inputs/19/snippets/kubernetes.md
+++ b/test/inputs/19/snippets/kubernetes.md
@@ -1,7 +1,7 @@
 ---
 imports:
-    - kubectl.md
-    - helm3.md
+    - ./kubectl.md
+    - ./helm3.md
 ---
 
 # Install Ray on a Kubernetes Cluster

--- a/test/inputs/2/in.md
+++ b/test/inputs/2/in.md
@@ -2,4 +2,4 @@ smurf
 
 hello _world_
 
---8<-- "tabs.md"
+--8<-- "./tabs.md"

--- a/test/inputs/20/in.md
+++ b/test/inputs/20/in.md
@@ -1,4 +1,4 @@
 # Conditional Inline of Imports
 
 === "Tab1"
-    --8<-- "import.md"
+    --8<-- "./snippets/import.md"

--- a/test/inputs/20/snippets/import.md
+++ b/test/inputs/20/snippets/import.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - a.md
+    - ./a.md
 ---
 
 ```shell
@@ -8,4 +8,4 @@ echo III
 ```
 
 === "ITab1"
-    --8<-- "import2.md"
+    --8<-- "./import2.md"

--- a/test/inputs/20/snippets/import2.md
+++ b/test/inputs/20/snippets/import2.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - b.md
+    - ./b.md
 ---
 
 ```shell

--- a/test/inputs/23/data.md
+++ b/test/inputs/23/data.md
@@ -1,6 +1,6 @@
 # Install Ray Data
 
---8<-- "glossary/dataset.md"
+--8<-- "./glossary/dataset.md"
 
 To get started with Ray Data, you will need to install a library.
 

--- a/test/inputs/23/examples/dataset/index.md
+++ b/test/inputs/23/examples/dataset/index.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - ../data.md
+    - ../../data.md
 ---
 
 # Creating and Transforming Datasets
@@ -8,7 +8,7 @@ imports:
 --8<-- "../../../glossary/dataset.md"
 
 === "New Dataset from Range"
-    --8<-- "create/from-range.md"
+    --8<-- "./create/from-range.md"
 
 === "New Dataset from File"
-    --8<-- "create/from-file.md"
+    --8<-- "./create/from-file.md"

--- a/test/inputs/23/examples/index.md
+++ b/test/inputs/23/examples/index.md
@@ -1,8 +1,8 @@
 === "Example: Using Ray Tasks to Parallelize a Function"
-    --8<-- "tasks.md"
+    --8<-- "./tasks.md"
 
 === "Example: Using Ray Actors to Parallelize a Class"
-    --8<-- "actors.md"
+    --8<-- "./actors.md"
 
 === "Example: Creating and Transforming Datasets"
-    --8<-- "dataset/index.md"
+    --8<-- "./dataset/index.md"

--- a/test/inputs/23/in.md
+++ b/test/inputs/23/in.md
@@ -1,8 +1,8 @@
 ---
 imports:
-    - install/index.md
+    - ./install/index.md
 ---
 
 # Run a Ray Job
 
---8<-- "examples/index.md"
+--8<-- "./examples/index.md"

--- a/test/inputs/23/install/index.md
+++ b/test/inputs/23/install/index.md
@@ -25,4 +25,4 @@
         hello
 
 === "Kubernetes Install"
-    --8<-- "kubernetes.md"
+    --8<-- "./kubernetes.md"

--- a/test/inputs/23/python/conda/install.md
+++ b/test/inputs/23/python/conda/install.md
@@ -1,6 +1,6 @@
 # Conda: Installation
 
---8<-- "what-is-conda.md"
+--8<-- "./what-is-conda.md"
 
 ## Choose a Conda Installation Method
 

--- a/test/inputs/25/in.md
+++ b/test/inputs/25/in.md
@@ -1,6 +1,6 @@
 === "Tab1"
-    :import{a.md}
-    :import{b.md}
+    :import{./a.md}
+    :import{./b.md}
 
 === "Tab2"
-    :import{a.md}
+    :import{./a.md}

--- a/test/inputs/3/in.md
+++ b/test/inputs/3/in.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - snippets-in-tab3.md
+    - ../snippets/snippets-in-tab3.md
 ---
 
 <!-- You should see a tree view. This is the Imports.tsx component -->

--- a/test/inputs/4/in.md
+++ b/test/inputs/4/in.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - snippets-in-tab4.md
+    - ../snippets/snippets-in-tab4.md
 ---
 
 <!-- You should see a tree view. This is the Imports.tsx component -->

--- a/test/inputs/5/in.md
+++ b/test/inputs/5/in.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - snippets-in-tab5.md
+    - ../snippets/snippets-in-tab5.md
 ---
 
 <!-- You should see a tree view. This is the Imports.tsx component -->

--- a/test/inputs/6/in.md
+++ b/test/inputs/6/in.md
@@ -1,7 +1,7 @@
 ---
 imports:
-    - importd.md
-    - snippets-in-tab5.md
+    - ../snippets/importd.md
+    - ../snippets/snippets-in-tab5.md
 ---
 
 <!-- You should see a tree view. This is the Imports.tsx component -->

--- a/test/inputs/7/in.md
+++ b/test/inputs/7/in.md
@@ -1,7 +1,7 @@
 ---
 imports:
-    - importd.md
-    - snippets-in-tab5.md
+    - ../snippets/importd.md
+    - ../snippets/snippets-in-tab5.md
 ---
 
 <!-- You should see a tree view. This is the Imports.tsx component -->

--- a/test/inputs/8/in.md
+++ b/test/inputs/8/in.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - snippets-in-tab6.md
+    - ../snippets/snippets-in-tab6.md
 ---
 
 ::imports

--- a/test/inputs/9/in.md
+++ b/test/inputs/9/in.md
@@ -1,8 +1,8 @@
 ---
 imports:
-    - importg.md
-    - importa.md
-    - importd.md
+    - ../snippets/importg.md
+    - ../snippets/importa.md
+    - ../snippets/importd.md
 ---
 
 ::imports

--- a/test/inputs/snippets/importaa.md
+++ b/test/inputs/snippets/importaa.md
@@ -1,1 +1,1 @@
-{% include "importa.md" %}
+{% include "./importa.md" %}

--- a/test/inputs/snippets/importd.md
+++ b/test/inputs/snippets/importd.md
@@ -1,9 +1,9 @@
 # DDD
 
 === "SubTab1"
-    --8<-- "importa.md"
-    --8<-- "importa.md"
-    --8<-- "importa.md"
+    --8<-- "./importa.md"
+    --8<-- "./importa.md"
+    --8<-- "./importa.md"
     
 === "SubTab2"
-    --8<-- "importb.md"
+    --8<-- "./importb.md"

--- a/test/inputs/snippets/importdd.md
+++ b/test/inputs/snippets/importdd.md
@@ -1,1 +1,1 @@
-{% include "importd.md" %}
+{% include "./importd.md" %}

--- a/test/inputs/snippets/importf.md
+++ b/test/inputs/snippets/importf.md
@@ -1,4 +1,4 @@
 ---
 imports:
-    - importd.md
+    - ./importd.md
 ---

--- a/test/inputs/snippets/importgg.md
+++ b/test/inputs/snippets/importgg.md
@@ -1,1 +1,1 @@
-{% include "importg.md" %}
+{% include "./importg.md" %}

--- a/test/inputs/snippets/snippets-in-tab0.md
+++ b/test/inputs/snippets/snippets-in-tab0.md
@@ -3,9 +3,9 @@ AAA
 --8<-- "importa.md"
 
 === "Tab1"
-    --8<-- "snippets-in-tab0a.md"
+    --8<-- "./snippets-in-tab0a.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab0b.md"
+    --8<-- "./snippets-in-tab0b.md"
 
 DDD

--- a/test/inputs/snippets/snippets-in-tab0a.md
+++ b/test/inputs/snippets/snippets-in-tab0a.md
@@ -1,4 +1,4 @@
 BBB
 
---8<-- "importb.md"
+--8<-- "./importb.md"
 

--- a/test/inputs/snippets/snippets-in-tab0b.md
+++ b/test/inputs/snippets/snippets-in-tab0b.md
@@ -1,4 +1,4 @@
---8<-- "importc.md"
+--8<-- "./importc.md"
 
 ???+ tip "TipTitle"
     TipContent

--- a/test/inputs/snippets/snippets-in-tab1.md
+++ b/test/inputs/snippets/snippets-in-tab1.md
@@ -2,7 +2,7 @@
 layout:
     1: right
 imports:
-    - importa.md
+    - ./importa.md
 ---
 
 ::imports
@@ -12,9 +12,9 @@ imports:
 AAA
 
 === "Tab1"
-    --8<-- "snippets-in-tab1a.md"
+    --8<-- "./snippets-in-tab1a.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab1b.md"
+    --8<-- "./snippets-in-tab1b.md"
 
 DDD

--- a/test/inputs/snippets/snippets-in-tab1a.md
+++ b/test/inputs/snippets/snippets-in-tab1a.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - importb.md
+    - ./importb.md
 ---
 
 BBB

--- a/test/inputs/snippets/snippets-in-tab1b.md
+++ b/test/inputs/snippets/snippets-in-tab1b.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - importc.md
+    - ./importc.md
 ---
 
 ???+ tip "TipTitle"

--- a/test/inputs/snippets/snippets-in-tab2.md
+++ b/test/inputs/snippets/snippets-in-tab2.md
@@ -1,9 +1,9 @@
 AAA
 
 === "Tab1"
-    --8<-- "snippets-in-tab1b.md"
+    --8<-- "./snippets-in-tab1b.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab1a.md"
+    --8<-- "./snippets-in-tab1a.md"
 
 DDD

--- a/test/inputs/snippets/snippets-in-tab3.md
+++ b/test/inputs/snippets/snippets-in-tab3.md
@@ -2,9 +2,9 @@
 layout:
     1: right
 imports:
-    - importa.md
-    - importe.md
-    - importf.md
+    - ./importa.md
+    - ./importe.md
+    - ./importf.md
 ---
 
 ::imports
@@ -14,9 +14,9 @@ imports:
 # AAA
 
 === "Tab1"
-    --8<-- "snippets-in-tab3a.md"
+    --8<-- "./snippets-in-tab3a.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab1b.md"
+    --8<-- "./snippets-in-tab1b.md"
 
 DDD

--- a/test/inputs/snippets/snippets-in-tab3a.md
+++ b/test/inputs/snippets/snippets-in-tab3a.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - importd.md
+    - ./importd.md
 ---
 
 BBBoo

--- a/test/inputs/snippets/snippets-in-tab4.md
+++ b/test/inputs/snippets/snippets-in-tab4.md
@@ -2,8 +2,8 @@
 layout:
     1: right
 imports:
-    - importa.md
-    - importe.md
+    - ./importa.md
+    - ./importe.md
 ---
 
 ::imports
@@ -13,9 +13,9 @@ imports:
 # AAA
 
 === "Tab1"
-    --8<-- "snippets-in-tab3a.md"
+    --8<-- "./snippets-in-tab3a.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab4b.md"
+    --8<-- "./snippets-in-tab4b.md"
 
 DDD

--- a/test/inputs/snippets/snippets-in-tab5.md
+++ b/test/inputs/snippets/snippets-in-tab5.md
@@ -2,8 +2,8 @@
 layout:
     1: right
 imports:
-    - importa.md
-    - importe.md
+    - ./importa.md
+    - ./importe.md
 ---
 
 ::imports
@@ -13,12 +13,12 @@ imports:
 # AAA
 
 === "Tab1"
-    --8<-- "snippets-in-tab3a.md"
+    --8<-- "./snippets-in-tab3a.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab4b.md"
+    --8<-- "./snippets-in-tab4b.md"
 
 === "Tab3"
-    --8<-- "snippets-in-tab5c.md"
+    --8<-- "./snippets-in-tab5c.md"
 
 DDD

--- a/test/inputs/snippets/snippets-in-tab5c.md
+++ b/test/inputs/snippets/snippets-in-tab5c.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - importd.md
+    - ./importd.md
 ---
 
 CCCoo

--- a/test/inputs/snippets/snippets-in-tab6.md
+++ b/test/inputs/snippets/snippets-in-tab6.md
@@ -1,11 +1,11 @@
 # Chooser
 
 === "Tab1"
-    :import{importd.md}
+    :import{./importd.md}
 
 === "Tab2"
-    :import{importd.md}
+    :import{./importd.md}
 
 === "Tab3"
-    :import{importd.md}
+    :import{./importd.md}
 


### PR DESCRIPTION
BREAKING CHANGE: with this PR, we adopt the nodejs convention for imports:

Assumed to come from the store (if one is registered)
foo/bar
foo/bar/index.md

Assumed not to come from the store:
foo
./foo/bar
https://foo.com/bar