### PR TITLE
fix: graph optimizer should not prematurely validate beyond the first choice

### DIFF
--- a/test/inputs/3/tree-noaprioris.txt
+++ b/test/inputs/3/tree-noaprioris.txt
@@ -1,11 +1,16 @@
-Prerequisites
-├── EEE
-│   └── Option 1: TabE1
-│       └── echo EEE
-└── DDD
-    ├── Option 1: SubTab1
-    │   ├── echo AAA †
-    │   ├── echo AAA †
-    │   └── echo AAA †
-    └── Option 2: SubTab2
-        └── echo BBB
+AAA
+├── Prerequisites
+│   ├── EEE
+│   │   └── Option 1: TabE1
+│   │       └── echo EEE
+│   └── DDD
+│       ├── Option 1: SubTab1
+│       │   ├── echo AAA †
+│       │   ├── echo AAA †
+│       │   └── echo AAA †
+│       └── Option 2: SubTab2
+│           └── echo BBB
+└── Main Tasks
+    └── Option 2: Tab2
+        └── importc.md
+            └── echo CCC †

--- a/test/inputs/3/tree.txt
+++ b/test/inputs/3/tree.txt
@@ -1,11 +1,16 @@
-Prerequisites
-├── EEE
-│   └── Option 1: TabE1
-│       └── echo EEE
-└── DDD
-    ├── Option 1: SubTab1
-    │   ├── echo AAA †
-    │   ├── echo AAA †
-    │   └── echo AAA †
-    └── Option 2: SubTab2
-        └── echo BBB
+AAA
+├── Prerequisites
+│   ├── EEE
+│   │   └── Option 1: TabE1
+│   │       └── echo EEE
+│   └── DDD
+│       ├── Option 1: SubTab1
+│       │   ├── echo AAA †
+│       │   ├── echo AAA †
+│       │   └── echo AAA †
+│       └── Option 2: SubTab2
+│           └── echo BBB
+└── Main Tasks
+    └── Option 2: Tab2
+        └── importc.md
+            └── echo CCC †

--- a/test/inputs/3/wizard-noaprioris.json
+++ b/test/inputs/3/wizard-noaprioris.json
@@ -106,5 +106,53 @@
         }
       ]
     }
+  },
+  {
+    "graph": {
+      "group": "Tab1####Tab2",
+      "title": "Main Tasks",
+      "source": "placeholder",
+      "provenance": ["test/inputs/snippets/snippets-in-tab3.md"],
+      "choices": [
+        {
+          "member": 1,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "key": "somekey",
+                "title": "importc.md",
+                "filepath": "test/inputs/snippets/importc.md",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "echo CCC",
+                      "language": "bash",
+                      "validate": true,
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
+              }
+            ]
+          },
+          "title": "Tab2"
+        }
+      ]
+    },
+    "step": {
+      "name": "Main Tasks",
+      "description": "This step requires you to choose how to proceed",
+      "content": [
+        {
+          "title": "Tab2",
+          "group": "Tab1####Tab2",
+          "member": 1,
+          "isFirstChoice": false
+        }
+      ]
+    }
   }
 ]

--- a/test/inputs/3/wizard.json
+++ b/test/inputs/3/wizard.json
@@ -106,5 +106,53 @@
         }
       ]
     }
+  },
+  {
+    "graph": {
+      "group": "Tab1####Tab2",
+      "title": "Main Tasks",
+      "source": "placeholder",
+      "provenance": ["test/inputs/snippets/snippets-in-tab3.md"],
+      "choices": [
+        {
+          "member": 1,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "key": "somekey",
+                "title": "importc.md",
+                "filepath": "test/inputs/snippets/importc.md",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "echo CCC",
+                      "language": "bash",
+                      "validate": true,
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
+              }
+            ]
+          },
+          "title": "Tab2"
+        }
+      ]
+    },
+    "step": {
+      "name": "Main Tasks",
+      "description": "This step requires you to choose how to proceed",
+      "content": [
+        {
+          "title": "Tab2",
+          "group": "Tab1####Tab2",
+          "member": 1,
+          "isFirstChoice": false
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
There's no sense in issuing potentially expensive validation tasks after the first choice. 1) may be wasted work; 2) may not even be meaningful, as the choice may alter state in a way that affects the way those contingent validation tasks behave