### PR TITLE
feat: allow clients to pass in a `name` option, and use this in logging

### DIFF
--- a/src/fe/MadWizardOptions.ts
+++ b/src/fe/MadWizardOptions.ts
@@ -48,6 +48,9 @@ export interface RunOptions {
 }
 
 export interface DisplayOptions {
+  /** name to display in log messages */
+  name: string
+
   /** Shorten output of long or multi-line code blocks. */
   narrow: boolean
 

--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -480,6 +480,9 @@ export class Guide {
       console.clear()
     }
 
+    // a name we might want to associate with the run, in the logs
+    const name = this.options.name ? ` (${this.options.name})` : ""
+
     const tasks = await this.resolveChoices()
     try {
       // await this.showPlan(true, true)
@@ -488,14 +491,14 @@ export class Guide {
       if (tasksWereRun && this.isGuided) {
         if (this.allDoneSuccessfully()) {
           console.log()
-          console.log("✨ Guidebook successful")
+          console.log("✨ Guidebook successful" + name)
         } else {
           console.log()
-          console.log(chalk.red("Guidebook incomplete"))
+          console.log(chalk.red("Guidebook incomplete" + name))
         }
       }
     } catch (err) {
-      throw new Error(chalk.red(mainSymbols.cross) + " Run failed: " + err.message)
+      throw new Error(chalk.red(mainSymbols.cross) + " Run failed" + name + ": " + err.message)
     }
   }
 }


### PR DESCRIPTION
this helps clients, which may be running multiple guidebooks concurrently, distinguish the output a bit better.

Either pass this into the CLI with a `{ name }` option, or via `$GUIDEBOOK_NAME`