### PR TITLE
feat: improve Profiles api, including GUIDEBOOK_PROFILE_DATA_PATH env var

### DIFF
--- a/src/exec/options.ts
+++ b/src/exec/options.ts
@@ -17,13 +17,14 @@
 import { Writable } from "stream"
 
 import { Memos } from "../memoization/index.js"
-import { DisplayOptions, RunOptions } from "../fe/MadWizardOptions.js"
+import { FetchOptions, DisplayOptions, RunOptions } from "../fe/MadWizardOptions.js"
 
 /** Environment variable state that might be mutated by the guidebook itself */
 export type Env = Pick<Memos, "env">
 
 export type ExecOptions = Partial<DisplayOptions> &
-  Partial<RunOptions> & {
+  Partial<RunOptions> &
+  Partial<FetchOptions> & {
     /** Do not emit to console */
     quiet?: boolean
 

--- a/src/exec/shell.ts
+++ b/src/exec/shell.ts
@@ -18,6 +18,7 @@ import { spawn, execSync, StdioOptions } from "child_process"
 
 import { ExecOptions } from "./options.js"
 import { Memos } from "../memoization/index.js"
+import { guidebookGlobalDataPath, guidebookProfileDataPath } from "../profiles/index.js"
 
 export function shellSync(cmdline: string, memos: Memos) {
   execSync(cmdline, { env: Object.assign({}, process.env, memos.env || {}) })
@@ -34,12 +35,20 @@ export default async function shellItOut(
 ): Promise<"success"> {
   const capture = typeof opts.capture === "string"
 
+  // location for guidebooks to store non-profile-specific data
+  const GUIDEBOOK_GLOBAL_DATA_PATH = guidebookGlobalDataPath(opts)
+
+  // location for guidebooks to store profile-specific data
+  const GUIDEBOOK_PROFILE_DATA_PATH = guidebookProfileDataPath(opts)
+
   const env = Object.assign(
     {
       IBMCLOUD_VERSION_CHECK: "false",
       HOMEBREW_NO_INSTALL_CLEANUP: "1",
       HOMEBREW_NO_INSTALL_UPGRADE: "1",
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1",
+      GUIDEBOOK_GLOBAL_DATA_PATH,
+      GUIDEBOOK_PROFILE_DATA_PATH,
     },
     process.env,
     memos.env || {},

--- a/src/fe/MadWizardOptions.ts
+++ b/src/fe/MadWizardOptions.ts
@@ -58,7 +58,7 @@ export interface DisplayOptions {
   clear: boolean
 }
 
-interface FetchOptions {
+export interface FetchOptions {
   /** Base URI of Guidebook store? */
   store: string
 
@@ -70,6 +70,9 @@ interface FetchOptions {
 
   /** Location of persisted profiles (remembered choices from prior runs) */
   profilesPath: string
+
+  /** Location for guidebooks to store persisted data */
+  dataPath: string
 }
 
 export type MadWizardOptions = Partial<CompilerOptions> &

--- a/src/fe/cli/defaults.ts
+++ b/src/fe/cli/defaults.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { dataPath } from "../../util/cache.js"
 import { MadWizardOptions } from "../MadWizardOptions.js"
 
 const defaults: MadWizardOptions = {
   clean: true,
+  dataPath: dataPath(),
   interactive: false,
   profile: "default",
   profileSaveDelay: 50,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export * as Parser from "./parser/index.js"
 export * as Choices from "./choices/index.js"
 export * as Wizard from "./wizard/index.js"
 export * as CodeBlock from "./codeblock/index.js"
-export { default as listProfiles } from "./profiles/list.js"
+export * as Profiles from "./profiles/list.js"
 
 export { Memoizer } from "./memoization/index.js"
 

--- a/src/profiles/index.ts
+++ b/src/profiles/index.ts
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 
+import { join } from "path"
+
+import defaults from "../fe/cli/defaults.js"
 import { ChoicesMap } from "../choices/index.js"
+import { MadWizardOptions } from "../fe/index.js"
+
+export { default as clone } from "./clone.js"
+export { default as list } from "./list.js"
+export { default as persist } from "./persist.js"
+export { default as restore } from "./restore.js"
 
 export interface Profile {
   /** Name of this profile */
@@ -46,4 +55,12 @@ export function isProfile(obj: unknown): obj is Profile {
 
 export function copyWithName(profile: Profile, name: string) {
   return Object.assign({}, profile, { name })
+}
+
+export function guidebookGlobalDataPath(opts: MadWizardOptions) {
+  return opts.dataPath || defaults.dataPath
+}
+
+export function guidebookProfileDataPath(opts: MadWizardOptions) {
+  return join(guidebookGlobalDataPath(opts), opts.profile || defaults.profile)
 }


### PR DESCRIPTION
1) guidebooks can now use GUIDEBOOK_GLOBAL_DATA_PATH and GUIDEBOOK_PROFILE_DATA_PATH to store data that is either not specific to a profile, or specific to a profile, respectively.
2) madwizard now exports these and the full profile api via `import { Profiles } from 'madwizard'`