### PR TITLE
feat: initial support for remembered choices

### DIFF
--- a/src/choices/impl.ts
+++ b/src/choices/impl.ts
@@ -108,4 +108,9 @@ export default class ChoiceStateImpl extends ChoiceEventManager implements Choic
       }
     }
   }
+
+  /** Serialize */
+  public serialize(): string {
+    return JSON.stringify(this._choices, undefined, 2)
+  }
 }

--- a/src/choices/index.ts
+++ b/src/choices/index.ts
@@ -66,6 +66,9 @@ export interface ChoiceState {
 
   /** Take care with this. If you have a `Choice`, then prefer to use `remove(choice)` */
   removeKey: (key: Key) => boolean
+
+  /** Serialize */
+  serialize(): string
 }
 
 export type Choices = {
@@ -74,4 +77,9 @@ export type Choices = {
 
 export function newChoiceState(assertions: ChoicesMap = {}): ChoiceState {
   return new ChoiceStateImpl(assertions)
+}
+
+/** Deserialize constructor */
+export function deserialize(str: string) {
+  return newChoiceState(JSON.parse(str))
 }

--- a/src/exec/conda-install.ts
+++ b/src/exec/conda-install.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ExecOptions } from "./options.js"
+import { Memos } from "../memoization/index.js"
 import { CustomExecutable } from "../codeblock/index.js"
 
 /**
@@ -22,18 +22,18 @@ import { CustomExecutable } from "../codeblock/index.js"
  */
 export default function addCondaDependences(
   cmdline: string | boolean,
-  opts: ExecOptions,
+  memos: Memos,
   exec?: CustomExecutable["exec"] /* execute code block with custom exec, rather than `sh` */
 ) {
-  if (exec && typeof cmdline === "string" && /^\s*conda-install\s*$/.test(exec) && opts.dependencies) {
-    if (!opts.dependencies.conda) {
-      opts.dependencies.conda = []
+  if (exec && typeof cmdline === "string" && /^\s*conda-install\s*$/.test(exec) && memos.dependencies) {
+    if (!memos.dependencies.conda) {
+      memos.dependencies.conda = []
     }
 
     cmdline
       .split(/\n/)
       .filter(Boolean)
-      .forEach((_) => opts.dependencies.conda.push(_))
+      .forEach((_) => memos.dependencies.conda.push(_))
     return "success" as const
   }
 }

--- a/src/exec/custom.ts
+++ b/src/exec/custom.ts
@@ -18,6 +18,7 @@ import { basename } from "path"
 
 import shellItOut from "./shell.js"
 import { ExecOptions } from "./options.js"
+import { Memos } from "../memoization/index.js"
 import { CustomExecutable } from "../codeblock/index.js"
 
 export interface CustomEnv {
@@ -51,6 +52,7 @@ export interface CustomEnv {
  */
 export default async function execAsCustom(
   cmdline: string | boolean,
+  memos: Memos,
   opts: ExecOptions,
   _exec: CustomExecutable["exec"] | ((env: CustomEnv) => CustomExecutable["exec"] | Promise<CustomExecutable["exec"]>),
   async?: boolean,
@@ -80,7 +82,7 @@ export default async function execAsCustom(
                 }
               }
 
-              shellItOut(exec, opts, mwenv, async, myOnClose).then(resolve, reject)
+              shellItOut(exec, memos, opts, mwenv, async, myOnClose).then(resolve, reject)
             }
           })
         })

--- a/src/exec/options.ts
+++ b/src/exec/options.ts
@@ -14,22 +14,25 @@
  * limitations under the License.
  */
 
+import { Writable } from "stream"
 import { Memos } from "../memoization/index.js"
 
 /** Environment variable state that might be mutated by the guidebook itself */
 export type Env = Pick<Memos, "env">
 
