### PR TITLE
feat: restore interactive as the default guide mode

### DIFF
--- a/src/fe/cli/defaults.ts
+++ b/src/fe/cli/defaults.ts
@@ -18,11 +18,29 @@ import { dataPath } from "../../util/cache.js"
 import { MadWizardOptions } from "../MadWizardOptions.js"
 
 const defaults: MadWizardOptions = {
-  clean: true,
+  /**
+   * The default path for guidebooks to store data is determined by
+   * `dataPath()`, which uses platform-specific logic.
+   */
   dataPath: dataPath(),
-  interactive: false,
+
+  interactive: true,
+
+  /** The choice profile to use */
   profile: "default",
+
+  /**
+   * Hysteresis, in milliseconds, for batching the persistence (to
+   * disk) of choice updates. This can avoid a flurry of file I/O, but
+   * means process crashes or ctrl+c's may result in unsaved choices.
+   */
   profileSaveDelay: 50,
+
+  /**
+   * [Advanced] Yes, we want to kill any subprocesses guidebooks might
+   * have launched (via `shell.async`).
+   */
+  clean: true,
 }
 
 export default defaults

--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -72,12 +72,12 @@ export async function cli<Writer extends Writable["write"]>(
   // validation and expanding lists is ok
   const dryRun = !!_argv.find((_) => _ === "--dry-run")
 
-  const interactive = !!_argv.find((_) => _ === "-i" || _ === "--interactive")
-  const noOptimize = !!_argv.find((_) => _ === "-O0" || _ === "--optimize=0" || _ === "--no-optimize")
-  const noAprioris = !!_argv.find((_) => _ === "--no-aprioris")
-  const noValidate = !!_argv.find((_) => _ === "--no-validate")
-  const verbose = !!_argv.find((_) => _ === "--verbose" || _ === "-V")
-  const optimize = noOptimize ? false : { aprioris: !noAprioris, validate: !noValidate }
+  const interactive = _argv.find((_) => _ === "-i" || _ === "--interactive") ? true : undefined
+  const noOptimize = _argv.find((_) => _ === "-O0" || _ === "--optimize=0" || _ === "--no-optimize") ? true : undefined
+  const noAprioris = _argv.find((_) => _ === "--no-aprioris") ? true : undefined
+  const noValidate = _argv.find((_) => _ === "--no-validate") ? true : undefined
+  const verbose = _argv.find((_) => _ === "--verbose" || _ === "-V") ? true : undefined
+  const optimize = noOptimize ? undefined : { aprioris: !noAprioris, validate: !noValidate }
 
   // base uri of guidebook store; this will allow users to type
   // shortnames for books in the store
@@ -85,16 +85,36 @@ export async function cli<Writer extends Writable["write"]>(
     ? _argv.find((_) => _.startsWith("--store=")).replace(/^--store=/, "")
     : undefined
 
-  const commandLineOptions: MadWizardOptions = {
-    veto,
-    dryRun,
-    mkdocs,
-    narrow,
-    optimize,
-    profilesPath,
-    store,
-    verbose,
-    interactive,
+  const commandLineOptions: MadWizardOptions = {}
+  if (interactive !== undefined) {
+    commandLineOptions.interactive = interactive
+  }
+  if (veto !== undefined) {
+    commandLineOptions.veto = veto
+  }
+  if (dryRun !== undefined) {
+    commandLineOptions.dryRun = dryRun
+  }
+  if (mkdocs !== undefined) {
+    commandLineOptions.mkdocs = mkdocs
+  }
+  if (narrow !== undefined) {
+    commandLineOptions.narrow = narrow
+  }
+  if (optimize !== undefined) {
+    commandLineOptions.optimize = optimize
+  }
+  if (profilesPath !== undefined) {
+    commandLineOptions.profilesPath = profilesPath
+  }
+  if (store !== undefined) {
+    commandLineOptions.store = store
+  }
+  if (verbose !== undefined) {
+    commandLineOptions.verbose = verbose
+  }
+  if (interactive !== undefined) {
+    commandLineOptions.interactive = interactive
   }
   const options: MadWizardOptions = Object.assign({}, defaultOptions, commandLineOptions, providedOptions)
 


### PR DESCRIPTION
This PR also cleans up the handling of command line options, so that defaults apply correctly when the user hasn't specified an option on the command line