### PR TITLE
fix: `Profiles.list()` API should not fail if profiles directory does not exist

### DIFF
--- a/src/profiles/list.ts
+++ b/src/profiles/list.ts
@@ -26,7 +26,11 @@ export default async function list(options: MadWizardOptions): Promise<ChoiceSta
   return new Promise((resolve, reject) => {
     readdir(filepath, (err, files) => {
       if (err) {
-        reject(err)
+        if (err.code === "ENOENT") {
+          resolve([])
+        } else {
+          reject(err)
+        }
       } else {
         resolve(
           Promise.all(


### PR DESCRIPTION
Instead, it will now return `[]`, i.e. an empty list of profiles.