### PR TITLE
fix: change default mkdir option for profilesPath API to true

### DIFF
--- a/src/profiles/paths.ts
+++ b/src/profiles/paths.ts
@@ -35,7 +35,7 @@ export function guidebookJobDataPath(opts: MadWizardOptions) {
 }
 
 /** @return the filepath in which persistent profiles are stored */
-export async function profilesPath(options: MadWizardOptions, mkdir = false) {
+export async function profilesPath(options: MadWizardOptions, mkdir = true) {
   const filepath =
     options.profilesPath || process.env.MWPROFILES_PATH || join(guidebookGlobalDataPath(options), "profiles")
   if (mkdir) {


### PR DESCRIPTION
I don't see any reason why we shouldn't always create the profiles directory.