### PR TITLE
feat: add Profiles.isTemporary() API to allow clients to know which profiles are temps

### DIFF
--- a/src/profiles/index.ts
+++ b/src/profiles/index.ts
@@ -24,8 +24,8 @@ export * from "./paths.js"
 export { default as list } from "./list.js"
 export { default as clone } from "./clone.js"
 export { default as rename } from "./rename.js"
-export { default as persist } from "./persist.js"
 export { default as restore } from "./restore.js"
+export { isTemporary, default as persist } from "./persist.js"
 
 export interface Profile {
   /** Name of this profile */

--- a/src/profiles/persist.ts
+++ b/src/profiles/persist.ts
@@ -21,6 +21,11 @@ import { profilesPath } from "./paths.js"
 import { MadWizardOptions } from "../fe/index.js"
 import { ChoiceState, emptyChoiceState } from "../choices/index.js"
 
+/** We can't seem to control any aspect of the temporary file names used by `write-file-atomic` :( */
+export function isTemporary(profile: string) {
+  return /\.\d+/.test(profile)
+}
+
 /**
  * Persist the set of `choices`, unioned with the previously restored suggestions.
  */


### PR DESCRIPTION
e.g. resulting from a use of `write-file-atomic`