### PR TITLE
fix: another refinement to collapse validated up to first choice

### DIFF
--- a/src/graph/collapseValidated.ts
+++ b/src/graph/collapseValidated.ts
@@ -134,7 +134,7 @@ export default async function collapseValidated<
           .filter(Boolean),
       })
     }
-  } else if (isSubTask<T>(graph)) {
+  } else if (isSubTask<T>(graph) && !isChoice(graph.graph)) {
     const subgraph = await recurse(graph.graph)
     if (subgraph) {
       return Object.assign({}, graph, { graph: subgraph })


### PR DESCRIPTION
At some point, I think we may need to redo this in a better way... using choice frontier?