### PR TITLE
fix: cli API treats the Writer paramter as optional, but types don't …

### DIFF
--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -32,7 +32,7 @@ function enableTracing(task: DebugTask, subtask = "*") {
 
 export async function cli<Writer extends (msg: string) => boolean>(
   _argv: string[],
-  write: Writer,
+  write?: Writer,
   providedOptions: MadWizardOptions = {}
 ) {
   const [


### PR DESCRIPTION
…declare it as such