### PR TITLE
feat: asynchronous code block execution

### DIFF
--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -1,5 +1,5 @@
 echo -n A
-for i in {1..29}
+for i in {1..30}
 do
     if [ -f ./test/inputs/$i/assert.txt ]; then
         ASSERT="--assert=$(cat ./test/inputs/$i/assert.txt | tr '\n' ' ')"
@@ -16,7 +16,7 @@ done
 echo
 
 echo -n B
-for i in {1..8} {11..18} {20..22} {24..29}
+for i in {1..8} {11..18} {20..22} {24..30}
 do
     if [ -f ./test/inputs/$i/assert.txt ]; then
         ASSERT="--assert=$(cat ./test/inputs/$i/assert.txt)"

--- a/src/codeblock/CodeBlockProps.ts
+++ b/src/codeblock/CodeBlockProps.ts
@@ -152,6 +152,13 @@ export type CodeBlockProps = Partial<CustomExecutable> &
     language: SupportedLanguage
     optional?: boolean
     nesting?: CodeBlockNestingParent[]
+
+    /**
+     * Should this code block be executed asynchronously? If so, its
+     * execution will be forked, and joined before the guidebook
+     * completes.
+     */
+    async?: boolean
   }
 
 export function addNesting(props: CodeBlockProps, nesting: CodeBlockNestingParent, insertIdx?: number) {

--- a/src/exec/index.ts
+++ b/src/exec/index.ts
@@ -32,7 +32,8 @@ export async function shellExec(
   cmdline: string | boolean,
   opts: ExecOptions = { quiet: false },
   language: SupportedLanguage = "shell",
-  exec?: CustomExecutable["exec"]
+  exec?: CustomExecutable["exec"] /* execute code block with custom exec, rather than `sh` */,
+  async?: boolean /* fire and forget, until this process exits? */
 ): Promise<"success"> {
   if (exec) {
     // then the source has provided a custom executor
@@ -44,7 +45,7 @@ export async function shellExec(
       exporter(cmdline, opts) || // export FOO=3
       which(cmdline) || // which foo
       pipShow(cmdline, opts) || // optimized pip show
-      shell(cmdline, opts) // vanilla shell exec
+      shell(cmdline, opts, undefined, async) // vanilla shell exec
     )
   } else if (isPythonic(language)) {
     // then the code block has been declared with a `python` language

--- a/src/exec/options.ts
+++ b/src/exec/options.ts
@@ -20,7 +20,7 @@ import { Memos } from "../memoization/index.js"
 export type Env = Pick<Memos, "env">
 
 export type ExecOptions = Partial<Env> &
-  Partial<Pick<Memos, "dependencies" | "invalidate">> & {
+  Partial<Pick<Memos, "dependencies" | "invalidate" | "subprocesses">> & {
     /** Do not emit to console */
     quiet?: boolean
 

--- a/src/exec/shell.ts
+++ b/src/exec/shell.ts
@@ -21,7 +21,8 @@ import { ExecOptions } from "./options.js"
 export default async function shellItOut(
   cmdline: string | boolean,
   opts: ExecOptions = { quiet: false },
-  extraEnv: Record<string, string> = {}
+  extraEnv: Record<string, string> = {},
+  async?: boolean /* fire and forget, until this process exits? */
 ): Promise<"success"> {
   const capture = typeof opts.capture === "string"
 
@@ -73,6 +74,11 @@ export default async function shellItOut(
     if (capture) {
       child.stderr.on("data", (data) => (out += data.toString()))
       child.stdout.on("data", (data) => (out += data.toString()))
+    }
+
+    if (async) {
+      opts.subprocesses.push(child)
+      resolve("success")
     }
   })
 }

--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -30,7 +30,7 @@ import { ChoiceState } from "../../choices/index.js"
 import { CodeBlockProps } from "../../codeblock/index.js"
 import { shellExec, isExport } from "../../exec/index.js"
 import indent from "../../parser/markdown/util/indent.js"
-import { Memos, Memoizer, statusOf } from "../../memoization/index.js"
+import { Memos, statusOf } from "../../memoization/index.js"
 import { UI, AnsiUI, prettyPrintUITreeFromBlocks } from "../tree/index.js"
 import { ChoiceStep, TaskStep, Wizard, isChoiceStep, isForm, isTaskStep, wizardify } from "../../wizard/index.js"
 import { Graph, Status, blocks, compile, extractTitle, extractDescription, validate } from "../../graph/index.js"
@@ -45,7 +45,7 @@ export class Guide {
     private readonly blocks: CodeBlockProps[],
     private readonly choices: ChoiceState,
     private readonly options: MadWizardOptions,
-    private readonly memos: Memos = new Memoizer(),
+    private readonly memos: Memos,
     private readonly ui: UI<string> = new AnsiUI()
   ) {}
 
@@ -202,7 +202,7 @@ export class Guide {
                     const statusMemoKey = block.id
                     status =
                       (this.memos.statusMemo && this.memos.statusMemo[statusMemoKey] === "success" && "success") ||
-                      (await shellExec(block.body, this.memos, block.language, block.exec))
+                      (await shellExec(block.body, this.memos, block.language, block.exec, block.async))
 
                     if (status == "success" && this.memos.statusMemo) {
                       this.memos.statusMemo[statusMemoKey] = status

--- a/src/memoization/index.ts
+++ b/src/memoization/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { ChildProcess } from "child_process"
+
 import { ChoiceState } from "../choices/index.js"
 import { ExpansionMap } from "../choices/groups/expansion.js"
 import { Graph, Status, StatusMap, isLeafNode, isChoice, partsOf } from "../graph/index.js"
@@ -32,6 +34,9 @@ export interface Memos {
   /** Any collected dependencies that need to be injected into the runtime */
   dependencies: Record<string, string[]>
 
+  /** Any forked subprocesses that we should wait for? */
+  subprocesses: ChildProcess[]
+
   /** Invalidate any memos that make use of the given shell variable */
   invalidate(variable: string): void
 }
@@ -49,6 +54,9 @@ export class Memoizer implements Memos {
 
   /** Any collected dependencies that need to be injected into the runtime */
   public dependencies = {}
+
+  /** Any forked subprocesses that we should wait for? */
+  public subprocesses: ChildProcess[] = []
 
   /** Invalidate any memos that make use of the given shell variable */
   public invalidate(variable: string): void {

--- a/src/parser/markdown/rehype-code-indexer/index.ts
+++ b/src/parser/markdown/rehype-code-indexer/index.ts
@@ -141,9 +141,13 @@ export function rehypeCodeIndexer(uuid: string, filepath: string, codeblocks?: C
       visitParents(/* <Element> */ ast, "element", function visitor(node, ancestors) {
         if (node.tagName === "code") {
           // react-markdown v6+ places the language in the className
-          const match = node.properties.className ? /language-([\w{.]+)/.exec(node.properties.className.toString()) : ""
-          const language = match ? match[1].replace(/[{.]/g, "") : undefined
-          // re: the replace: this is a bit of a hack to support {.bash .no-copy} style languages from pymdown
+          const match = node.properties.className
+            ? /language-({\.)?(\w+)(\.async)?/.exec(node.properties.className.toString())
+            : ""
+          const language = match ? match[2] : undefined
+          const async = match && match[3] ? true : undefined
+          // re: {. bit: this is a bit of a hack to support {.bash .no-copy} style languages from pymdown
+          // re: .async bit: allow markdown to specify that a code block's execution should be executed asynchronously
 
           if (isExecutable(language)) {
             const myCodeIdx = codeIdx++
@@ -163,10 +167,10 @@ export function rehypeCodeIndexer(uuid: string, filepath: string, codeblocks?: C
                 }
 
                 const dumpCodeBlockProps = !base64
-                  ? () => Object.assign({ body, language }, attributes)
+                  ? () => Object.assign({ body, language, async }, attributes)
                   : () =>
                       Buffer.from(
-                        JSON.stringify(Object.assign({ body, language }, attributes), (key, value) =>
+                        JSON.stringify(Object.assign({ body, language, async }, attributes), (key, value) =>
                           key === "nesting" || key === "source" ? undefined : value
                         )
                       ).toString("base64")

--- a/test/inputs/30/in.md
+++ b/test/inputs/30/in.md
@@ -1,0 +1,17 @@
+# Test for asynchronous code block execution.
+
+```shell
+echo AAA
+```
+
+This code block's output shuld not be seen by the `run` test, because
+the guidebook run will have completed before the sleep finishes.
+
+```shell.async
+sleep 20
+echo BBB
+```
+
+```{.shell .YYY}
+echo CCC
+```

--- a/test/inputs/30/run.txt
+++ b/test/inputs/30/run.txt
@@ -1,0 +1,6 @@
+echo AAA
+AAA
+sleep 20
+echo BBB
+echo CCC
+CCC

--- a/test/inputs/30/tree-noaprioris.txt
+++ b/test/inputs/30/tree-noaprioris.txt
@@ -1,0 +1,5 @@
+Test for asynchronous code block execution.
+├── echo AAA
+├── sleep 20
+│   echo BBB
+└── echo CCC

--- a/test/inputs/30/tree-noopt.txt
+++ b/test/inputs/30/tree-noopt.txt
@@ -1,0 +1,5 @@
+Test for asynchronous code block execution.
+├── echo AAA
+├── sleep 20
+│   echo BBB
+└── echo CCC

--- a/test/inputs/30/tree.txt
+++ b/test/inputs/30/tree.txt
@@ -1,0 +1,5 @@
+Test for asynchronous code block execution.
+├── echo AAA
+├── sleep 20
+│   echo BBB
+└── echo CCC

--- a/test/inputs/30/wizard-noaprioris.json
+++ b/test/inputs/30/wizard-noaprioris.json
@@ -1,0 +1,72 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "title": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo AAA",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "title": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "sleep 20\necho BBB",
+            "language": "shell",
+            "async": true,
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "title": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo CCC",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n"
+    }
+  }
+]

--- a/test/inputs/30/wizard-noopt.json
+++ b/test/inputs/30/wizard-noopt.json
@@ -1,0 +1,72 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "title": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo AAA",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "title": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "sleep 20\necho BBB",
+            "language": "shell",
+            "async": true,
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "title": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo CCC",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n"
+    }
+  }
+]

--- a/test/inputs/30/wizard.json
+++ b/test/inputs/30/wizard.json
@@ -1,0 +1,72 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "title": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo AAA",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "title": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "sleep 20\necho BBB",
+            "language": "shell",
+            "async": true,
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "title": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo CCC",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test for asynchronous code block execution.",
+      "description": "This code block's output shuld not be seen by the `run` test, because the guidebook run will have completed before the sleep finishes.\n"
+    }
+  }
+]


### PR DESCRIPTION
This PR adds support for asynchronous code block execution, via:

```shell.async
do something
```

An async code block will execute under fire-and-forget semantics, except that the subprocesses will be killed at exit of the main guidebook execution.