### PR TITLE
fix: improvements for cleaning up straggler async processes on exit

### DIFF
--- a/src/exec/shell.ts
+++ b/src/exec/shell.ts
@@ -44,6 +44,7 @@ export default async function shellItOut(
       ["-c", process.platform === "win32" ? cmdline.toString() : `set -o pipefail; ${cmdline}`],
       {
         env,
+        detached: async, // see Memoizer.cleanup() for asyncs, we detach and then kill that detached process group
         stdio: opts.quiet
           ? ["inherit", "ignore", "pipe"]
           : capture

--- a/src/memoization/index.ts
+++ b/src/memoization/index.ts
@@ -80,14 +80,20 @@ export class Memoizer implements Memos {
     if (this.subprocesses.length > 0) {
       try {
         this.subprocesses.forEach((child) => {
-          child.kill()
+          Debug("madwizard/cleanup")("killing process" + child.pid)
 
           // TODO windows...
           // maybe https://medium.com/@almenon214/killing-processes-with-node-772ffdd19aad
           try {
             process.kill(-child.pid) // kill the process group e.g. for pipes
           } catch (err) {
-            Debug("madwizard/cleanup")("error killing process group", err)
+            Debug("madwizard/cleanup")("error killing process group " + -child.pid, err)
+          }
+
+          try {
+            child.kill()
+          } catch (err) {
+            Debug("madwizard/cleanup")("error killing process " + child.pid, err)
           }
         })
       } catch (err) {


### PR DESCRIPTION
This PR uses a `detached: true` subprocess execution for `shell.async` code blocks. Then, on cleanup, we kill that process group. This seems to fix stragglers (i.e. subprocesses sticking around after exit) for cases where a subprocess spawns subprocesses... At least macos gets confused in this case, and attaches those grandchildren to `1`.

Whereas, by detaching, we ask the OS to create a new process group, one that we can control and kill.