### PR TITLE
feat: guide should return the env map that the guidebook created

### DIFF
--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -292,7 +292,10 @@ export async function cli<Writer extends Writable["write"]>(
         }
       }
 
-      return cleanExit
+      return {
+        cleanExit,
+        env: memoizer.env,
+      }
     }
 
     default:


### PR DESCRIPTION
This will allow calling clients to consume environment variables that the guidebook produces.