### PR TITLE
fix: export exec handler does not properly deal with errors

### DIFF
--- a/src/exec/export.ts
+++ b/src/exec/export.ts
@@ -33,9 +33,10 @@ export default function execAsExport(cmdline: string | boolean, opts: ExecOption
       // about to update it
       opts.invalidate(key)
 
-      const options = Object.assign({}, opts, { capture: "", throwErrors: true })
+      const options = Object.assign({}, opts, { capture: "", ignoreStderr: true })
       return shellItOut(`${cmdline}${semicolon} echo -n $${key}`, options)
         .then(() => options.capture)
+        .catch(() => "")
         .then((valueForUpdate) => {
           opts.env[key] = valueForUpdate
           return "success" as const

--- a/src/exec/options.ts
+++ b/src/exec/options.ts
@@ -26,4 +26,7 @@ export type ExecOptions = Partial<Env> &
 
     /** Capture stdout here */
     capture?: string
+
+    /** Ignore stderr in capture? */
+    ignoreStderr?: boolean
   }

--- a/src/exec/shell.ts
+++ b/src/exec/shell.ts
@@ -74,7 +74,9 @@ export default async function shellItOut(
     }
 
     if (capture) {
-      child.stderr.on("data", (data) => (out += data.toString()))
+      if (!opts.ignoreStderr) {
+        child.stderr.on("data", (data) => (out += data.toString()))
+      }
       child.stdout.on("data", (data) => (out += data.toString()))
     }
 


### PR DESCRIPTION
the error message is stored in the env var