### PR TITLE
feat: allow CLI callers to specify no-clean

### DIFF
--- a/src/fe/MadWizardOptions.ts
+++ b/src/fe/MadWizardOptions.ts
@@ -27,6 +27,9 @@ export interface RunOptions {
 
   /** Profile flush hysteresis. To avoid a flood of file writes, you can control the hystersis delay for profile persistence [default: 50ms] */
   profileSaveDelay: number
+
+  /** Clean up guidebook subprocesses, instead of relying on the caller to do so, via the return value from `fe/cli` [default: true] */
+  clean: boolean
 }
 
 export interface DisplayOptions {

--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -254,9 +254,12 @@ export async function cli<Writer extends Writable["write"]>(
           }
         }
 
-        cleanExit()
+        if (options.clean !== false) {
+          cleanExit()
+        }
       }
-      break
+
+      return cleanExit
     }
 
     default:


### PR DESCRIPTION
So that they can control the lifecycle of the guidebook's subprocesses