### PR TITLE
fix: avoid remark-marks and remark-keys

### DIFF
--- a/src/parser/markdown/hack.ts
+++ b/src/parser/markdown/hack.ts
@@ -15,16 +15,17 @@
  */
 
 // ==foo== -> <mark>foo</mark>
-import hackMarks from "./remark-mark.js"
+// import hackMarks from "./remark-mark.js"
 
 // ++ctrl+alt+delete++== -> <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>delete</kbd>
-import hackKeys from "./remark-keys.js"
+// import hackKeys from "./remark-keys.js"
 
 // support pymdown's indentation-based tab and tip blocking
 import hackIndentation from "./rehype-tabbed/hack.js"
 
 export function hackMarkdownSource(source: string) {
-  return hackKeys(hackMarks(hackIndentation(source)))
+  // return hackKeys(hackMarks(hackIndentation(source)))
+  return hackIndentation(source)
     .trim()
     .replace(/\){target=[^}]+}/g, ")")
     .replace(/{draggable=(false|true)}/g, "")


### PR DESCRIPTION
i don't think we need these for guidebooks. these are more of a UI rendering thing.

In any case, we can't blindly apply remark-marks as it does now. It is completely context insensitive. As a result, it can turn `==` in e.g. python code blocks into `<mark/>`