-export type ExecOptions = Partial<Env> &
-  Partial<Pick<Memos, "dependencies" | "invalidate" | "subprocesses" | "onExit">> & {
-    /** Do not emit to console */
-    quiet?: boolean
+export type ExecOptions = {
+  /** Do not emit to console */
+  quiet?: boolean
 
-    /** Capture stdout here */
-    capture?: string
+  /** Capture stdout here */
+  capture?: string
 
-    /** Ignore stderr in capture? */
-    ignoreStderr?: boolean
+  /** Ignore stderr in capture? */
+  ignoreStderr?: boolean
 
-    /** throw any non-zero exit codes */
-    throwErrors?: boolean
-  }
+  /** throw any non-zero exit codes */
+  throwErrors?: boolean
+
+  /** optional writer, e.g. for tests to capture output */
+  write?: Writable["write"]
+}

--- a/src/exec/pip-install.ts
+++ b/src/exec/pip-install.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ExecOptions } from "./options.js"
+import { Memos } from "../memoization/index.js"
 import { CustomExecutable } from "../codeblock/index.js"
 
 /**
@@ -22,18 +22,18 @@ import { CustomExecutable } from "../codeblock/index.js"
  */
 export default function addPipDependences(
   cmdline: string | boolean,
-  opts: ExecOptions,
+  memos: Memos,
   exec?: CustomExecutable["exec"] /* execute code block with custom exec, rather than `sh` */
 ) {
-  if (exec && typeof cmdline === "string" && /^\s*pip-install\s*$/.test(exec) && opts.dependencies) {
-    if (!opts.dependencies.pip) {
-      opts.dependencies.pip = []
+  if (exec && typeof cmdline === "string" && /^\s*pip-install\s*$/.test(exec) && memos.dependencies) {
+    if (!memos.dependencies.pip) {
+      memos.dependencies.pip = []
     }
 
     cmdline
       .split(/\n/)
       .filter(Boolean)
-      .forEach((_) => opts.dependencies.pip.push(_))
+      .forEach((_) => memos.dependencies.pip.push(_))
     return "success" as const
   }
 }

--- a/src/exec/pip-show.ts
+++ b/src/exec/pip-show.ts
@@ -15,14 +15,14 @@
  */
 
 import shellItOut from "./shell.js"
-import { ExecOptions } from "./options.js"
+import { Memos } from "../memoization/index.js"
 
 /**
  * This is purely an optimization, since `pip show` is muy slow. The
  * goal is to check if a pip package is installed, without a lot of
  * fanfare.
  */
-export default function execAsPythonPackageCheck(cmdline: string | boolean, opts: ExecOptions) {
+export default function execAsPythonPackageCheck(cmdline: string | boolean, memos: Memos) {
   if (typeof cmdline === "string") {
     const match = cmdline.match(/^\s*pip-show\s+([^[]+)(\[(.+)\])?$/)
     if (match) {
@@ -40,14 +40,14 @@ export default function execAsPythonPackageCheck(cmdline: string | boolean, opts
 
       const cmdline = `python3 -c '${imports}; sys.exit(0) if ${isDirInSitePackages} or ${isFileInSitePackages} or ${isDirInUserSite} or ${isFileInUserSite} else sys.exit(1)'`
 
-      if (opts.dependencies) {
-        if (!opts.dependencies.pip) {
-          opts.dependencies.pip = []
+      if (memos.dependencies) {
+        if (!memos.dependencies.pip) {
+          memos.dependencies.pip = []
         }
-        opts.dependencies.pip.push(match[1])
+        memos.dependencies.pip.push(match[1])
       }
 
-      return shellItOut(cmdline, opts)
+      return shellItOut(cmdline, memos)
     }
   }
 }

--- a/src/exec/python.ts
+++ b/src/exec/python.ts
@@ -16,9 +16,10 @@
 
 import shellItOut from "./shell.js"
 import { ExecOptions } from "./options.js"
+import { Memos } from "../memoization/index.js"
 
 /** Execute a python script in a subprocess */
-export default async function pythonItOut(cmdline: string | boolean, opts: ExecOptions) {
+export default async function pythonItOut(cmdline: string | boolean, memos: Memos, opts: ExecOptions) {
   const [{ write }, { file: tmpFile }] = await Promise.all([import("fs"), import("tmp")])
 
   return new Promise<"success">((resolve, reject) => {
@@ -30,7 +31,7 @@ export default async function pythonItOut(cmdline: string | boolean, opts: ExecO
           if (err) {
             reject(err)
           } else {
-            shellItOut(`python3 -u "${filepath}"`, opts).then(resolve, reject).finally(cleanupCallback)
+            shellItOut(`python3 -u "${filepath}"`, memos, opts).then(resolve, reject).finally(cleanupCallback)
           }
         })
       }

--- a/src/fe/MadWizardOptions.ts
+++ b/src/fe/MadWizardOptions.ts
@@ -33,6 +33,9 @@ interface FetchOptions {
    * finding snippet content when parsing markdown.
    */
   mkdocs: string
+
+  /** Location of persisted profiles (remembered choices from prior runs) */
+  profilesPath: string
 }
 
 export type MadWizardOptions = Partial<CompilerOptions> & Partial<DisplayOptions> & Partial<FetchOptions>

--- a/src/fe/cli/madwizardRead.ts
+++ b/src/fe/cli/madwizardRead.ts
@@ -16,16 +16,16 @@
 
 import Debug from "debug"
 import { VFile } from "vfile"
-import envPaths from "env-paths"
 import { isAbsolute, join } from "path"
 
 import fetch from "make-fetch-happen"
 import { read as vfileRead } from "to-vfile"
 
+import { cachePath } from "../../util/cache.js"
 import { toRawGithubUserContent } from "../../parser/markdown/snippets/urls.js"
 
 export async function get(uri: string) {
-  return fetch(uri, { cachePath: envPaths("madwizard").cache })
+  return fetch(uri, { cachePath: cachePath() })
 }
 
 /** Fetch the contents of the given `VFile` */

--- a/src/fe/tree/pretty-print.ts
+++ b/src/fe/tree/pretty-print.ts
@@ -108,7 +108,7 @@ export async function prettyPrintUITreeFromBlocks(
   options: PrettyPrintOptions & MadWizardOptions & { root?: string } = {}
 ) {
   const memos = new Memoizer()
-  const graph = await compile(blocks, choices, Object.assign({}, memos, options))
+  const graph = await compile(blocks, choices, memos, options)
 
   const treeifier = new Treeifier(new AnsiUI(), memos.statusMemo)
   const tree = treeifier.toTree(order(graph))

--- a/src/graph/compile.ts
+++ b/src/graph/compile.ts
@@ -101,12 +101,13 @@ export interface CompilerOptions {
       }
 }
 
-export type CompileOptions = Partial<CompilerOptions> & ValidateOptions & Partial<Memos> & Partial<ExecutorOptions>
+export type CompileOptions = Partial<CompilerOptions> & ValidateOptions & Partial<ExecutorOptions>
 
 /** Take a list of code blocks and arrange them into a control flow dag */
 export async function compile(
   blocks: CodeBlockProps[],
   choices: ChoiceState,
+  memos: Memos,
   options: CompileOptions = {},
   ordering: "sequence" | "parallel" = "sequence",
   title?: string,
@@ -365,11 +366,11 @@ export async function compile(
         : await doExpand(
             parts.length === 1 ? parts[0] : ordering === "parallel" ? parallel(parts) : sequence(parts),
             choices,
-            options
+            memos
           )
 
     debug("optimizing")
-    const optimized = options.optimize === false ? unoptimized : await optimize(unoptimized, choices, options)
+    const optimized = options.optimize === false ? unoptimized : await optimize(unoptimized, choices, memos, options)
     debug("optimizing done")
 
     if (title && !extractTitle(optimized)) {

--- a/src/graph/optimize.ts
+++ b/src/graph/optimize.ts
@@ -16,6 +16,7 @@
 
 import Debug from "debug"
 
+import { Memos } from "../memoization/index.js"
 import { ChoiceState } from "../choices/index.js"
 import { CompileOptions, Graph, sequence } from "./index.js"
 
@@ -25,7 +26,7 @@ import collapseValidated from "./collapseValidated.js"
 import collapseMadeChoices from "./collapseMadeChoices.js"
 import deadCodeElimination from "./deadCodeElimination.js"
 
-export default async function optimize(graph: Graph, choices: ChoiceState, options?: CompileOptions) {
+export default async function optimize(graph: Graph, choices: ChoiceState, memos: Memos, options?: CompileOptions) {
   const debug = Debug("madwizard/timing/graph:optimize")
   debug("start")
 
@@ -35,6 +36,7 @@ export default async function optimize(graph: Graph, choices: ChoiceState, optio
         deadCodeElimination(
           await collapseValidated(
             deadCodeElimination(collapseMadeChoices(hoistSubTasks(deadCodeElimination(graph)), choices)),
+            memos,
             options
           )
         )

--- a/src/graph/vetoes.ts
+++ b/src/graph/vetoes.ts
@@ -17,6 +17,7 @@
 import { EOL } from "os"
 import chalk from "chalk"
 
+import { Memos } from "../memoization/index.js"
 import { MadWizardOptions } from "../fe/index.js"
 import { ChoiceState } from "../choices/index.js"
 import { CodeBlockProps } from "../codeblock/index.js"
@@ -35,13 +36,23 @@ export function vetoes(graph: Graph): Provenance["provenance"] {
  * List the veto-able provenances. This can be used to help fill in
  * the `--veto` field of `MadWizardOptions`.
  */
-export async function vetoesFromBlocks(blocks: CodeBlockProps[], choices: ChoiceState, options: CompileOptions = {}) {
-  const graph = await compile(blocks, choices, Object.assign({}, options, { optimize: false, expand: false }))
+export async function vetoesFromBlocks(
+  blocks: CodeBlockProps[],
+  choices: ChoiceState,
+  memos: Memos,
+  options: CompileOptions = {}
+) {
+  const graph = await compile(blocks, choices, memos, Object.assign({}, options, { optimize: false, expand: false }))
   return vetoes(graph)
 }
 
-export async function vetoesToString(blocks: CodeBlockProps[], choices: ChoiceState, options: MadWizardOptions = {}) {
-  return (await vetoesFromBlocks(blocks, choices, Object.assign({}, options, { optimize: false })))
+export async function vetoesToString(
+  blocks: CodeBlockProps[],
+  choices: ChoiceState,
+  memos: Memos,
+  options: MadWizardOptions = {}
+) {
+  return (await vetoesFromBlocks(blocks, choices, memos, Object.assign({}, options, { optimize: false })))
     .map((_) => (options.veto && options.veto.test(_) ? `${_} ${chalk.red("[VETOED]")}` : _))
     .join(EOL)
 }

--- a/src/memoization/index.ts
+++ b/src/memoization/index.ts
@@ -17,12 +17,15 @@
 import Debug from "debug"
 import { ChildProcess } from "child_process"
 
-import { ChoiceState } from "../choices/index.js"
 import { ExpansionMap } from "../choices/groups/expansion.js"
+import { ChoiceState, newChoiceState } from "../choices/index.js"
 import { Graph, Status, StatusMap, isLeafNode, isChoice, partsOf } from "../graph/index.js"
 
 /** Optimize certain expensive or non-idempotent operations */
 export interface Memos {
+  /** Suggestions as to what the user might have done last time */
+  suggestions: ChoiceState
+
   /** the `Status` of a given `LeafNode` in a `Graph` */
   statusMemo: StatusMap
 
@@ -50,6 +53,8 @@ export interface Memos {
 
 /** Default implementation of `Memos` */
 export class Memoizer implements Memos {
+  public constructor(public readonly suggestions: ChoiceState = newChoiceState()) {}
+
   /** the `Status` of a given `LeafNode` in a `Graph` */
   public readonly statusMemo: StatusMap = {}
 

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Debug from "debug"
+import { join } from "path"
+import envPaths from "env-paths"
+
+import { MadWizardOptions } from "../fe/index.js"
+import { ChoiceState, deserialize, newChoiceState } from "../choices/index.js"
+
+/** @return the filepath in which all persistent caches are stored */
+export function cachePath() {
+  return envPaths("madwizard").cache
+}
+
+/** @return the filepath in which all persistent data are stored */
+export function dataPath() {
+  return envPaths("madwizard").data
+}
+
+/** @return the filepath in which persistent profiles are stored */
+async function profilesPath(options: MadWizardOptions, mkdir = false) {
+  const filepath = join(options.profilesPath || process.env.MWPROFILES_PATH || dataPath(), "profiles")
+  if (mkdir) {
+    const mkdirp = await import("mkdirp").then((_) => _.default)
+    await mkdirp(filepath)
+  }
+  return filepath
+}
+
+/** Persist the set of `choices`, unioned with the previously restored suggestions, as a profile named by `profile` */
+export async function persistChoices(
+  options: MadWizardOptions,
+  choices: ChoiceState,
+  suggestions: ChoiceState,
+  profile = "default"
+) {
+  const writeFile = await import("fs").then((_) => _.writeFile)
+  const filepath = join(await profilesPath(options, true), profile)
+
+  // Careul of the order: we want to overlay new choices on top of
+  // previous suggestions
+  const union = suggestions.clone()
+  choices.entries().forEach(([key, value]) => {
+    union.setKey(key, value)
+  })
+
+  return new Promise<void>((resolve, reject) => {
+    writeFile(filepath, union.serialize(), (err) => {
+      if (err) {
+        Debug("madwizard/profile")("error saving profile to " + filepath, err)
+        reject(err)
+      } else {
+        Debug("madwizard/profile")("profile saved to " + filepath)
+        resolve()
+      }
+    })
+  })
+}
+
+export async function restoreChoices(options: MadWizardOptions, profile = "default"): Promise<ChoiceState> {
+  const readFile = await import("fs").then((_) => _.readFile)
+  const filepath = join(await profilesPath(options), profile)
+
+  return new Promise((resolve, reject) => {
+    readFile(filepath, (err, data) => {
+      if (err) {
+        if (err.code == "ENOENT") {
+          Debug("madwizard/profile")("using fresh profile")
+          resolve(newChoiceState())
+        } else {
+          Debug("madwizard/profile")("error restoring profile from " + filepath, err)
+          reject(err)
+        }
+      } else {
+        Debug("madwizard/profile")("profile restored from " + filepath)
+        try {
+          resolve(deserialize(data.toString()))
+        } catch (err) {
+          Debug("madwizard/profile")("error parsing profile from " + filepath, err)
+          reject(err)
+        }
+      }
+    })
+  })
+}


### PR DESCRIPTION
By default now, choices will be stored in a fixed profile (TODO: allow named profiles).

- `--no-profile` CLI option disables profiles altogether
- `--profiles-path` CLI option lets you point to a profiles directory
- `process.env.MWPROFILES_PATH` ibid but via env var

The default profiles path is the platform data directory; e.g. on macOS ~/Library/Application Support/

This PR also does some internal cleanup to avoid Object.assigning Memos and random other stuff. This is helpful, because the default impl `Memoizer` is a class, and so it is important not to mess with `this`. This helps this PR, because we want to pass through extra options, and finally broke things with the way we were smashing memos and options together.

This PR also updates the test rig finally to avoid spawning madwizard as a subprocess for the `run` tests. This helps with this PR, because we will be doing a bunch more run tests, to test the profile support. It is dramatically faster to call madwizard rather than subprocess spawn it (not quite sure why; e.g. 30 seconds down to 6.5 seconds).