### PR TITLE
fix: don't validate inside of choices

### DIFF
--- a/src/graph/collapseValidated.ts
+++ b/src/graph/collapseValidated.ts
@@ -29,7 +29,6 @@ import {
   Unordered,
   doValidate,
   extractTitle,
-  hasKey,
   isSequence,
   isParallel,
   isChoice,
@@ -55,7 +54,7 @@ async function collapseValidated<T extends Unordered | Ordered = Unordered, G ex
   }
 
   if (isValidatable(graph)) {
-    const key: string = hasKey(graph) ? graph.key : graph.validate.toString()
+    const key: string = graph.validate.toString()
     if (graph.validate === true) {
       return undefined
     } else if (typeof graph.validate === "string") {
@@ -115,7 +114,7 @@ async function collapseValidated<T extends Unordered | Ordered = Unordered, G ex
     if (subgraph) {
       return Object.assign({}, graph, { graph: subgraph })
     }
-  } else if (isChoice<T>(graph) && graph.group === firstChoice.group) {
+    /* } else if (isChoice<T>(graph) && graph.group === firstChoice.group) {
     const parts = await Promise.all(graph.choices.map(recurse2))
     if (parts.filter(Boolean).length > 0) {
       return Object.assign({}, graph, {
@@ -128,7 +127,7 @@ async function collapseValidated<T extends Unordered | Ordered = Unordered, G ex
           })
           .filter(Boolean),
       })
-    }
+    } */
   } else {
     return graph
   }


### PR DESCRIPTION
we can't do this, because the user hasn't made that choice that!

apparently we were doing this because of some bugs in the ibm/cloud/login and ibm/cloud/target guidebooks, which resulted in them always asking the user to login or target, respectively