### PR TITLE
fix: optimize load time by deferring import of parsing logic

### DIFF
--- a/src/fe/cli/index.ts
+++ b/src/fe/cli/index.ts
@@ -44,10 +44,8 @@ export async function cli<Writer extends Writable["write"]>(
     return import("../../version.js").then((_) => _.version())
   }
 
-  const [{ parse }, { newChoiceState }, { madwizardRead }, { compile, order, vetoesToString }] = await Promise.all([
-    import("../../parser/index.js"),
+  const [{ newChoiceState }, { compile, order, vetoesToString }] = await Promise.all([
     import("../../choices/index.js"),
-    import("./madwizardRead.js"),
     import("../../graph/index.js"),
   ])
 
@@ -204,7 +202,7 @@ export async function cli<Writer extends Writable["write"]>(
     // check to see if the compiled model exists
     const [{ access, readFile }, { targetPathForAst }] = await Promise.all([
       import("fs/promises"),
-      import("../../parser/markdown/snippets/mirror.js"),
+      import("../../parser/markdown/snippets/mirror-paths.js"),
     ])
 
     const ast1 = targetPathForAst(input + "/index.md", options.store)
@@ -229,6 +227,10 @@ export async function cli<Writer extends Writable["write"]>(
       return JSON.parse(await readFile(exists1 || exists2).then((_) => _.toString()))
     } else {
       // no! we need to parse it from the source (much slower)
+      const [{ madwizardRead }, { parse }] = await Promise.all([
+        import("./madwizardRead.js"),
+        import("../../parser/index.js"),
+      ])
       return parse(input, madwizardRead, choices, undefined, options).then((_) => _.blocks)
     }
   }

--- a/src/parser/markdown/snippets/mirror-paths.ts
+++ b/src/parser/markdown/snippets/mirror-paths.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { basename, dirname, join } from "path"
+
+/**
+ * We pre-parse the source into the `blocks` model (our AST). This
+ * returns the location of the ast model associated with the given source `filepath`.
+ */
+export function targetPathForAst(filepath: string, storePrefix = "") {
+  return join(storePrefix, dirname(filepath), basename(filepath, ".md") + "-madwizard.json")
+}

--- a/src/parser/markdown/snippets/mirror.ts
+++ b/src/parser/markdown/snippets/mirror.ts
@@ -14,25 +14,18 @@
  * limitations under the License.
  */
 
+import { join } from "path"
 import { readdir } from "fs"
 import { oraPromise } from "ora"
 import { writeFile } from "fs/promises"
-import { basename, dirname, join } from "path"
 
 import { inliner } from "./inliner.js"
 import { MadWizardOptions } from "../../../fe/index.js"
 
 import { parse } from "../../../parser/index.js"
+import { targetPathForAst } from "./mirror-paths.js"
 import { newChoiceState } from "../../../choices/index.js"
 import { madwizardRead } from "../../../fe/cli/madwizardRead.js"
-
-/**
- * We pre-parse the source into the `blocks` model (our AST). This
- * returns the location of the ast model associated with the given source `filepath`.
- */
-export function targetPathForAst(filepath: string, storePrefix = "") {
-  return join(storePrefix, dirname(filepath), basename(filepath, ".md") + "-madwizard.json")
-}
 
 export async function mirror(srcDir: string, targetDir: string, srcRelPath = "", options: MadWizardOptions) {
   // Debug.enable("madwizard/fetch/snippets")


### PR DESCRIPTION
we don't need to load all of the markdown parsing logic when using a precompiled ast