### PR TITLE
fix: rename API is not changing the `name` field in the model itself

### DIFF
--- a/src/profiles/clone.ts
+++ b/src/profiles/clone.ts
@@ -22,7 +22,7 @@ import { MadWizardOptions } from "../fe/index.js"
 export default async function clone(
   options: MadWizardOptions,
   srcProfileName: string,
-  destProfileName: string
+  dstProfileName: string
 ): Promise<void> {
-  await persist(options, await restore(options, srcProfileName), undefined, destProfileName)
+  await persist(options, await restore(options, srcProfileName), undefined, dstProfileName)
 }

--- a/src/profiles/rename.ts
+++ b/src/profiles/rename.ts
@@ -16,6 +16,7 @@
 
 import { join } from "path"
 
+import clone from "./clone.js"
 import { profilesPath } from "./paths.js"
 import { MadWizardOptions } from "../fe/index.js"
 
@@ -25,8 +26,9 @@ export default async function rename(
   srcProfileName: string,
   dstProfileName: string
 ): Promise<void> {
-  const { rename } = await import("fs/promises")
+  await clone(options, srcProfileName, dstProfileName)
+
   const srcFilepath = join(await profilesPath(options), srcProfileName)
-  const dstFilepath = join(await profilesPath(options), dstProfileName)
-  await rename(srcFilepath, dstFilepath)
+  const { unlink } = await import("fs/promises")
+  await unlink(srcFilepath)
 }


### PR DESCRIPTION
It was only changing the name of the profile file in the filesystem.