### PR TITLE
fix: avoid use of env -S which seems to confuse npm on windows

### DIFF
--- a/bin/madwizard.js
+++ b/bin/madwizard.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-warnings
+#!/usr/bin/env node
 
 /* eslint-env node */
 /* ^^^ rather than add env: node globally in package.json */


### PR DESCRIPTION
the shim binaries it creates use "-S" as the name of the binary :(