### PR TITLE
fix: hoistSubTasks optimizer is not order preserving

### DIFF
--- a/src/graph/hoistSubTasks.ts
+++ b/src/graph/hoistSubTasks.ts
@@ -336,7 +336,7 @@ function hoist(inputGraph: Graph, inheritedSubTasks: SubTask[]): Graph | void {
   const choiceFrontier = findChoiceFrontier(inputGraph)
   const frontierAllChoicesSubTasks = choiceFrontier.flatMap(extractSubTasksCommonToAllChoices)
 
-  const mySubTasks = removeDuplicates(union(frontierAllChoicesSubTasks, myDominatedSubTasks))
+  const mySubTasks = removeDuplicates(union(myDominatedSubTasks, frontierAllChoicesSubTasks))
   const allSubTasks = removeDuplicates(union(mySubTasks, inheritedSubTasks))
 
   if (allSubTasks.length === 0) {

--- a/test/inputs/8/tree-noaprioris.txt
+++ b/test/inputs/8/tree-noaprioris.txt
@@ -1,8 +1,7 @@
-Prerequisites
-└── DDD
-    ├── Option 1: SubTab1
-    │   ├── echo AAA †
-    │   ├── echo AAA †
-    │   └── echo AAA †
-    └── Option 2: SubTab2
-        └── echo BBB
+DDD
+├── Option 1: SubTab1
+│   ├── echo AAA †
+│   ├── echo AAA †
+│   └── echo AAA †
+└── Option 2: SubTab2
+    └── echo BBB

--- a/test/inputs/8/tree.txt
+++ b/test/inputs/8/tree.txt
@@ -1,8 +1,7 @@
-Prerequisites
-└── DDD
-    ├── Option 1: SubTab1
-    │   ├── echo AAA †
-    │   ├── echo AAA †
-    │   └── echo AAA †
-    └── Option 2: SubTab2
-        └── echo BBB
+DDD
+├── Option 1: SubTab1
+│   ├── echo AAA †
+│   ├── echo AAA †
+│   └── echo AAA †
+└── Option 2: SubTab2
+    └── echo BBB


### PR DESCRIPTION
This PR does not fully fix this problem, but at least gives an ordering that makes more sense. The deeper problem is here:

```typescript
const mySubTasks = removeDuplicates(union(myDominatedSubTasks, frontierAllChoicesSubTasks))
```

this PR gives that swapped order (my, frontier); before it was (frontier, my). The real answer is to find a way to interleave my and frontier subtasks in a way that preserves that initial order of occurence.