### PR TITLE
chore: switch to non-experimental esm module imports

### DIFF
--- a/bin/madwizard.js
+++ b/bin/madwizard.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-specifier-resolution=node --no-warnings --experimental-import-meta-resolve
+#!/usr/bin/env -S node --no-warnings
 
 /* eslint-env node */
 /* ^^^ rather than add env: node globally in package.json */
@@ -20,7 +20,7 @@ const store =
     : process.env.MWSTORE || join(dirname(require.resolve(madwizard)), "store")
 const argv = process.argv.slice(1).concat(["--store=" + store])
 
-import(madwizard + "/dist/fe/cli")
+import(madwizard + "/dist/fe/cli/index.js")
   .then((_) => _.cli(argv))
   .catch((err) => {
     if (process.env.DEBUG) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "watch": "npm run devhack && cross-env concurrently -n CORE,TEST 'tsc --build . --watch' 'cd test && tsc --build . --watch'",
     "build": "npm run devhack && tsc --build .",
     "build:test": "cross-env-shell tsc --project test",
-    "test": "cross-env npm run build:test && cross-env concurrently --raw -n TYPES,TESTS 'tsc --noEmit' 'node --no-warnings --experimental-specifier-resolution=node test/dist'",
+    "test": "cross-env npm run build:test && cross-env concurrently --raw -n TYPES,TESTS 'tsc --noEmit' 'node --no-warnings test/dist'",
     "format": "cross-env prettier --write '**/*.{scss,css,html,js,json,md,ts,tsx}'",
     "format:test:input": "cross-env prettier --write test/inputs",
     "mirror": "T=$(mktemp -d); (cd $T && git clone --depth=1 git@github.com:guidebooks/store.git) && echo \"mirror stage in $T/store\" && ./bin/madwizard.js mirror $T/store/guidebooks ./dist/store",

--- a/src/choices/groups/aprioris/arch.ts
+++ b/src/choices/groups/aprioris/arch.ts
@@ -16,9 +16,9 @@
 
 import { Element } from "hast"
 
-import debug from "./debug"
-import { ChoiceState } from "../.."
-import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from ".."
+import debug from "./debug.js"
+import { ChoiceState } from "../../index.js"
+import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from "../index.js"
 
 export class Arch {
   /** internal, the value should be namespaced and unique, but the particulars don't matter */

--- a/src/choices/groups/aprioris/debug.ts
+++ b/src/choices/groups/aprioris/debug.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Debug } from "../debug"
+import { Debug } from "../debug.js"
 
 export default function debug(subtask: string, formatter: string, ...args: string[]) {
   return Debug(`aprioris/${subtask}`)(formatter, ...args)

--- a/src/choices/groups/aprioris/homebrew.ts
+++ b/src/choices/groups/aprioris/homebrew.ts
@@ -17,9 +17,9 @@
 import { Element } from "hast"
 import which from "which"
 
-import debug from "./debug"
-import { ChoiceState } from "../.."
-import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from ".."
+import debug from "./debug.js"
+import { ChoiceState } from "../../index.js"
+import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from "../index.js"
 
 export class Homebrew {
   /** the value should be namespaced and unique, but the particulars don't matter */

--- a/src/choices/groups/aprioris/index.ts
+++ b/src/choices/groups/aprioris/index.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import arch from "./arch"
-import platform from "./platform"
-import homebrew from "./homebrew"
-import interminal from "./interminal"
+import arch from "./arch.js"
+import platform from "./platform.js"
+import homebrew from "./homebrew.js"
+import interminal from "./interminal.js"
 
 export default [arch, platform, homebrew, interminal]

--- a/src/choices/groups/aprioris/interminal.ts
+++ b/src/choices/groups/aprioris/interminal.ts
@@ -16,9 +16,9 @@
 
 import { Element } from "hast"
 
-import debug from "./debug"
-import { ChoiceState } from "../.."
-import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from ".."
+import debug from "./debug.js"
+import { ChoiceState } from "../../index.js"
+import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from "../index.js"
 
 export class RunningInTerminal {
   /** internal, the value should be namespaced and unique, but the particulars don't matter */

--- a/src/choices/groups/aprioris/platform.ts
+++ b/src/choices/groups/aprioris/platform.ts
@@ -16,9 +16,9 @@
 
 import { Element } from "hast"
 
-import debug from "./debug"
-import { ChoiceState } from "../.."
-import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from ".."
+import debug from "./debug.js"
+import { ChoiceState } from "../../index.js"
+import { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from "../index.js"
 
 export class Platform {
   /** internal, the value should be namespaced and unique, but the particulars don't matter */

--- a/src/choices/groups/expansion.ts
+++ b/src/choices/groups/expansion.ts
@@ -16,11 +16,11 @@
 
 import chalk from "chalk"
 import { v4 } from "uuid"
-import { oraPromise } from "../../util/ora-delayed-promise"
+import { oraPromise } from "../../util/ora-delayed-promise.js"
 
-import { Debug } from "./debug"
-import { ExecutorOptions } from "../../exec/Executor"
-import { Memos } from "../../memoization"
+import { Debug } from "./debug.js"
+import { ExecutorOptions } from "../../exec/Executor.js"
+import { Memos } from "../../memoization/index.js"
 import {
   Graph,
   Choice,
@@ -31,7 +31,7 @@ import {
   isChoice,
   isTitledSteps,
   isSubTask,
-} from "../../graph"
+} from "../../graph/index.js"
 
 export type ExpansionMap = Record<ReturnType<typeof isExpansion>, string[]>
 
@@ -102,7 +102,7 @@ function expandPart(template: ChoicePart, names: string[]): ChoicePart[] {
 async function doExpand(expansionExpr: string, options: Partial<ExecutorOptions>): Promise<string[]> {
   try {
     const response = await oraPromise(
-      (options.exec || (await import("../../exec").then((_) => _.shellExecToString)))(expansionExpr, options),
+      (options.exec || (await import("../../exec/index.js").then((_) => _.shellExecToString)))(expansionExpr, options),
       chalk.dim(`Expanding ${chalk.blue(expansionExpr)}`)
     )
     return response.split(/\n/).filter(Boolean)

--- a/src/choices/groups/index.ts
+++ b/src/choices/groups/index.ts
@@ -17,12 +17,17 @@
 import { Node, Element } from "hast"
 import { visit } from "unist-util-visit"
 
-import { ChoiceState } from ".."
-import { MadWizardOptions } from "../../fe"
-import { isTabGroup } from "../../parser/markdown/rehype-tabbed"
-export { getTabTitle, isTabWithProperties, setTabGroup, setTabTitle } from "../../parser/markdown/rehype-tabbed"
+import { ChoiceState } from "../index.js"
+import { MadWizardOptions } from "../../fe/index.js"
+import { isTabGroup } from "../../parser/markdown/rehype-tabbed/index.js"
+export {
+  getTabTitle,
+  isTabWithProperties,
+  setTabGroup,
+  setTabTitle,
+} from "../../parser/markdown/rehype-tabbed/index.js"
 
-import aprioris from "./aprioris"
+import aprioris from "./aprioris/index.js"
 
 /**
  * Scan tab groups to see if we can squash down the choice given our a

--- a/src/choices/impl.ts
+++ b/src/choices/impl.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { ChoiceState, ChoicesMap } from "."
-import ChoiceEventManager from "./events"
+import ChoiceEventManager from "./events.js"
+import { ChoiceState, ChoicesMap } from "./index.js"
 
 export default class ChoiceStateImpl extends ChoiceEventManager implements ChoiceState {
   public constructor(

--- a/src/choices/index.ts
+++ b/src/choices/index.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import ChoiceStateImpl from "./impl"
-import { Choice as CodeBlockChoice } from "../codeblock/CodeBlockProps"
-import { ChoiceHandlerRegistration } from "./events"
+import ChoiceStateImpl from "./impl.js"
+import { Choice as CodeBlockChoice } from "../codeblock/CodeBlockProps.js"
+import { ChoiceHandlerRegistration } from "./events.js"
 
-export { expand, updateContent } from "./groups/expansion"
+export { expand, updateContent } from "./groups/expansion.js"
 
 /* map from choice group to selected choice member */
 export type ChoicesMap = Record<CodeBlockChoice["group"], CodeBlockChoice["title"]>

--- a/src/codeblock/CodeBlockProps.ts
+++ b/src/codeblock/CodeBlockProps.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { FormElement } from "./form"
-import { SupportedLanguage } from "./language"
-import { Something } from "../parser/markdown/util/toMarkdownString"
+import { FormElement } from "./form.js"
+import { SupportedLanguage } from "./language.js"
+import { Something } from "../parser/markdown/util/toMarkdownString.js"
 
-export * from "./form"
+export * from "./form.js"
 
 export interface Validatable {
   /**

--- a/src/codeblock/index.ts
+++ b/src/codeblock/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export * from "./language"
-export * from "./isCodeBlock"
-export * from "./CodeBlockProps"
+export * from "./language.js"
+export * from "./isCodeBlock.js"
+export * from "./CodeBlockProps.js"

--- a/src/codeblock/isCodeBlock.ts
+++ b/src/codeblock/isCodeBlock.ts
@@ -15,7 +15,7 @@
  */
 
 import { Element } from "hast"
-import { SupportedLanguage } from "./language"
+import { SupportedLanguage } from "./language.js"
 
 export function isExecutable(language: string): language is SupportedLanguage {
   return /bash|sh|shell|py|python/.test(language)

--- a/src/exec/Executor.ts
+++ b/src/exec/Executor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ExecOptions } from "./options"
+import { ExecOptions } from "./options.js"
 
 export type Executor = (cmdline: string, opts?: ExecOptions) => Promise<string>
 

--- a/src/exec/custom.ts
+++ b/src/exec/custom.ts
@@ -16,9 +16,9 @@
 
 import { basename } from "path"
 
-import shellItOut from "./shell"
-import { ExecOptions } from "./options"
-import { CustomExecutable } from "../codeblock"
+import shellItOut from "./shell.js"
+import { ExecOptions } from "./options.js"
+import { CustomExecutable } from "../codeblock/index.js"
 
 export interface CustomEnv {
   /** Directory in which the custom executable will be executed */

--- a/src/exec/export.ts
+++ b/src/exec/export.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ExecOptions } from "./options"
+import { ExecOptions } from "./options.js"
 
 /** See if we are being asked to execute `export FOO=bar` */
 export default function execAsExport(cmdline: string | boolean, opts: ExecOptions) {

--- a/src/exec/index.ts
+++ b/src/exec/index.ts
@@ -15,15 +15,15 @@
  */
 
 import { Env, ExecOptions } from "./options"
-import { CustomExecutable, SupportedLanguage, isPythonic, isShellish } from "../codeblock"
+import { CustomExecutable, SupportedLanguage, isPythonic, isShellish } from "../codeblock/index.js"
 
-import shell from "./shell"
-import which from "./which"
-import custom from "./custom"
-import python from "./python"
-import exporter from "./export"
-import pipShow from "./pip-show"
-import raySubmit from "./ray-submit"
+import shell from "./shell.js"
+import which from "./which.js"
+import custom from "./custom.js"
+import python from "./python.js"
+import exporter from "./export.js"
+import pipShow from "./pip-show.js"
+import raySubmit from "./ray-submit.js"
 
 export { Env, ExecOptions }
 

--- a/src/exec/options.ts
+++ b/src/exec/options.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Memos } from "../memoization"
+import { Memos } from "../memoization/index.js"
 
 /** Environment variable state that might be mutated by the guidebook itself */
 export type Env = Pick<Memos, "env">

--- a/src/exec/pip-show.ts
+++ b/src/exec/pip-show.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import shellItOut from "./shell"
-import { ExecOptions } from "./options"
+import shellItOut from "./shell.js"
+import { ExecOptions } from "./options.js"
 
 /**
  * This is purely an optimization, since `pip show` is muy slow. The

--- a/src/exec/python.ts
+++ b/src/exec/python.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import shellItOut from "./shell"
-import { ExecOptions } from "./options"
+import shellItOut from "./shell.js"
+import { ExecOptions } from "./options.js"
 
 /** Execute a python script in a subprocess */
 export default async function pythonItOut(cmdline: string | boolean, opts: ExecOptions) {

--- a/src/exec/ray-submit.ts
+++ b/src/exec/ray-submit.ts
@@ -15,8 +15,8 @@
  */
 
 import Debug from "debug"
-import { ExecOptions } from "./options"
-import custom, { CustomEnv } from "./custom"
+import { ExecOptions } from "./options.js"
+import custom, { CustomEnv } from "./custom.js"
 
 type Pip = {
   pip: string[]

--- a/src/exec/shell.ts
+++ b/src/exec/shell.ts
@@ -15,7 +15,7 @@
  */
 
 import { spawn } from "child_process"
-import { ExecOptions } from "./options"
+import { ExecOptions } from "./options.js"
 
 /** Shell out the execution of the given `cmdline` */
 export default async function shellItOut(

--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -17,10 +17,10 @@
 import { EOL } from "os"
 import Debug from "debug"
 
-import usage from "./usage"
-import { DebugTask, isDebugTask, isValidTask } from "./tasks"
+import usage from "./usage.js"
+import { DebugTask, isDebugTask, isValidTask } from "./tasks.js"
 
-import { MadWizardOptions } from "../MadWizardOptions"
+import { MadWizardOptions } from "../MadWizardOptions.js"
 
 function assertExhaustive(value: never, message = "Reached unexpected case in exhaustive switch"): never {
   throw new Error(message)
@@ -39,14 +39,14 @@ export async function cli<Writer extends (msg: string) => boolean>(
   const argv = _argv.filter((_, idx) => !/^-/.test(_) && (idx === 0 || !/^--/.test(_argv[idx - 1])))
 
   if (argv[1] === "version") {
-    return import("../../version").then((_) => _.version())
+    return import("../../version.js").then((_) => _.version())
   }
 
   const [{ parse }, { newChoiceState }, { madwizardRead }, { compile, order, vetoesToString }] = await Promise.all([
-    import("../../parser"),
-    import("../../choices"),
-    import("./madwizardRead"),
-    import("../../graph"),
+    import("../../parser/index.js"),
+    import("../../choices/index.js"),
+    import("./madwizardRead.js"),
+    import("../../graph/index.js"),
   ])
 
   const task = !argv[2] ? "guide" : argv[1]
@@ -108,11 +108,11 @@ export async function cli<Writer extends (msg: string) => boolean>(
   // mirror calls build over a directory tree), you can also amortize
   // the cost of many file reads/remote fetches per run.
   if (task === "build") {
-    const { inliner } = await import("../../parser/markdown/snippets/inliner")
+    const { inliner } = await import("../../parser/markdown/snippets/inliner.js")
     await inliner(input, argv[3], argv[4])
     return
   } else if (task === "mirror") {
-    const { mirror } = await import("../../parser/markdown/snippets/mirror")
+    const { mirror } = await import("../../parser/markdown/snippets/mirror.js")
     await mirror(input, argv[3])
     return
   }
@@ -133,14 +133,14 @@ export async function cli<Writer extends (msg: string) => boolean>(
     case "debug:fetch": {
       // print out timing
       const graph = await compile(blocks, choices, options)
-      await import("../../wizard").then((_) => _.wizardify(graph))
+      await import("../../wizard/index.js").then((_) => _.wizardify(graph))
 
-      await import("../tree").then((_) => new _.Treeifier(new _.DevNullUI()).toTree(order(graph)))
+      await import("../tree/index.js").then((_) => new _.Treeifier(new _.DevNullUI()).toTree(order(graph)))
       break
     }
 
     case "plan":
-      await import("../tree").then((_) =>
+      await import("../tree/index.js").then((_) =>
         _.prettyPrintUITreeFromBlocks(blocks, choices, Object.assign({ write }, options))
       )
       break
@@ -151,7 +151,7 @@ export async function cli<Writer extends (msg: string) => boolean>(
 
     case "json": {
       const graph = await compile(blocks, choices, options)
-      const wizard = await import("../../wizard").then((_) => _.wizardify(graph))
+      const wizard = await import("../../wizard/index.js").then((_) => _.wizardify(graph))
       ;(write || process.stdout.write.bind(process.stdout))(
         JSON.stringify(
           wizard,
@@ -180,7 +180,7 @@ export async function cli<Writer extends (msg: string) => boolean>(
 
     case "run":
     case "guide": {
-      const Guide = await import("../guide").then((_) => _.Guide)
+      const Guide = await import("../guide/index.js").then((_) => _.Guide)
       await new Guide(task, blocks, choices, options).run()
       break
     }

--- a/src/fe/cli/madwizardRead.ts
+++ b/src/fe/cli/madwizardRead.ts
@@ -21,8 +21,8 @@ import envPaths from "env-paths"
 import fetch from "make-fetch-happen"
 import { read as vfileRead } from "to-vfile"
 
-import { join } from "../../parser/markdown/snippets"
-import { toRawGithubUserContent } from "../../parser/markdown/snippets/urls"
+import { join } from "../../parser/markdown/snippets/index.js"
+import { toRawGithubUserContent } from "../../parser/markdown/snippets/urls.js"
 
 export async function get(uri: string) {
   return fetch(uri, { cachePath: envPaths("madwizard").cache })

--- a/src/fe/cli/usage.ts
+++ b/src/fe/cli/usage.ts
@@ -17,7 +17,7 @@
 import chalk from "chalk"
 import { basename } from "path"
 
-import { validTasks } from "./tasks"
+import { validTasks } from "./tasks.js"
 
 export default function usage(argv: string[], msg?: string) {
   if (msg) {

--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -23,17 +23,17 @@ import { Writable } from "stream"
 import { mainSymbols } from "figures"
 import { EventEmitter } from "events"
 
-import { taskRunner, Task } from "./taskrunner"
+import { taskRunner, Task } from "./taskrunner.js"
 
-import { shellExec } from "../../exec"
-import { MadWizardOptions } from "../../"
-import { ChoiceState } from "../../choices"
-import { CodeBlockProps } from "../../codeblock"
-import indent from "../../parser/markdown/util/indent"
-import { Memos, Memoizer, statusOf } from "../../memoization"
-import { UI, AnsiUI, prettyPrintUITreeFromBlocks } from "../tree"
-import { ChoiceStep, TaskStep, Wizard, isChoiceStep, isForm, isTaskStep, wizardify } from "../../wizard"
-import { Graph, Status, blocks, compile, extractTitle, extractDescription, validate } from "../../graph"
+import { shellExec } from "../../exec/index.js"
+import { MadWizardOptions } from "../../index.js"
+import { ChoiceState } from "../../choices/index.js"
+import { CodeBlockProps } from "../../codeblock/index.js"
+import indent from "../../parser/markdown/util/indent.js"
+import { Memos, Memoizer, statusOf } from "../../memoization/index.js"
+import { UI, AnsiUI, prettyPrintUITreeFromBlocks } from "../tree/index.js"
+import { ChoiceStep, TaskStep, Wizard, isChoiceStep, isForm, isTaskStep, wizardify } from "../../wizard/index.js"
+import { Graph, Status, blocks, compile, extractTitle, extractDescription, validate } from "../../graph/index.js"
 
 type Question = enquirer.prompt.SelectQuestionOptions | enquirer.prompt.FormQuestionOptions
 

--- a/src/fe/index.ts
+++ b/src/fe/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from "./MadWizardOptions"
+export * from "./MadWizardOptions.js"

--- a/src/fe/tree/index.ts
+++ b/src/fe/tree/index.ts
@@ -35,15 +35,15 @@ import {
   isSequence,
   isParallel,
   progress,
-} from "../../graph"
+} from "../../graph/index.js"
 
-import { UI } from "./ui"
-import TreeTransformer from "./xform"
-import { UINode, UITree } from "./props"
+import { UI } from "./ui.js"
+import TreeTransformer from "./xform.js"
+import { UINode, UITree } from "./props.js"
 
-export * from "./ui"
-export * from "./props"
-export * from "./pretty-print"
+export * from "./ui.js"
+export * from "./props.js"
+export * from "./pretty-print.js"
 
 type Progress = { nDone: number; nError: number; nTotal: number }
 

--- a/src/fe/tree/pretty-print.ts
+++ b/src/fe/tree/pretty-print.ts
@@ -17,12 +17,12 @@
 import { EOL } from "os"
 import chalk from "chalk"
 
-import { Memoizer } from "../../memoization"
-import { ChoiceState } from "../../choices"
-import { compile, order } from "../../graph"
-import { CodeBlockProps } from "../../codeblock"
-import { AnsiUI, Treeifier, UITree } from "../tree"
-import { MadWizardOptions } from "../MadWizardOptions"
+import { Memoizer } from "../../memoization/index.js"
+import { ChoiceState } from "../../choices/index.js"
+import { compile, order } from "../../graph/index.js"
+import { CodeBlockProps } from "../../codeblock/index.js"
+import { AnsiUI, Treeifier, UITree } from "../tree/index.js"
+import { MadWizardOptions } from "../MadWizardOptions.js"
 
 const Symbols = {
   ansi: {

--- a/src/fe/tree/ui.ts
+++ b/src/fe/tree/ui.ts
@@ -18,7 +18,7 @@ import terminalLink from "terminal-link"
 import { highlight } from "cli-highlight"
 import chalk, { Modifiers, Color } from "chalk"
 
-import { Status } from "../../graph"
+import { Status } from "../../graph/index.js"
 
 export type Decoration = Modifiers | Color
 

--- a/src/fe/tree/xform.ts
+++ b/src/fe/tree/xform.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { UITree } from "./props"
-import { isChoice, isSubTask, isTitledSteps } from "../../graph"
+import { UITree } from "./props.js"
+import { isChoice, isSubTask, isTitledSteps } from "../../graph/index.js"
 
 export default class TreeTransformer<Content> {
   /**

--- a/src/graph/choice-frontier.ts
+++ b/src/graph/choice-frontier.ts
@@ -27,7 +27,7 @@ import {
   isSubTask,
   isTitledSteps,
   withTitle,
-} from "."
+} from "./index.js"
 
 /** Choose `A` if it has a title, else `B` */
 function titlest(A: Graph, B?: EnTitled) {

--- a/src/graph/collapseMadeChoices.ts
+++ b/src/graph/collapseMadeChoices.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ChoiceState, updateContent } from "../choices"
+import { ChoiceState, updateContent } from "../choices/index.js"
 import {
   Graph,
   emptySequence,
@@ -27,7 +27,7 @@ import {
   isTitledSteps,
   sequence,
   subtask,
-} from "."
+} from "./index.js"
 
 function collapse(graph: Graph, choices: ChoiceState): Graph {
   if (isChoice(graph)) {

--- a/src/graph/collapseValidated.ts
+++ b/src/graph/collapseValidated.ts
@@ -17,8 +17,8 @@
 import chalk from "chalk"
 import Debug from "debug"
 
-import { hasProvenance } from "./provenance"
-import { oraPromise } from "../util/ora-delayed-promise"
+import { hasProvenance } from "./provenance.js"
+import { oraPromise } from "../util/ora-delayed-promise.js"
 
 import {
   CompileOptions,
@@ -34,7 +34,7 @@ import {
   isTitledSteps,
   isSubTask,
   isValidatable,
-} from "."
+} from "./index.js"
 
 /**
  * Execute the `validate` property of the steps in the given `wizard`,

--- a/src/graph/compile.ts
+++ b/src/graph/compile.ts
@@ -15,9 +15,9 @@
  */
 
 import Debug from "debug"
-import { CodeBlockProps } from "../codeblock"
-import { ChoiceState, expand } from "../choices"
-import { ExecutorOptions } from "../exec/Executor"
+import { CodeBlockProps } from "../codeblock/index.js"
+import { ChoiceState, expand } from "../choices/index.js"
+import { ExecutorOptions } from "../exec/Executor.js"
 import {
   Choice,
   Graph,
@@ -30,10 +30,10 @@ import {
   seq,
   sequence,
   subtask,
-} from "."
+} from "./index.js"
 
-import { Memos } from "../memoization"
-import { ValidateOptions } from "./validate"
+import { Memos } from "../memoization/index.js"
+import { ValidateOptions } from "./validate.js"
 
 import {
   Import as CodeBlockImport,
@@ -42,10 +42,10 @@ import {
   isChoice as isCodeBlockChoice,
   isImport as isCodeBlockImport,
   isWizardStep as isCodeBlockWizardStep,
-} from "../codeblock/CodeBlockProps"
+} from "../codeblock/CodeBlockProps.js"
 
-import optimize from "./optimize"
-import provenanceOf from "./provenance"
+import optimize from "./optimize.js"
+import provenanceOf from "./provenance.js"
 
 type ChoiceNesting = { parent: CodeBlockChoice; graph: Choice }
 type SubTaskNesting = { parent: CodeBlockImport; graph: SubTask }

--- a/src/graph/deadCodeElimination.ts
+++ b/src/graph/deadCodeElimination.ts
@@ -14,7 +14,17 @@
  * limitations under the License.
  */
 
-import { Graph, Ordered, Unordered, emptySequence, isSequence, isParallel, isSubTask, isTitledSteps, isChoice } from "."
+import {
+  Graph,
+  Ordered,
+  Unordered,
+  emptySequence,
+  isSequence,
+  isParallel,
+  isSubTask,
+  isTitledSteps,
+  isChoice,
+} from "./index.js"
 
 /** Remove any subgraphs that contain no code blocks */
 function dce<T extends Unordered | Ordered, G extends Graph<T>>(graph: G): G {

--- a/src/graph/hoistSubTasks.ts
+++ b/src/graph/hoistSubTasks.ts
@@ -35,10 +35,10 @@ import {
   parallel,
   sequence,
   subtask,
-} from "."
-import { Source } from "../codeblock"
+} from "./index.js"
+import { Source } from "../codeblock/index.js"
 
-import { findChoicesOnFrontier as findChoiceFrontier } from "./choice-frontier"
+import { findChoicesOnFrontier as findChoiceFrontier } from "./choice-frontier.js"
 
 type LookupTable = Record<SubTask["key"], SubTask>
 

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -28,8 +28,8 @@
 import { v4 } from "uuid"
 import { basename } from "path"
 
-import { ChoiceState } from "../choices"
-import { Provenance } from "./provenance"
+import { ChoiceState } from "../choices/index.js"
+import { Provenance } from "./provenance.js"
 import {
   Barrier,
   Validatable,
@@ -38,17 +38,17 @@ import {
   Title,
   Description,
   FormElement,
-} from "../codeblock/CodeBlockProps"
+} from "../codeblock/CodeBlockProps.js"
 
-export * from "./order"
-export * from "./vetoes"
-export * from "./Status"
-export * from "./compile"
-export * from "./optional"
-export * from "./progress"
-export * from "./validate"
-export * from "./linearize"
-export * from "./choice-frontier"
+export * from "./order.js"
+export * from "./vetoes.js"
+export * from "./Status.js"
+export * from "./compile.js"
+export * from "./optional.js"
+export * from "./progress.js"
+export * from "./validate.js"
+export * from "./linearize.js"
+export * from "./choice-frontier.js"
 
 type Key = {
   key: string

--- a/src/graph/linearize.ts
+++ b/src/graph/linearize.ts
@@ -25,10 +25,20 @@
  *
  */
 
-import { Ordered, Unordered, Graph, choose, isSequence, isParallel, isSubTask, isTitledSteps, isChoice } from "."
+import {
+  Ordered,
+  Unordered,
+  Graph,
+  choose,
+  isSequence,
+  isParallel,
+  isSubTask,
+  isTitledSteps,
+  isChoice,
+} from "./index.js"
 
-import { ChoiceState } from "../choices"
-import { CodeBlockProps } from "../codeblock"
+import { ChoiceState } from "../choices/index.js"
+import { CodeBlockProps } from "../codeblock/index.js"
 
 export function nodes<T extends Unordered | Ordered, F extends Graph<T>>(
   graph: Graph<T>,

--- a/src/graph/optimize.ts
+++ b/src/graph/optimize.ts
@@ -16,14 +16,14 @@
 
 import Debug from "debug"
 
-import { ChoiceState } from "../choices"
-import { CompileOptions, Graph, sequence } from "."
+import { ChoiceState } from "../choices/index.js"
+import { CompileOptions, Graph, sequence } from "./index.js"
 
-import hoistSubTasks from "./hoistSubTasks"
-import propagateTitles from "./propagateTitles"
-import collapseValidated from "./collapseValidated"
-import collapseMadeChoices from "./collapseMadeChoices"
-import deadCodeElimination from "./deadCodeElimination"
+import hoistSubTasks from "./hoistSubTasks.js"
+import propagateTitles from "./propagateTitles.js"
+import collapseValidated from "./collapseValidated.js"
+import collapseMadeChoices from "./collapseMadeChoices.js"
+import deadCodeElimination from "./deadCodeElimination.js"
 
 export default async function optimize(graph: Graph, choices: ChoiceState, options?: CompileOptions) {
   const debug = Debug("madwizard/timing/graph:optimize")

--- a/src/graph/optional.ts
+++ b/src/graph/optional.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Graph, isChoice, isSequence, isParallel, isSubTask, isTitledSteps } from "."
+import { Graph, isChoice, isSequence, isParallel, isSubTask, isTitledSteps } from "./index.js"
 
 export function isOptional(graph: Graph) {
   if (isSequence(graph)) {

--- a/src/graph/order.ts
+++ b/src/graph/order.ts
@@ -33,9 +33,9 @@ import {
   isSequence,
   isParallel,
   isTitledSteps,
-} from "."
+} from "./index.js"
 
-import { CodeBlockProps } from "../codeblock"
+import { CodeBlockProps } from "../codeblock/index.js"
 
 function orderSequence(graph: Sequence = emptySequence(), ordinal = 0): Sequence<Ordered> {
   const { postorder, sequence } = graph.sequence.reduce(

--- a/src/graph/progress.ts
+++ b/src/graph/progress.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { ChoiceState } from "../choices"
-import { CodeBlockProps } from "../codeblock"
+import { ChoiceState } from "../choices/index.js"
+import { CodeBlockProps } from "../codeblock/index.js"
 import {
   Status,
   StatusMap,
@@ -27,7 +27,7 @@ import {
   isSequence,
   isParallel,
   isTitledSteps,
-} from "."
+} from "./index.js"
 
 type Progress = { nDone: number; nError: number; nTotal: number; nextOrdinals: number[] }
 

--- a/src/graph/propagateTitles.ts
+++ b/src/graph/propagateTitles.ts
@@ -15,7 +15,7 @@
  */
 
 import { basename } from "path"
-import { Graph, isSubTask, isChoice, isSequence, isParallel, isTitledSteps } from "."
+import { Graph, isSubTask, isChoice, isSequence, isParallel, isTitledSteps } from "./index.js"
 
 /**
  * Attempt to propagate "meaning" to less areas without prior meaning,

--- a/src/graph/validate.ts
+++ b/src/graph/validate.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { Memos } from "../memoization"
-import { Validatable } from "../codeblock"
-import { ExecOptions } from "../exec"
-import { Status, Graph, isSequence, isParallel, isChoice, isTitledSteps, isSubTask, isValidatable } from "."
+import { Memos } from "../memoization/index.js"
+import { Validatable } from "../codeblock/index.js"
+import { ExecOptions } from "../exec/index.js"
+import { Status, Graph, isSequence, isParallel, isChoice, isTitledSteps, isSubTask, isValidatable } from "./index.js"
 
 export type ValidationExecutor = (cmdline: string, opts?: ExecOptions) => "success" | Promise<"success">
 
@@ -69,7 +69,7 @@ export async function doValidate(
   }
 
   try {
-    await (opts.validator || (await import("../exec").then((_) => _.shellExec)))(validate, {
+    await (opts.validator || (await import("../exec/index.js").then((_) => _.shellExec)))(validate, {
       quiet: true,
       env: opts.env,
       dependencies: opts.dependencies,

--- a/src/graph/vetoes.ts
+++ b/src/graph/vetoes.ts
@@ -17,11 +17,11 @@
 import { EOL } from "os"
 import chalk from "chalk"
 
-import { MadWizardOptions } from ".."
-import { ChoiceState } from "../choices"
-import { CodeBlockProps } from "../codeblock"
-import { Provenance, hasProvenance } from "./provenance"
-import { CompileOptions, Graph, compile, nodes } from "."
+import { MadWizardOptions } from "../fe/index.js"
+import { ChoiceState } from "../choices/index.js"
+import { CodeBlockProps } from "../codeblock/index.js"
+import { Provenance, hasProvenance } from "./provenance.js"
+import { CompileOptions, Graph, compile, nodes } from "./index.js"
 
 /**
  * List the veto-able provenances. This can be used to help fill in

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,25 +15,25 @@
  */
 
 // CLI
-export * as CLI from "./fe/cli"
+export * as CLI from "./fe/cli/index.js"
 
 // UI support
-export * as Tree from "./fe/tree"
+export * as Tree from "./fe/tree/index.js"
 
 // APIs
-export * as Graph from "./graph"
-export * as Parser from "./parser"
-export * as Choices from "./choices"
-export * as Wizard from "./wizard"
-export * as CodeBlock from "./codeblock"
+export * as Graph from "./graph/index.js"
+export * as Parser from "./parser/index.js"
+export * as Choices from "./choices/index.js"
+export * as Wizard from "./wizard/index.js"
+export * as CodeBlock from "./codeblock/index.js"
 
 // Options
-export * from "./fe"
+export * from "./fe/index.js"
 
 // Version
-export * from "./version"
+export * from "./version.js"
 
 // Reader
 export async function reader() {
-  return import("./fe/cli/madwizardRead").then((_) => _.madwizardRead)
+  return import("./fe/cli/madwizardRead.js").then((_) => _.madwizardRead)
 }

--- a/src/memoization/index.ts
+++ b/src/memoization/index.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { ChoiceState } from "../choices"
-import { ExpansionMap } from "../choices/groups/expansion"
-import { Graph, Status, StatusMap, isLeafNode, isChoice, partsOf } from "../graph"
+import { ChoiceState } from "../choices/index.js"
+import { ExpansionMap } from "../choices/groups/expansion.js"
+import { Graph, Status, StatusMap, isLeafNode, isChoice, partsOf } from "../graph/index.js"
 
 /** Optimize certain expensive or non-idempotent operations */
 export interface Memos {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -17,11 +17,11 @@
 import { VFileCompatible } from "vfile"
 import { extname as pathExtname } from "path"
 
-import { ChoiceState } from "../choices"
-import { MadWizardOptions } from "../fe"
-import { Reader } from "./markdown/fetch"
+import { ChoiceState } from "../choices/index.js"
+import { MadWizardOptions } from "../fe/index.js"
+import { Reader } from "./markdown/fetch.js"
 
-export * from "./markdown"
+export * from "./markdown/index.js"
 
 /** @return the file extension for the given `input` */
 function extname(input: VFileCompatible) {
@@ -46,7 +46,7 @@ export async function parse(
 ) {
   const ext = extname(input)
   if (ext === ".md" || !ext) {
-    return await import("./markdown").then((_) => _.blockify(input, reader, choices, uuid, madwizardOptions))
+    return await import("./markdown/index.js").then((_) => _.blockify(input, reader, choices, uuid, madwizardOptions))
   } else {
     throw new Error(`Unsupported file type: ${String(input)}`)
   }

--- a/src/parser/markdown/frontmatter/index.ts
+++ b/src/parser/markdown/frontmatter/index.ts
@@ -21,12 +21,12 @@ import { u } from "unist-builder"
 import { visit } from "unist-util-visit"
 import { visitParents } from "unist-util-visit-parents"
 
-import { isLiteral, isText } from "../util/isElement"
-import { isOnAnImportChain, visitImportContainers } from "../remark-import"
-import KuiFrontmatter, { hasWizardSteps, isNormalSplit, isValidPosition, isValidPositionObj } from "./KuiFrontmatter"
-import { preprocessCodeBlocksInContent, preprocessCodeBlocksInImports } from "../remark-codeblocks-topmatter"
+import { isLiteral, isText } from "../util/isElement.js"
+import { isOnAnImportChain, visitImportContainers } from "../remark-import.js"
+import KuiFrontmatter, { hasWizardSteps, isNormalSplit, isValidPosition, isValidPositionObj } from "./KuiFrontmatter.js"
+import { preprocessCodeBlocksInContent, preprocessCodeBlocksInImports } from "../remark-codeblocks-topmatter.js"
 
-export { tryFrontmatter } from "./frontmatter-parser"
+export { tryFrontmatter } from "./frontmatter-parser.js"
 
 export function splitTarget(node) {
   if (node.type === "raw") {

--- a/src/parser/markdown/hack.ts
+++ b/src/parser/markdown/hack.ts
@@ -15,13 +15,13 @@
  */
 
 // ==foo== -> <mark>foo</mark>
-import hackMarks from "./remark-mark"
+import hackMarks from "./remark-mark.js"
 
 // ++ctrl+alt+delete++== -> <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>delete</kbd>
-import hackKeys from "./remark-keys"
+import hackKeys from "./remark-keys.js"
 
 // support pymdown's indentation-based tab and tip blocking
-import hackIndentation from "./rehype-tabbed/hack"
+import hackIndentation from "./rehype-tabbed/hack.js"
 
 export function hackMarkdownSource(source: string) {
   return hackKeys(hackMarks(hackIndentation(source)))

--- a/src/parser/markdown/index.ts
+++ b/src/parser/markdown/index.ts
@@ -23,44 +23,44 @@ import remarkParse from "remark-parse"
 import remarkRehype from "remark-rehype"
 import { unified, PluggableList } from "unified"
 
-import { MadWizardOptions } from "../../"
-import { Reader, fetcherFor } from "./fetch"
+import { MadWizardOptions } from "../../fe/index.js"
+import { Reader, fetcherFor } from "./fetch.js"
 
-import { CodeBlockProps } from "../../codeblock"
-import { ChoiceState, newChoiceState } from "../../choices"
+import { CodeBlockProps } from "../../codeblock/index.js"
+import { ChoiceState, newChoiceState } from "../../choices/index.js"
 
-import { hackMarkdownSource } from "./hack"
+import { hackMarkdownSource } from "./hack.js"
 
 // parses out ::import{filepath} as node.type === 'leafDirective', but
 // does not create any DOM elements
 import remarkDirective from "remark-directive"
 
-import inlineSnippets from "./snippets"
-import { toRawGithubUserContent } from "./snippets/urls"
+import inlineSnippets from "./snippets/index.js"
+import { toRawGithubUserContent } from "./snippets/urls.js"
 
 import frontmatter from "remark-frontmatter"
 
-import { rehypeTip } from "./rehype-tip"
-import { rehypeTabbed } from "./rehype-tabbed"
+import { rehypeTip } from "./rehype-tip/index.js"
+import { rehypeTabbed } from "./rehype-tabbed/index.js"
 
-import { rehypeWizard } from "./rehype-wizard"
-import rehypeImports, { remarkImports } from "./remark-import"
+import { rehypeWizard } from "./rehype-wizard.js"
+import rehypeImports, { remarkImports } from "./remark-import.js"
 
-import { rehypeCodeIndexer } from "./rehype-code-indexer"
+import { rehypeCodeIndexer } from "./rehype-code-indexer/index.js"
 
 // react-markdown v6+ now require use of these to support html
 // import rehypeRaw from "rehype-raw"
 // import rehypeSlug from "rehype-slug"
 
 // import icons from "./rehype-icons"
-import { kuiFrontmatter } from "./frontmatter"
+import { kuiFrontmatter } from "./frontmatter/index.js"
 
-export * from "./hack"
-export * from "./fetch"
-export * from "./rehype-tip"
-export * from "./rehype-tabbed"
-export * from "./rehype-wizard"
-export * from "./rehype-code-indexer"
+export * from "./hack.js"
+export * from "./fetch.js"
+export * from "./rehype-tip/index.js"
+export * from "./rehype-tabbed/index.js"
+export * from "./rehype-wizard.js"
+export * from "./rehype-code-indexer/index.js"
 
 const remarkPlugins = (): PluggableList => [
   remarkDirective,

--- a/src/parser/markdown/rehype-code-indexer/index.ts
+++ b/src/parser/markdown/rehype-code-indexer/index.ts
@@ -22,19 +22,19 @@ import { Transformer } from "unified"
 import { toString } from "hast-util-to-string"
 import { visitParents } from "unist-util-visit-parents"
 
-import { provenanceOfFilepath } from "../../../graph/provenance"
+import { provenanceOfFilepath } from "../../../graph/provenance.js"
 
-import dump from "./dump"
-import { isTab } from "../rehype-tabbed"
-import { isExecutable } from "../../../codeblock/isCodeBlock"
-import { getTipTitle, isTipWithFullTitle } from "../rehype-tip"
+import dump from "./dump.js"
+import { isTab } from "../rehype-tabbed/index.js"
+import { isExecutable } from "../../../codeblock/isCodeBlock.js"
+import { getTipTitle, isTipWithFullTitle } from "../rehype-tip/index.js"
 import isElementWithProperties, {
   hasContentChildren,
   isParagraph,
   isText,
   isNonEmptyTextOrParagraph,
-} from "../util/isElement"
-import { toMarkdownString, Node } from "../util/toMarkdownString"
+} from "../util/isElement.js"
+import { toMarkdownString, Node } from "../util/toMarkdownString.js"
 
 import {
   isHeading,
@@ -46,9 +46,9 @@ import {
   getTitle,
   getDescription,
   getHeadingLevel,
-} from "../rehype-wizard"
+} from "../rehype-wizard.js"
 
-import { tryFrontmatter } from "../frontmatter"
+import { tryFrontmatter } from "../frontmatter/index.js"
 import {
   isBarrier,
   isOnAnImportChain,
@@ -57,8 +57,8 @@ import {
   getImportFilepath,
   getImportTitle,
   getValidate,
-} from "../remark-import"
-import { CodeBlockProps, addNesting as addCodeBlockNesting, Choice } from "../../../codeblock/CodeBlockProps"
+} from "../remark-import.js"
+import { CodeBlockProps, addNesting as addCodeBlockNesting, Choice } from "../../../codeblock/CodeBlockProps.js"
 
 /**
  * Heuristic: Code Blocks inside of closed "tips" (i.e. default-closed

--- a/src/parser/markdown/rehype-tabbed/hack.ts
+++ b/src/parser/markdown/rehype-tabbed/hack.ts
@@ -16,9 +16,9 @@
 
 import Debug from "debug"
 
-import { isExecutable } from "../../../codeblock"
-import { START_OF_TIP, END_OF_TIP } from "../rehype-tip"
-import { START_OF_TAB, END_OF_TAB, PUSH_TABS } from "."
+import { isExecutable } from "../../../codeblock/index.js"
+import { START_OF_TIP, END_OF_TIP } from "../rehype-tip/index.js"
+import { START_OF_TAB, END_OF_TAB, PUSH_TABS } from "./index.js"
 
 /** A placeholder marker to indicate markdown that uses indentation not to mean Tab or Tip content */
 const FAKE_END_MARKER = ""

--- a/src/parser/markdown/rehype-tabbed/index.ts
+++ b/src/parser/markdown/rehype-tabbed/index.ts
@@ -18,13 +18,13 @@ import Debug from "debug"
 import { Transformer } from "unified"
 import { Element, ElementContent, Properties } from "hast"
 
-import { ChoiceState } from "../../../choices"
-import { MadWizardOptions } from "../../../fe"
-import isElementWithProperties from "../util/isElement"
-import { identifyRecognizableTabGroups } from "../../../choices/groups"
-import { AllowedFormElement, FormElementType } from "../../../codeblock"
+import { ChoiceState } from "../../../choices/index.js"
+import { MadWizardOptions } from "../../../fe/index.js"
+import isElementWithProperties from "../util/isElement.js"
+import { identifyRecognizableTabGroups } from "../../../choices/groups/index.js"
+import { AllowedFormElement, FormElementType } from "../../../codeblock/index.js"
 
-import populateTabs from "./populate"
+import populateTabs from "./populate.js"
 
 export const START_OF_TAB = `<!-- ____KUI_START_OF_TAB____ -->`
 export const PUSH_TABS = `<!-- ____KUI_NESTED_TABS____ -->`

--- a/src/parser/markdown/rehype-tabbed/populate.ts
+++ b/src/parser/markdown/rehype-tabbed/populate.ts
@@ -16,15 +16,15 @@
 
 import { Node } from "hast"
 
-import withFormProperties from "./form"
-import { getTabTitle, Tab } from "."
-import { isParent } from "../util/isElement"
-import { isImports } from "../remark-import"
+import withFormProperties from "./form.js"
+import { getTabTitle, Tab } from "./index.js"
+import { isParent } from "../util/isElement.js"
+import { isImports } from "../remark-import.js"
 
 // const RE_TAB = /^(.|[\n\r])*===\s+"(.+)"\s*(\n(.|[\n\r])*)?$/
 const RE_TAB = /^===\s+"(.+)/
 
-import { START_OF_TAB, END_OF_TAB, PUSH_TABS } from "."
+import { START_OF_TAB, END_OF_TAB, PUSH_TABS } from "./index.js"
 
 export default function populateTabs(uuid: string, tree: Node): { tree: Node; tabgroupIdx: number } {
   let tabgroupIdx = -1

--- a/src/parser/markdown/rehype-tip/index.ts
+++ b/src/parser/markdown/rehype-tip/index.ts
@@ -17,7 +17,7 @@
 import Debug from "debug"
 import { Node, Element } from "hast"
 
-import isElementWithProperties from "../util/isElement"
+import isElementWithProperties from "../util/isElement.js"
 
 const RE_TIP =
   /^([?!][?!][?!])(\+?)\s+(tip|todo|bug|info|note|warning|caution|success|question)(\s+"(.+)"\s*)?(\s+inline)?(\s+inline\s+end)?(\n(.|[\n\r])*)?$/i

--- a/src/parser/markdown/rehype-wizard.ts
+++ b/src/parser/markdown/rehype-wizard.ts
@@ -21,10 +21,10 @@ import { visit } from "unist-util-visit"
 import { Content, Element, Parent, Root } from "hast"
 import { visitParents, SKIP } from "unist-util-visit-parents"
 
-import isElementWithProperties from "./util/isElement"
-import { WizardSteps, PositionProps } from "./frontmatter/KuiFrontmatter"
-import { GroupMember as CodeBlockGroupMember } from "../../codeblock/CodeBlockProps"
-import { isImports, visitImportContainers } from "./remark-import"
+import isElementWithProperties from "./util/isElement.js"
+import { WizardSteps, PositionProps } from "./frontmatter/KuiFrontmatter.js"
+import { GroupMember as CodeBlockGroupMember } from "../../codeblock/CodeBlockProps.js"
+import { isImports, visitImportContainers } from "./remark-import.js"
 
 type Primordial = Pick<CodeBlockGroupMember, "group"> & {
   title: string

--- a/src/parser/markdown/remark-codeblocks-topmatter.ts
+++ b/src/parser/markdown/remark-codeblocks-topmatter.ts
@@ -19,10 +19,10 @@ import { Node } from "hast"
 import { Code } from "mdast"
 import { visitParents } from "unist-util-visit-parents"
 
-import dump from "./rehype-code-indexer/dump"
-import { tryFrontmatter } from "./frontmatter"
-import { isOnAnImportChain, visitImportContainers } from "./remark-import"
-import KuiFrontmatter, { hasCodeBlocks } from "./frontmatter/KuiFrontmatter"
+import dump from "./rehype-code-indexer/dump.js"
+import { tryFrontmatter } from "./frontmatter/index.js"
+import { isOnAnImportChain, visitImportContainers } from "./remark-import.js"
+import KuiFrontmatter, { hasCodeBlocks } from "./frontmatter/KuiFrontmatter.js"
 
 function isCode(node: Node): node is Code {
   return node.type === "code" && typeof (node as Code).value === "string"

--- a/src/parser/markdown/snippets/index.ts
+++ b/src/parser/markdown/snippets/index.ts
@@ -21,13 +21,13 @@ import { mainSymbols } from "figures"
 import expandHomeDir from "expand-home-dir"
 import { isAbsolute as pathIsAbsolute, dirname as pathDirname, join as pathJoin } from "path"
 
-import { isUrl, toRawGithubUserContent } from "./urls"
-import { oraPromise } from "../../../util/ora-delayed-promise"
+import { isUrl, toRawGithubUserContent } from "./urls.js"
+import { oraPromise } from "../../../util/ora-delayed-promise.js"
 
-import indent from "../util/indent"
-import { MadWizardOptions } from "../../.."
-import { hasImports } from "../frontmatter/KuiFrontmatter"
-import { tryFrontmatter } from "../frontmatter/frontmatter-parser"
+import indent from "../util/indent.js"
+import { MadWizardOptions } from "../../../fe/index.js"
+import { hasImports } from "../frontmatter/KuiFrontmatter.js"
+import { tryFrontmatter } from "../frontmatter/frontmatter-parser.js"
 
 const RE_DOCS_URL = /^(https:\/\/([^/]+\/){4}docs)/
 

--- a/src/parser/markdown/snippets/inliner.ts
+++ b/src/parser/markdown/snippets/inliner.ts
@@ -17,9 +17,9 @@
 import { writeFile } from "fs"
 import { dirname, join } from "path"
 
-import inlineSnippets from "."
-import { fetcherFor } from "../fetch"
-import { madwizardRead } from "../../../fe/cli/madwizardRead"
+import inlineSnippets from "./index.js"
+import { fetcherFor } from "../fetch.js"
+import { madwizardRead } from "../../../fe/cli/madwizardRead.js"
 
 /**
  * Fetch and inline all content in the given

--- a/src/parser/markdown/snippets/mirror.ts
+++ b/src/parser/markdown/snippets/mirror.ts
@@ -18,7 +18,7 @@ import { join } from "path"
 import { readdir } from "fs"
 import { oraPromise } from "ora"
 
-import { inliner } from "./inliner"
+import { inliner } from "./inliner.js"
 
 export async function mirror(srcDir: string, targetDir: string, srcRelPath = "") {
   // Debug.enable("madwizard/fetch/snippets")

--- a/src/parser/markdown/util/toMarkdownString.ts
+++ b/src/parser/markdown/util/toMarkdownString.ts
@@ -21,11 +21,11 @@ import { Content, Element, Parent } from "hast"
 import { visit, CONTINUE, SKIP } from "unist-util-visit"
 import { toMarkdown } from "mdast-util-to-markdown"
 
-import { isTip } from "../rehype-tip"
-import { isImports } from "../remark-import"
-import indent, { indentAll } from "./indent"
-import isElementWithProperties from "./isElement"
-import { isTabs, isTabWithProperties, getTabTitle, getTabsDepth } from "../rehype-tabbed"
+import { isTip } from "../rehype-tip/index.js"
+import { isImports } from "../remark-import.js"
+import indent, { indentAll } from "./indent.js"
+import isElementWithProperties from "./isElement.js"
+import { isTabs, isTabWithProperties, getTabTitle, getTabsDepth } from "../rehype-tabbed/index.js"
 
 type Node = Parameters<typeof toMdast>[0]
 export { Node }

--- a/src/wizard/index.ts
+++ b/src/wizard/index.ts
@@ -16,10 +16,10 @@
 
 import Debug from "debug"
 
-import { Choices, ChoiceState } from "../choices"
-import { Memos, statusOf } from "../memoization"
-import { Barrier, FormElement } from "../codeblock"
-import { toMarkdownString } from "../parser/markdown/util/toMarkdownString"
+import { Choices, ChoiceState } from "../choices/index.js"
+import { Memos, statusOf } from "../memoization/index.js"
+import { Barrier, FormElement } from "../codeblock/index.js"
+import { toMarkdownString } from "../parser/markdown/util/toMarkdownString.js"
 
 import {
   Graph,
@@ -33,7 +33,7 @@ import {
   isLeafNode,
   isBarrier,
   findChoiceFrontier,
-} from "../graph"
+} from "../graph/index.js"
 
 type Markdown = string | (() => string)
 

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -24,7 +24,7 @@ import { diffString } from "json-diff"
 import { createRequire } from "module"
 import { readdirSync, readFileSync } from "fs"
 
-import { CLI, MadWizardOptions } from "../.."
+import { CLI, MadWizardOptions } from "../../dist/index.js"
 
 const require = createRequire(import.meta.url)
 const inputDir = join(dirname(require.resolve(".")), "../inputs")


### PR DESCRIPTION
sigh, nodejs. this PR switches all imports to use the "fully specified" form of imports, so that we don't need to pass the `--experimental-specifier-resolution=node` node cli option, and also to improve happiness with webpack (which insists on fully specified semantics for esm node modules).