### PR TITLE
fix: large cleanup to guide output

### DIFF
--- a/src/choices/groups/expansion.ts
+++ b/src/choices/groups/expansion.ts
@@ -114,7 +114,7 @@ async function doExpand(
         memos,
         options
       ),
-      `Expanding ${chalk.blue(expansionExpr.message || expansionExpr.expr)}`
+      chalk.dim(`Expanding ${chalk.blue(expansionExpr.message || expansionExpr.expr)}`)
     )
     return response.split(/\n/).filter(Boolean)
   } catch (err) {

--- a/src/fe/MadWizardOptions.ts
+++ b/src/fe/MadWizardOptions.ts
@@ -35,6 +35,9 @@ export interface DisplayOptions {
 
   /** Verbose output */
   verbose: boolean
+
+  /** Clear the screen when running in guide mode [default: true] */
+  clear: boolean
 }
 
 interface FetchOptions {

--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -168,6 +168,7 @@ export class Guide {
     return opts.type === "select"
   }
 
+  /** Present the given question to the user */
   private ask(opts: Question) {
     if (process.env.MWCLEAR) {
       console.clear()
@@ -183,7 +184,7 @@ export class Guide {
 
   /** Try to be quiet when executing this task? */
   private beQuietForTaskRunner(block: CodeBlockProps) {
-    return !this.options.verbose && (!!isExport(block.body) || /^\s*(echo|cat|mkdir|while).+/gm.test(block.body))
+    return !this.options.verbose && (!!isExport(block.body) || /^\s*(echo|cat|mkdir|while|if).+/gm.test(block.body))
   }
 
   private listrTaskStep({ step, graph }: TaskStep, taskIdx: number, dryRun: boolean): Task {
@@ -206,9 +207,11 @@ export class Guide {
           (block): Task => ({
             title: block.validate
               ? chalk.dim("checking to see if this task has already been done\u2026")
-              : this.ui.code(block.body, block.language),
+              : this.options.verbose
+              ? this.ui.code(block.body, block.language)
+              : "",
             spinner: !!block.validate,
-            quiet: this.beQuietForTaskRunner(block),
+            quiet: !this.options.verbose,
             task: async (subtask) => {
               let status: Status = statusOf(block, this.memos.statusMemo, this.choices)
 
@@ -411,6 +414,10 @@ export class Guide {
   }
 
   public async run() {
+    if (this.options.clear !== false) {
+      console.clear()
+    }
+
     const tasks = await this.resolveChoices()
     try {
       // await this.showPlan(true, true)

--- a/src/fe/guide/taskrunner.ts
+++ b/src/fe/guide/taskrunner.ts
@@ -63,7 +63,7 @@ class TaskWrapperImpl implements TaskWrapper {
   public skip(parentheticalMsg = "SKIPPED", fullMsg = ` [${parentheticalMsg}]`) {
     if (this.spinner) {
       skip(this.spinner, this.title + chalk.yellow(fullMsg))
-    } else {
+    } else if (!this.quiet) {
       this.write(chalk.yellow(fullMsg))
       this.write(EOL)
     }
@@ -105,7 +105,7 @@ export async function taskRunner(
 ) {
   await promiseEach(tasks, async ({ title, task, spinner, quiet }, idx) => {
     if (idx > 0 && !options.quiet && !quiet) {
-      write(EOL)
+      // write(EOL)
     }
 
     if (!spinner && title && !quiet) {

--- a/src/parser/markdown/rehype-code-indexer/index.ts
+++ b/src/parser/markdown/rehype-code-indexer/index.ts
@@ -194,6 +194,24 @@ export function rehypeCodeIndexer(uuid: string, filepath: string, codeblocks?: C
                   reserialize()
                 }
 
+                // look for a directly enclosing heading to name the code block
+                const parent = ancestors[ancestors.length - 1]
+                const grandparent = ancestors[ancestors.length - 2]
+                if (parent && grandparent) {
+                  const { child, title, source } = findNearestEnclosingTitle(grandparent, parent, node)
+                  if (title) {
+                    // found one!
+                    addNesting(attributes, {
+                      kind: "Import",
+                      source,
+                      key: title,
+                      title,
+                      description: extractFirstParagraph(grandparent, child),
+                      filepath: "",
+                    })
+                  }
+                }
+
                 // go from top to bottom, which is in reverse order, so
                 // that we can synthesize the "optional" and "choices"
                 // attributes
@@ -285,24 +303,6 @@ export function rehypeCodeIndexer(uuid: string, filepath: string, codeblocks?: C
                         source: _,
                         key: title,
                         title,
-                        filepath: "",
-                      })
-                    }
-                  }
-                }
-
-                if (!attributes.nesting) {
-                  const parent = ancestors[ancestors.length - 1]
-                  const grandparent = ancestors[ancestors.length - 2]
-                  if (parent && grandparent) {
-                    const { child, title, source } = findNearestEnclosingTitle(grandparent, parent, node)
-                    if (title) {
-                      addNesting(attributes, {
-                        kind: "Import",
-                        source,
-                        key: title,
-                        title,
-                        description: extractFirstParagraph(grandparent, child),
                         filepath: "",
                       })
                     }

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -201,6 +201,7 @@ function testRunTask(test: Test, input: string, suffix: string) {
 
       try {
         await CLI.cli(["test", "run", filepath, ...getCLIOptions(input, config)], write, {
+          clear: false,
           profilesPath,
           profile,
           profileSaveDelay: 0,

--- a/src/util/ora-delayed-promise.ts
+++ b/src/util/ora-delayed-promise.ts
@@ -17,19 +17,21 @@
 import { oraPromise as theRealOraPromise, PromiseOptions } from "ora"
 
 /** Fire of an `oraPromise` with a delay */
-export function oraPromise<T>(action: Promise<T>, options?: string | PromiseOptions<T>, delayMs = 500): Promise<T> {
+export function oraPromise<T>(action: T | Promise<T>, options?: string | PromiseOptions<T>, delayMs = 500): Promise<T> {
   let isResolved = false
-  action.then(() => (isResolved = true)).catch(() => (isResolved = true))
+  Promise.resolve(action)
+    .then(() => (isResolved = true))
+    .catch(() => (isResolved = true))
 
   if (!isResolved) {
     setTimeout(() => {
       if (!isResolved) {
-        theRealOraPromise(action, options).catch(() => {
+        theRealOraPromise(Promise.resolve(action), options).catch(() => {
           /* the caller will be alerted by our `return action` */
         })
       }
     }, delayMs)
   }
 
-  return action
+  return Promise.resolve(action)
 }

--- a/test/inputs/12/wizard-noopt.json
+++ b/test/inputs/12/wizard-noopt.json
@@ -1,14 +1,27 @@
 [
   {
     "graph": {
-      "body": "echo AAA",
-      "language": "shell",
-      "validate": "echo true",
-      "id": "somekey"
+      "key": "somekey",
+      "group": "Codeblocks in enclosing markdown",
+      "title": "Codeblocks in enclosing markdown",
+      "description": "We expect to see the yellow dagger in the tree to denote that we inherited the validation topmatter from the enclosing in.md file.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo AAA",
+            "language": "shell",
+            "validate": "echo true",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
     },
     "step": {
-      "name": "Missing title",
-      "content": "```shell\necho AAA\n```"
+      "name": "Codeblocks in enclosing markdown",
+      "description": "We expect to see the yellow dagger in the tree to denote that we inherited the validation topmatter from the enclosing in.md file.\n"
     }
   }
 ]

--- a/test/inputs/19/tree-darwin.txt
+++ b/test/inputs/19/tree-darwin.txt
@@ -6,5 +6,6 @@ Install Ray
     │   └── brew install kubectl
     ├── Install Helm
     │   └── brew install helm
-    └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
-        kubectl wait --for=condition=available --all rayclusters
+    └── Install Ray on a Kubernetes Cluster
+        └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+            kubectl wait --for=condition=available --all rayclusters

--- a/test/inputs/19/tree-linux.txt
+++ b/test/inputs/19/tree-linux.txt
@@ -6,5 +6,6 @@ Install Ray
     │   └── curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
     ├── Install Helm
     │   └── bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
-    └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
-        kubectl wait --for=condition=available --all rayclusters
+    └── Install Ray on a Kubernetes Cluster
+        └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+            kubectl wait --for=condition=available --all rayclusters

--- a/test/inputs/19/tree-noaprioris.txt
+++ b/test/inputs/19/tree-noaprioris.txt
@@ -67,5 +67,6 @@ Install Ray
     │   │   └── bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
     │   └── Option 3: Windows
     │       └── bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
-    └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
-        kubectl wait --for=condition=available --all rayclusters
+    └── Install Ray on a Kubernetes Cluster
+        └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+            kubectl wait --for=condition=available --all rayclusters

--- a/test/inputs/19/tree-noopt.txt
+++ b/test/inputs/19/tree-noopt.txt
@@ -67,5 +67,6 @@ Install Ray
     │   │   └── bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
     │   └── Option 3: Windows
     │       └── bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
-    └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
-        kubectl wait --for=condition=available --all rayclusters
+    └── Install Ray on a Kubernetes Cluster
+        └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+            kubectl wait --for=condition=available --all rayclusters

--- a/test/inputs/19/tree-win32.txt
+++ b/test/inputs/19/tree-win32.txt
@@ -6,5 +6,6 @@ Install Ray
     │   └── curl -LO "https://dl.k8s.io/release/v1.23.0/bin/windows/amd64/kubectl.exe"
     ├── Install Helm
     │   └── bash $<(curl -L https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
-    └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
-        kubectl wait --for=condition=available --all rayclusters
+    └── Install Ray on a Kubernetes Cluster
+        └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+            kubectl wait --for=condition=available --all rayclusters

--- a/test/inputs/19/wizard-darwin.json
+++ b/test/inputs/19/wizard-darwin.json
@@ -84,9 +84,21 @@
                 "source": "placeholder"
               },
               {
-                "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
-                "language": "shell",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Install Ray on a Kubernetes Cluster",
+                "description": "This will install Ray on a Kubernetes context of your choosing.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
+                      "language": "shell",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },

--- a/test/inputs/19/wizard-linux.json
+++ b/test/inputs/19/wizard-linux.json
@@ -84,9 +84,21 @@
                 "source": "placeholder"
               },
               {
-                "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
-                "language": "shell",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Install Ray on a Kubernetes Cluster",
+                "description": "This will install Ray on a Kubernetes context of your choosing.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
+                      "language": "shell",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },

--- a/test/inputs/19/wizard-noaprioris.json
+++ b/test/inputs/19/wizard-noaprioris.json
@@ -621,9 +621,21 @@
                 "source": "placeholder"
               },
               {
-                "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
-                "language": "shell",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Install Ray on a Kubernetes Cluster",
+                "description": "This will install Ray on a Kubernetes context of your choosing.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
+                      "language": "shell",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },

--- a/test/inputs/19/wizard-noopt.json
+++ b/test/inputs/19/wizard-noopt.json
@@ -611,9 +611,21 @@
                 "source": "placeholder"
               },
               {
-                "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
-                "language": "shell",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Install Ray on a Kubernetes Cluster",
+                "description": "This will install Ray on a Kubernetes context of your choosing.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
+                      "language": "shell",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },

--- a/test/inputs/19/wizard-win32.json
+++ b/test/inputs/19/wizard-win32.json
@@ -84,9 +84,21 @@
                 "source": "placeholder"
               },
               {
-                "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
-                "language": "shell",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Install Ray on a Kubernetes Cluster",
+                "description": "This will install Ray on a Kubernetes context of your choosing.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
+                      "language": "shell",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },

--- a/test/inputs/23/tree-darwin.txt
+++ b/test/inputs/23/tree-darwin.txt
@@ -14,32 +14,35 @@ Run a Ray Job
 │           │   └── Choose a Kubernetes context
 │           │       └── Option 1: fakeit
 │           │           └── kubectl config set-context "${choice}"
-│           └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
-│               kubectl wait --for=condition=available --all rayclusters
+│           └── Install Ray on a Kubernetes Cluster
+│               └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+│                   kubectl wait --for=condition=available --all rayclusters
 └── Main Tasks
     ├── Option 1: Example: Using Ray Tasks to Parallelize a Function
-    │   └── import ray
-    │       ray.init()
-    │       @ray.remote
-    │       def f(x):
-    │           return x * x
-    │       futures = [f.remote(i) for i in range(4)]
-    │       print(ray.get(futures)) 
+    │   └── Ray Core: Parallelizing Functions with Ray Tasks
+    │       └── import ray
+    │           ray.init()
+    │           @ray.remote
+    │           def f(x):
+    │               return x * x
+    │           futures = [f.remote(i) for i in range(4)]
+    │           print(ray.get(futures)) 
     ├── Option 2: Example: Using Ray Actors to Parallelize a Class
-    │   └── import ray
-    │       ray.init() 
-    │       @ray.remote
-    │       class Counter(object):
-    │           def __init__(self):
-    │               self.n = 0
-    │           def increment(self):
-    │               self.n += 1
-    │           def read(self):
-    │               return self.n
-    │       counters = [Counter.remote() for i in range(4)]
-    │       [c.increment.remote() for c in counters]
-    │       futures = [c.read.remote() for c in counters]
-    │       print(ray.get(futures)) 
+    │   └── Ray Core: Parallelizing Classes with Ray Actors
+    │       └── import ray
+    │           ray.init() 
+    │           @ray.remote
+    │           class Counter(object):
+    │               def __init__(self):
+    │                   self.n = 0
+    │               def increment(self):
+    │                   self.n += 1
+    │               def read(self):
+    │                   return self.n
+    │           counters = [Counter.remote() for i in range(4)]
+    │           [c.increment.remote() for c in counters]
+    │           futures = [c.read.remote() for c in counters]
+    │           print(ray.get(futures)) 
     └── Option 3: Example: Creating and Transforming Datasets
         └── Creating and Transforming Datasets
             ├── Prerequisites

--- a/test/inputs/23/tree-linux.txt
+++ b/test/inputs/23/tree-linux.txt
@@ -14,32 +14,35 @@ Run a Ray Job
 │           │   └── Choose a Kubernetes context
 │           │       └── Option 1: fakeit
 │           │           └── kubectl config set-context "${choice}"
-│           └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
-│               kubectl wait --for=condition=available --all rayclusters
+│           └── Install Ray on a Kubernetes Cluster
+│               └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+│                   kubectl wait --for=condition=available --all rayclusters
 └── Main Tasks
     ├── Option 1: Example: Using Ray Tasks to Parallelize a Function
-    │   └── import ray
-    │       ray.init()
-    │       @ray.remote
-    │       def f(x):
-    │           return x * x
-    │       futures = [f.remote(i) for i in range(4)]
-    │       print(ray.get(futures)) 
+    │   └── Ray Core: Parallelizing Functions with Ray Tasks
+    │       └── import ray
+    │           ray.init()
+    │           @ray.remote
+    │           def f(x):
+    │               return x * x
+    │           futures = [f.remote(i) for i in range(4)]
+    │           print(ray.get(futures)) 
     ├── Option 2: Example: Using Ray Actors to Parallelize a Class
-    │   └── import ray
-    │       ray.init() 
-    │       @ray.remote
-    │       class Counter(object):
-    │           def __init__(self):
-    │               self.n = 0
-    │           def increment(self):
-    │               self.n += 1
-    │           def read(self):
-    │               return self.n
-    │       counters = [Counter.remote() for i in range(4)]
-    │       [c.increment.remote() for c in counters]
-    │       futures = [c.read.remote() for c in counters]
-    │       print(ray.get(futures)) 
+    │   └── Ray Core: Parallelizing Classes with Ray Actors
+    │       └── import ray
+    │           ray.init() 
+    │           @ray.remote
+    │           class Counter(object):
+    │               def __init__(self):
+    │                   self.n = 0
+    │               def increment(self):
+    │                   self.n += 1
+    │               def read(self):
+    │                   return self.n
+    │           counters = [Counter.remote() for i in range(4)]
+    │           [c.increment.remote() for c in counters]
+    │           futures = [c.read.remote() for c in counters]
+    │           print(ray.get(futures)) 
     └── Option 3: Example: Creating and Transforming Datasets
         └── Creating and Transforming Datasets
             ├── Prerequisites

--- a/test/inputs/23/tree-noaprioris.txt
+++ b/test/inputs/23/tree-noaprioris.txt
@@ -39,7 +39,8 @@ Run a Ray Job
 │       │       │   │           └── Option 4: IBM z/Linux and LinuxONE
 │       │       │   │               └── curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-s390x.sh
 │       │       │   │                   bash Anaconda3-2021.11-Linux-s390x.sh -b -p $HOME/miniconda
-│       │       │   └── export PATH=~/miniconda/bin:$PATH
+│       │       │   └── Update your PATH to include conda
+│       │       │       └── export PATH=~/miniconda/bin:$PATH
 │       │       └── conda activate
 │       │           pip uninstall grpcio
 │       │           conda install grpcio
@@ -95,32 +96,35 @@ Run a Ray Job
 │           │   └── Choose a Kubernetes context
 │           │       └── Option 1: fakeit
 │           │           └── kubectl config set-context "${choice}"
-│           └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
-│               kubectl wait --for=condition=available --all rayclusters
+│           └── Install Ray on a Kubernetes Cluster
+│               └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+│                   kubectl wait --for=condition=available --all rayclusters
 └── Main Tasks
     ├── Option 1: Example: Using Ray Tasks to Parallelize a Function
-    │   └── import ray
-    │       ray.init()
-    │       @ray.remote
-    │       def f(x):
-    │           return x * x
-    │       futures = [f.remote(i) for i in range(4)]
-    │       print(ray.get(futures)) 
+    │   └── Ray Core: Parallelizing Functions with Ray Tasks
+    │       └── import ray
+    │           ray.init()
+    │           @ray.remote
+    │           def f(x):
+    │               return x * x
+    │           futures = [f.remote(i) for i in range(4)]
+    │           print(ray.get(futures)) 
     ├── Option 2: Example: Using Ray Actors to Parallelize a Class
-    │   └── import ray
-    │       ray.init() 
-    │       @ray.remote
-    │       class Counter(object):
-    │           def __init__(self):
-    │               self.n = 0
-    │           def increment(self):
-    │               self.n += 1
-    │           def read(self):
-    │               return self.n
-    │       counters = [Counter.remote() for i in range(4)]
-    │       [c.increment.remote() for c in counters]
-    │       futures = [c.read.remote() for c in counters]
-    │       print(ray.get(futures)) 
+    │   └── Ray Core: Parallelizing Classes with Ray Actors
+    │       └── import ray
+    │           ray.init() 
+    │           @ray.remote
+    │           class Counter(object):
+    │               def __init__(self):
+    │                   self.n = 0
+    │               def increment(self):
+    │                   self.n += 1
+    │               def read(self):
+    │                   return self.n
+    │           counters = [Counter.remote() for i in range(4)]
+    │           [c.increment.remote() for c in counters]
+    │           futures = [c.read.remote() for c in counters]
+    │           print(ray.get(futures)) 
     └── Option 3: Example: Creating and Transforming Datasets
         └── Creating and Transforming Datasets
             ├── Prerequisites

--- a/test/inputs/23/tree-noopt.txt
+++ b/test/inputs/23/tree-noopt.txt
@@ -38,7 +38,8 @@ Run a Ray Job
 │   │       │   │           └── Option 4: IBM z/Linux and LinuxONE
 │   │       │   │               └── curl -LO https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-s390x.sh
 │   │       │   │                   bash Anaconda3-2021.11-Linux-s390x.sh -b -p $HOME/miniconda
-│   │       │   └── export PATH=~/miniconda/bin:$PATH
+│   │       │   └── Update your PATH to include conda
+│   │       │       └── export PATH=~/miniconda/bin:$PATH
 │   │       └── conda activate
 │   │           pip uninstall grpcio
 │   │           conda install grpcio
@@ -94,32 +95,35 @@ Run a Ray Job
 │       │   └── Choose a Kubernetes context
 │       │       └── Option 1: fakeit
 │       │           └── kubectl config set-context "${choice}"
-│       └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
-│           kubectl wait --for=condition=available --all rayclusters
+│       └── Install Ray on a Kubernetes Cluster
+│           └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+│               kubectl wait --for=condition=available --all rayclusters
 └── Run a Ray Job
     ├── Option 1: Example: Using Ray Tasks to Parallelize a Function
-    │   └── import ray
-    │       ray.init()
-    │       @ray.remote
-    │       def f(x):
-    │           return x * x
-    │       futures = [f.remote(i) for i in range(4)]
-    │       print(ray.get(futures)) 
+    │   └── Ray Core: Parallelizing Functions with Ray Tasks
+    │       └── import ray
+    │           ray.init()
+    │           @ray.remote
+    │           def f(x):
+    │               return x * x
+    │           futures = [f.remote(i) for i in range(4)]
+    │           print(ray.get(futures)) 
     ├── Option 2: Example: Using Ray Actors to Parallelize a Class
-    │   └── import ray
-    │       ray.init() 
-    │       @ray.remote
-    │       class Counter(object):
-    │           def __init__(self):
-    │               self.n = 0
-    │           def increment(self):
-    │               self.n += 1
-    │           def read(self):
-    │               return self.n
-    │       counters = [Counter.remote() for i in range(4)]
-    │       [c.increment.remote() for c in counters]
-    │       futures = [c.read.remote() for c in counters]
-    │       print(ray.get(futures)) 
+    │   └── Ray Core: Parallelizing Classes with Ray Actors
+    │       └── import ray
+    │           ray.init() 
+    │           @ray.remote
+    │           class Counter(object):
+    │               def __init__(self):
+    │                   self.n = 0
+    │               def increment(self):
+    │                   self.n += 1
+    │               def read(self):
+    │                   return self.n
+    │           counters = [Counter.remote() for i in range(4)]
+    │           [c.increment.remote() for c in counters]
+    │           futures = [c.read.remote() for c in counters]
+    │           print(ray.get(futures)) 
     └── Option 3: Example: Creating and Transforming Datasets
         ├── Install Ray Data
         │   └── pip install "ray[data]" dask

--- a/test/inputs/23/tree-win32.txt
+++ b/test/inputs/23/tree-win32.txt
@@ -14,32 +14,35 @@ Run a Ray Job
 │           │   └── Choose a Kubernetes context
 │           │       └── Option 1: fakeit
 │           │           └── kubectl config set-context "${choice}"
-│           └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
-│               kubectl wait --for=condition=available --all rayclusters
+│           └── Install Ray on a Kubernetes Cluster
+│               └── helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/
+│                   kubectl wait --for=condition=available --all rayclusters
 └── Main Tasks
     ├── Option 1: Example: Using Ray Tasks to Parallelize a Function
-    │   └── import ray
-    │       ray.init()
-    │       @ray.remote
-    │       def f(x):
-    │           return x * x
-    │       futures = [f.remote(i) for i in range(4)]
-    │       print(ray.get(futures)) 
+    │   └── Ray Core: Parallelizing Functions with Ray Tasks
+    │       └── import ray
+    │           ray.init()
+    │           @ray.remote
+    │           def f(x):
+    │               return x * x
+    │           futures = [f.remote(i) for i in range(4)]
+    │           print(ray.get(futures)) 
     ├── Option 2: Example: Using Ray Actors to Parallelize a Class
-    │   └── import ray
-    │       ray.init() 
-    │       @ray.remote
-    │       class Counter(object):
-    │           def __init__(self):
-    │               self.n = 0
-    │           def increment(self):
-    │               self.n += 1
-    │           def read(self):
-    │               return self.n
-    │       counters = [Counter.remote() for i in range(4)]
-    │       [c.increment.remote() for c in counters]
-    │       futures = [c.read.remote() for c in counters]
-    │       print(ray.get(futures)) 
+    │   └── Ray Core: Parallelizing Classes with Ray Actors
+    │       └── import ray
+    │           ray.init() 
+    │           @ray.remote
+    │           class Counter(object):
+    │               def __init__(self):
+    │                   self.n = 0
+    │               def increment(self):
+    │                   self.n += 1
+    │               def read(self):
+    │                   return self.n
+    │           counters = [Counter.remote() for i in range(4)]
+    │           [c.increment.remote() for c in counters]
+    │           futures = [c.read.remote() for c in counters]
+    │           print(ray.get(futures)) 
     └── Option 3: Example: Creating and Transforming Datasets
         └── Creating and Transforming Datasets
             ├── Prerequisites

--- a/test/inputs/23/wizard-darwin.json
+++ b/test/inputs/23/wizard-darwin.json
@@ -146,9 +146,21 @@
                 "source": "placeholder"
               },
               {
-                "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
-                "language": "shell",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Install Ray on a Kubernetes Cluster",
+                "description": "This will install Ray on a Kubernetes context of your choosing.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
+                      "language": "shell",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -192,9 +204,21 @@
             "key": "somekey",
             "sequence": [
               {
-                "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
-                "language": "python",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Ray Core: Parallelizing Functions with Ray Tasks",
+                "description": "First, you import Ray and and initialize it with `ray.init()`. Then you decorate your function with `@ray.remote` to declare that you want to run this function remotely. Lastly, you call that function with `.remote()` instead of calling it normally. This remote call yields a future, a so-called Ray object reference, that you can then fetch with `ray.get`.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
+                      "language": "python",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -207,9 +231,21 @@
             "key": "somekey",
             "sequence": [
               {
-                "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
-                "language": "python",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Ray Core: Parallelizing Classes with Ray Actors",
+                "description": "Ray provides actors to allow you to parallelize an instance of a class in Python or Java. When you instantiate a class that is a Ray actor, Ray will start a remote instance of that class in the cluster. This actor can then execute remote method calls and maintain its own internal state.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
+                      "language": "python",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -245,9 +281,21 @@
                               "key": "somekey",
                               "sequence": [
                                 {
-                                  "body": "pip install \"ray[data]\" dask",
-                                  "language": "shell",
-                                  "id": "somekey"
+                                  "key": "somekey",
+                                  "title": "Install Ray Data",
+                                  "description": "Ray Datasets are the standard way to load and exchange data in Ray libraries and applications. They provide basic distributed data transformations such as `map`, `filter`, and `repartition`, and are compatible with a variety of file formats, data sources, and distributed frameworks.\n",
+                                  "filepath": "",
+                                  "graph": {
+                                    "key": "somekey",
+                                    "sequence": [
+                                      {
+                                        "body": "pip install \"ray[data]\" dask",
+                                        "language": "shell",
+                                        "id": "somekey"
+                                      }
+                                    ]
+                                  },
+                                  "source": "placeholder"
                                 }
                               ]
                             },

--- a/test/inputs/23/wizard-linux.json
+++ b/test/inputs/23/wizard-linux.json
@@ -146,9 +146,21 @@
                 "source": "placeholder"
               },
               {
-                "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
-                "language": "shell",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Install Ray on a Kubernetes Cluster",
+                "description": "This will install Ray on a Kubernetes context of your choosing.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
+                      "language": "shell",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -192,9 +204,21 @@
             "key": "somekey",
             "sequence": [
               {
-                "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
-                "language": "python",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Ray Core: Parallelizing Functions with Ray Tasks",
+                "description": "First, you import Ray and and initialize it with `ray.init()`. Then you decorate your function with `@ray.remote` to declare that you want to run this function remotely. Lastly, you call that function with `.remote()` instead of calling it normally. This remote call yields a future, a so-called Ray object reference, that you can then fetch with `ray.get`.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
+                      "language": "python",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -207,9 +231,21 @@
             "key": "somekey",
             "sequence": [
               {
-                "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
-                "language": "python",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Ray Core: Parallelizing Classes with Ray Actors",
+                "description": "Ray provides actors to allow you to parallelize an instance of a class in Python or Java. When you instantiate a class that is a Ray actor, Ray will start a remote instance of that class in the cluster. This actor can then execute remote method calls and maintain its own internal state.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
+                      "language": "python",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -245,9 +281,21 @@
                               "key": "somekey",
                               "sequence": [
                                 {
-                                  "body": "pip install \"ray[data]\" dask",
-                                  "language": "shell",
-                                  "id": "somekey"
+                                  "key": "somekey",
+                                  "title": "Install Ray Data",
+                                  "description": "Ray Datasets are the standard way to load and exchange data in Ray libraries and applications. They provide basic distributed data transformations such as `map`, `filter`, and `repartition`, and are compatible with a variety of file formats, data sources, and distributed frameworks.\n",
+                                  "filepath": "",
+                                  "graph": {
+                                    "key": "somekey",
+                                    "sequence": [
+                                      {
+                                        "body": "pip install \"ray[data]\" dask",
+                                        "language": "shell",
+                                        "id": "somekey"
+                                      }
+                                    ]
+                                  },
+                                  "source": "placeholder"
                                 }
                               ]
                             },

--- a/test/inputs/23/wizard-noaprioris.json
+++ b/test/inputs/23/wizard-noaprioris.json
@@ -278,9 +278,20 @@
                                 ]
                               },
                               {
-                                "body": "export PATH=~/miniconda/bin:$PATH",
-                                "language": "shell",
-                                "id": "somekey"
+                                "key": "somekey",
+                                "title": "Update your PATH to include conda",
+                                "filepath": "",
+                                "graph": {
+                                  "key": "somekey",
+                                  "sequence": [
+                                    {
+                                      "body": "export PATH=~/miniconda/bin:$PATH",
+                                      "language": "shell",
+                                      "id": "somekey"
+                                    }
+                                  ]
+                                },
+                                "source": "placeholder"
                               }
                             ]
                           },
@@ -709,9 +720,21 @@
                 "source": "placeholder"
               },
               {
-                "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
-                "language": "shell",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Install Ray on a Kubernetes Cluster",
+                "description": "This will install Ray on a Kubernetes context of your choosing.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
+                      "language": "shell",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -755,9 +778,21 @@
             "key": "somekey",
             "sequence": [
               {
-                "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
-                "language": "python",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Ray Core: Parallelizing Functions with Ray Tasks",
+                "description": "First, you import Ray and and initialize it with `ray.init()`. Then you decorate your function with `@ray.remote` to declare that you want to run this function remotely. Lastly, you call that function with `.remote()` instead of calling it normally. This remote call yields a future, a so-called Ray object reference, that you can then fetch with `ray.get`.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
+                      "language": "python",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -770,9 +805,21 @@
             "key": "somekey",
             "sequence": [
               {
-                "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
-                "language": "python",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Ray Core: Parallelizing Classes with Ray Actors",
+                "description": "Ray provides actors to allow you to parallelize an instance of a class in Python or Java. When you instantiate a class that is a Ray actor, Ray will start a remote instance of that class in the cluster. This actor can then execute remote method calls and maintain its own internal state.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
+                      "language": "python",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -808,9 +855,21 @@
                               "key": "somekey",
                               "sequence": [
                                 {
-                                  "body": "pip install \"ray[data]\" dask",
-                                  "language": "shell",
-                                  "id": "somekey"
+                                  "key": "somekey",
+                                  "title": "Install Ray Data",
+                                  "description": "Ray Datasets are the standard way to load and exchange data in Ray libraries and applications. They provide basic distributed data transformations such as `map`, `filter`, and `repartition`, and are compatible with a variety of file formats, data sources, and distributed frameworks.\n",
+                                  "filepath": "",
+                                  "graph": {
+                                    "key": "somekey",
+                                    "sequence": [
+                                      {
+                                        "body": "pip install \"ray[data]\" dask",
+                                        "language": "shell",
+                                        "id": "somekey"
+                                      }
+                                    ]
+                                  },
+                                  "source": "placeholder"
                                 }
                               ]
                             },

--- a/test/inputs/23/wizard-noopt.json
+++ b/test/inputs/23/wizard-noopt.json
@@ -272,9 +272,20 @@
                                 ]
                               },
                               {
-                                "body": "export PATH=~/miniconda/bin:$PATH",
-                                "language": "shell",
-                                "id": "somekey"
+                                "key": "somekey",
+                                "title": "Update your PATH to include conda",
+                                "filepath": "",
+                                "graph": {
+                                  "key": "somekey",
+                                  "sequence": [
+                                    {
+                                      "body": "export PATH=~/miniconda/bin:$PATH",
+                                      "language": "shell",
+                                      "id": "somekey"
+                                    }
+                                  ]
+                                },
+                                "source": "placeholder"
                               }
                             ]
                           },
@@ -698,9 +709,21 @@
                 "source": "placeholder"
               },
               {
-                "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
-                "language": "shell",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Install Ray on a Kubernetes Cluster",
+                "description": "This will install Ray on a Kubernetes context of your choosing.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
+                      "language": "shell",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -744,9 +767,21 @@
             "key": "somekey",
             "sequence": [
               {
-                "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
-                "language": "python",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Ray Core: Parallelizing Functions with Ray Tasks",
+                "description": "First, you import Ray and and initialize it with `ray.init()`. Then you decorate your function with `@ray.remote` to declare that you want to run this function remotely. Lastly, you call that function with `.remote()` instead of calling it normally. This remote call yields a future, a so-called Ray object reference, that you can then fetch with `ray.get`.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
+                      "language": "python",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -759,9 +794,21 @@
             "key": "somekey",
             "sequence": [
               {
-                "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
-                "language": "python",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Ray Core: Parallelizing Classes with Ray Actors",
+                "description": "Ray provides actors to allow you to parallelize an instance of a class in Python or Java. When you instantiate a class that is a Ray actor, Ray will start a remote instance of that class in the cluster. This actor can then execute remote method calls and maintain its own internal state.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
+                      "language": "python",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -781,9 +828,21 @@
                   "key": "somekey",
                   "sequence": [
                     {
-                      "body": "pip install \"ray[data]\" dask",
-                      "language": "shell",
-                      "id": "somekey"
+                      "key": "somekey",
+                      "title": "Install Ray Data",
+                      "description": "Ray Datasets are the standard way to load and exchange data in Ray libraries and applications. They provide basic distributed data transformations such as `map`, `filter`, and `repartition`, and are compatible with a variety of file formats, data sources, and distributed frameworks.\n",
+                      "filepath": "",
+                      "graph": {
+                        "key": "somekey",
+                        "sequence": [
+                          {
+                            "body": "pip install \"ray[data]\" dask",
+                            "language": "shell",
+                            "id": "somekey"
+                          }
+                        ]
+                      },
+                      "source": "placeholder"
                     }
                   ]
                 },

--- a/test/inputs/23/wizard-win32.json
+++ b/test/inputs/23/wizard-win32.json
@@ -146,9 +146,21 @@
                 "source": "placeholder"
               },
               {
-                "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
-                "language": "shell",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Install Ray on a Kubernetes Cluster",
+                "description": "This will install Ray on a Kubernetes context of your choosing.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "helm -n ray install example-cluster --create-namespace https://github.com/ray-project/ray/tree/master/deploy/charts/ray/\nkubectl wait --for=condition=available --all rayclusters",
+                      "language": "shell",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -192,9 +204,21 @@
             "key": "somekey",
             "sequence": [
               {
-                "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
-                "language": "python",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Ray Core: Parallelizing Functions with Ray Tasks",
+                "description": "First, you import Ray and and initialize it with `ray.init()`. Then you decorate your function with `@ray.remote` to declare that you want to run this function remotely. Lastly, you call that function with `.remote()` instead of calling it normally. This remote call yields a future, a so-called Ray object reference, that you can then fetch with `ray.get`.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "import ray\nray.init()\n\n@ray.remote\ndef f(x):\n    return x * x\n\nfutures = [f.remote(i) for i in range(4)]\nprint(ray.get(futures)) # [0, 1, 4, 9]",
+                      "language": "python",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -207,9 +231,21 @@
             "key": "somekey",
             "sequence": [
               {
-                "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
-                "language": "python",
-                "id": "somekey"
+                "key": "somekey",
+                "title": "Ray Core: Parallelizing Classes with Ray Actors",
+                "description": "Ray provides actors to allow you to parallelize an instance of a class in Python or Java. When you instantiate a class that is a Ray actor, Ray will start a remote instance of that class in the cluster. This actor can then execute remote method calls and maintain its own internal state.\n",
+                "filepath": "",
+                "graph": {
+                  "key": "somekey",
+                  "sequence": [
+                    {
+                      "body": "import ray\nray.init() # Only call this once.\n\n@ray.remote\nclass Counter(object):\n    def __init__(self):\n        self.n = 0\n\n    def increment(self):\n        self.n += 1\n\n    def read(self):\n        return self.n\n\ncounters = [Counter.remote() for i in range(4)]\n[c.increment.remote() for c in counters]\nfutures = [c.read.remote() for c in counters]\nprint(ray.get(futures)) # [1, 1, 1, 1]",
+                      "language": "python",
+                      "id": "somekey"
+                    }
+                  ]
+                },
+                "source": "placeholder"
               }
             ]
           },
@@ -245,9 +281,21 @@
                               "key": "somekey",
                               "sequence": [
                                 {
-                                  "body": "pip install \"ray[data]\" dask",
-                                  "language": "shell",
-                                  "id": "somekey"
+                                  "key": "somekey",
+                                  "title": "Install Ray Data",
+                                  "description": "Ray Datasets are the standard way to load and exchange data in Ray libraries and applications. They provide basic distributed data transformations such as `map`, `filter`, and `repartition`, and are compatible with a variety of file formats, data sources, and distributed frameworks.\n",
+                                  "filepath": "",
+                                  "graph": {
+                                    "key": "somekey",
+                                    "sequence": [
+                                      {
+                                        "body": "pip install \"ray[data]\" dask",
+                                        "language": "shell",
+                                        "id": "somekey"
+                                      }
+                                    ]
+                                  },
+                                  "source": "placeholder"
                                 }
                               ]
                             },


### PR DESCRIPTION
This PR updates the guide taskrunner output to restrict low-level details to `--verbose/-V` mode.

This PR also fixes a long-standing issue with labels for some code blocks; in some cases, we were using the title "two levels up", rather than the nearest enclosing heading.