### PR TITLE
feat: support for parsing source into ast at `mirror` time

### DIFF
--- a/src/choices/groups/index.ts
+++ b/src/choices/groups/index.ts
@@ -29,20 +29,7 @@ export {
 
 import aprioris from "./aprioris/index.js"
 
-/**
- * Scan tab groups to see if we can squash down the choice given our a
- * priori knowledge, e.g. about what platform we are on.
- *
- */
-export function identifyRecognizableTabGroups(
-  tree: Node,
-  choices: ChoiceState,
-  { optimize = true }: MadWizardOptions = {}
-) {
-  if (!choices) {
-    return
-  }
-
+export function populateAprioris(choices: ChoiceState, { optimize = true }: MadWizardOptions = {}) {
   const useAprioris = !(optimize === false || (optimize !== true && optimize.aprioris === false))
 
   if (useAprioris) {
@@ -50,6 +37,21 @@ export function identifyRecognizableTabGroups(
       .filter((_) => !choices.contains(_.choiceGroup)) // already set?
       .forEach((_) => _.populateChoice(choices))
   }
+
+  return useAprioris
+}
+
+/**
+ * Scan tab groups to see if we can squash down the choice given our a
+ * priori knowledge, e.g. about what platform we are on.
+ *
+ */
+export function identifyRecognizableTabGroups(tree: Node, choices: ChoiceState, options: MadWizardOptions) {
+  if (!choices) {
+    return
+  }
+
+  const useAprioris = populateAprioris(choices, options)
 
   const nodesToVisit: Element[] = []
 


### PR DESCRIPTION
This is an optimization, where we pre-generate the `blocks` model, and persist it along with the mirror. We do this to work around the extremely slow parsing from the `micromark` markdown parsing node module family.

For a 1.2MB source markdown, this reduces startup time from 7-8 seconds down to nearly 1 second. Node profiling shows that at least 30% of this slowness is due to micromark's array splicing. Oof, we're not going to fix that easily, hence this work.

ref: https://github.com/micromark/micromark/discussions/115