### PR TITLE
test: no need to test type checking, now that we ditched parcel

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "watch": "npm run devhack && cross-env concurrently -n CORE,TEST 'tsc --build . --watch' 'cd test && tsc --build . --watch'",
     "build": "npm run devhack && tsc --build .",
     "build:test": "cross-env-shell tsc --project test",
-    "test": "cross-env npm run build:test && cross-env concurrently --raw -n TYPES,TESTS 'tsc --noEmit' 'node --no-warnings test/dist'",
+    "test": "cross-env npm run build:test && cross-env node --no-warnings test/dist/index.js",
     "format": "cross-env prettier --write '**/*.{scss,css,html,js,json,md,ts,tsx}'",
     "format:test:input": "cross-env prettier --write test/inputs",
     "mirror": "T=$(mktemp -d); (cd $T && git clone --depth=1 git@github.com:guidebooks/store.git) && echo \"mirror stage in $T/store\" && ./bin/madwizard.js mirror $T/store/guidebooks ./dist/store",


### PR DESCRIPTION
We had been doing a `tsc --noEmit` in `npm test` because we were using parcel to bundle. Now that we aren't, and are using tsc directly, we don't need to double check things.