### PR TITLE
feat: when running tasks, be a bit quieter

### DIFF
--- a/src/exec/export.ts
+++ b/src/exec/export.ts
@@ -16,10 +16,14 @@
 
 import { ExecOptions } from "./options.js"
 
+export function isExport(cmdline: string): ReturnType<string["match"]> {
+  return cmdline.match(/^\s*export\s+(.+)="?([^"]+)"?$/)
+}
+
 /** See if we are being asked to execute `export FOO=bar` */
 export default function execAsExport(cmdline: string | boolean, opts: ExecOptions) {
   if (opts.env && typeof cmdline === "string") {
-    const match = cmdline.match(/^\s*export\s+(.+)="?([^"]+)"?$/)
+    const match = isExport(cmdline)
     if (match) {
       const [, key, value] = match
       const valueForUpdate = value.replace(/\${?([^:]+)}?/g, (_, p1) => opts.env[p1] || process.env[p1])

--- a/src/exec/index.ts
+++ b/src/exec/index.ts
@@ -21,11 +21,11 @@ import shell from "./shell.js"
 import which from "./which.js"
 import custom from "./custom.js"
 import python from "./python.js"
-import exporter from "./export.js"
 import pipShow from "./pip-show.js"
 import raySubmit from "./ray-submit.js"
+import exporter, { isExport } from "./export.js"
 
-export { Env, ExecOptions }
+export { Env, ExecOptions, isExport }
 
 /** Shell out the execution of the given `cmdline` */
 export async function shellExec(

--- a/src/fe/MadWizardOptions.ts
+++ b/src/fe/MadWizardOptions.ts
@@ -19,6 +19,9 @@ import { CompilerOptions } from "../graph/compile"
 interface DisplayOptions {
   /** Shorten output of long or multi-line code blocks. */
   narrow: boolean
+
+  /** Verbose output */
+  verbose: boolean
 }
 
 interface FetchOptions {

--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -64,6 +64,7 @@ export async function cli<Writer extends (msg: string) => boolean>(
   const noOptimize = !!_argv.find((_) => _ === "-O0" || _ === "--optimize=0" || _ === "--no-optimize")
   const noAprioris = !!_argv.find((_) => _ === "--no-aprioris")
   const noValidate = !!_argv.find((_) => _ === "--no-validate")
+  const verbose = !!_argv.find((_) => _ === "--verbose" || _ === "-V")
   const optimize = noOptimize ? false : { aprioris: !noAprioris, validate: !noValidate }
 
   // base uri of guidebook store; this will allow users to type
@@ -84,7 +85,7 @@ export async function cli<Writer extends (msg: string) => boolean>(
           return M
         }, {})
 
-  const commandLineOptions: MadWizardOptions = { veto, mkdocs, narrow, optimize, store }
+  const commandLineOptions: MadWizardOptions = { veto, mkdocs, narrow, optimize, store, verbose }
   const options: MadWizardOptions = Object.assign(commandLineOptions, providedOptions)
 
   if (!task || !input) {

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -104,18 +104,22 @@ function tryParseInt(str: string): number {
 
 /** Read the cli.txt file, treated as extra command line args */
 function getCLIOptions(input: string) {
+  const baseOptions = ["--verbose"]
+
   try {
     const asserts = readFileSync(join(input, "assert.txt")).toString()
     if (asserts.length > 0) {
-      return asserts
-        .split(/\n/)
-        .filter(Boolean)
-        .map((_) => `--assert=${_}`)
+      return baseOptions.concat(
+        asserts
+          .split(/\n/)
+          .filter(Boolean)
+          .map((_) => `--assert=${_}`)
+      )
     }
   } catch (err) {
     // fall-through
   }
-  return []
+  return baseOptions
 }
 
 /** "madwizard plan" */


### PR DESCRIPTION
With this PR, the task runner won't emit anything for `export FOO=bar` and `echo xxx`, unless you specify `--verbose` or `-V` on the command line.