### PR TITLE
feat: allow code blocks to request an early, but normal, termination of the guidebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ You may find the source for these [here](https://github.com/guidebooks/store/tre
 npm install -g madwizard
 ```
 
+## Special Markdown Features
+
+- You may offer a choice to the user by using [PyMdown's tabbed syntax](https://facelessuser.github.io/pymdown-extensions/extensions/tabbed/)
+
+- Code blocks may request that a guidebook exits early, but with a
+  normal 0 overall exit code, by exiting that shell block with a `90`
+  exit code (there is no particular meaning to this exit code):
+  ```shell
+  echo "Stopping execution normally"
+  exit 90
+  ```
+
 ## Usage
 
 Point madwizard at a local or remote markdown file, and choose a

--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -15,7 +15,7 @@ function opts {
 }
 
 echo -n A
-for i in {1..32}
+for i in {1..33}
 do
     if [ -n "$WHICH" ] && [ $i != $WHICH ]; then continue; fi
 
@@ -35,7 +35,7 @@ done
 echo
 
 echo -n B
-for i in {1..8} {11..18} {20..22} {24..32}
+for i in {1..8} {11..18} {20..22} {24..33}
 do
     if [ -n "$WHICH" ] && [ $i != $WHICH ]; then continue; fi
 

--- a/src/exec/EarlyExit.ts
+++ b/src/exec/EarlyExit.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An Error used to designate that a guidebook wants to stop now, but
+ * with a normal exit code.
+ */
+export default function EarlyExit() {
+  return new Error("EarlyExit")
+}
+
+/** @return whether the given `err` indicates an EarlyExit situation */
+export function isEarlyExit(err: Error) {
+  return err.message === "EarlyExit"
+}

--- a/src/exec/shell.ts
+++ b/src/exec/shell.ts
@@ -16,6 +16,7 @@
 
 import { spawn, execSync, StdioOptions } from "child_process"
 
+import EarlyExit from "./EarlyExit.js"
 import { ExecOptions } from "./options.js"
 import { Memos } from "../memoization/index.js"
 import { guidebookGlobalDataPath, guidebookProfileDataPath, guidebookJobDataPath } from "../profiles/index.js"
@@ -99,7 +100,9 @@ export default async function shellItOut(
         await onClose()
       }
 
-      if (code === 0) {
+      if (code === 90) {
+        reject(EarlyExit())
+      } else if (code === 0) {
         resolve("success")
       } else {
         reject(new Error(err || `${cmdline} failed`))

--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -28,6 +28,7 @@ import { taskRunner, Task } from "./taskrunner.js"
 import { eqSet } from "../../util/set.js"
 import { MadWizardOptions } from "../../index.js"
 import { ChoiceState } from "../../choices/index.js"
+import { isEarlyExit } from "../../exec/EarlyExit.js"
 import { CodeBlockProps } from "../../codeblock/index.js"
 import { shellExec, isExport } from "../../exec/index.js"
 import indent from "../../parser/markdown/util/indent.js"
@@ -498,7 +499,9 @@ export class Guide {
         }
       }
     } catch (err) {
-      throw new Error(chalk.red(mainSymbols.cross) + " Run failed" + name + ": " + err.message)
+      if (!isEarlyExit(err)) {
+        throw new Error(chalk.red(mainSymbols.cross) + " Run failed" + name + ": " + err.message)
+      }
     }
   }
 }

--- a/test/inputs/33/in.md
+++ b/test/inputs/33/in.md
@@ -1,0 +1,12 @@
+```shell
+echo "this should be reachable"
+```
+
+```shell
+echo "stopping here"
+exit 90
+```
+
+```shell
+echo "this should not be reachable"
+```

--- a/test/inputs/33/run.txt
+++ b/test/inputs/33/run.txt
@@ -1,0 +1,5 @@
+echo "this should be reachable"
+this should be reachable
+echo "stopping here"
+exit 90
+stopping here

--- a/test/inputs/33/tree-noaprioris.txt
+++ b/test/inputs/33/tree-noaprioris.txt
@@ -1,0 +1,5 @@
+Sequence
+├── echo "this should be reachable"
+├── echo "stopping here"
+│   exit 90
+└── echo "this should not be reachable"

--- a/test/inputs/33/tree-noopt.txt
+++ b/test/inputs/33/tree-noopt.txt
@@ -1,0 +1,5 @@
+Sequence
+├── echo "this should be reachable"
+├── echo "stopping here"
+│   exit 90
+└── echo "this should not be reachable"

--- a/test/inputs/33/tree.txt
+++ b/test/inputs/33/tree.txt
@@ -1,0 +1,5 @@
+Sequence
+├── echo "this should be reachable"
+├── echo "stopping here"
+│   exit 90
+└── echo "this should not be reachable"

--- a/test/inputs/33/wizard-noaprioris.json
+++ b/test/inputs/33/wizard-noaprioris.json
@@ -1,0 +1,35 @@
+[
+  {
+    "graph": {
+      "body": "echo \"this should be reachable\"",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\necho \"this should be reachable\"\n```"
+    }
+  },
+  {
+    "graph": {
+      "body": "echo \"stopping here\"\nexit 90",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\necho \"stopping here\"\nexit 90\n```"
+    }
+  },
+  {
+    "graph": {
+      "body": "echo \"this should not be reachable\"",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\necho \"this should not be reachable\"\n```"
+    }
+  }
+]

--- a/test/inputs/33/wizard-noopt.json
+++ b/test/inputs/33/wizard-noopt.json
@@ -1,0 +1,35 @@
+[
+  {
+    "graph": {
+      "body": "echo \"this should be reachable\"",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\necho \"this should be reachable\"\n```"
+    }
+  },
+  {
+    "graph": {
+      "body": "echo \"stopping here\"\nexit 90",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\necho \"stopping here\"\nexit 90\n```"
+    }
+  },
+  {
+    "graph": {
+      "body": "echo \"this should not be reachable\"",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\necho \"this should not be reachable\"\n```"
+    }
+  }
+]

--- a/test/inputs/33/wizard.json
+++ b/test/inputs/33/wizard.json
@@ -1,0 +1,35 @@
+[
+  {
+    "graph": {
+      "body": "echo \"this should be reachable\"",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\necho \"this should be reachable\"\n```"
+    }
+  },
+  {
+    "graph": {
+      "body": "echo \"stopping here\"\nexit 90",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\necho \"stopping here\"\nexit 90\n```"
+    }
+  },
+  {
+    "graph": {
+      "body": "echo \"this should not be reachable\"",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\necho \"this should not be reachable\"\n```"
+    }
+  }
+]


### PR DESCRIPTION
They do so by exiting with code `90`:

```shell
echo "stopping here"
exit 90
```

See tests/input/33/in.md, and the README.md for more info.

re: 90, 
> The author of this document proposes restricting user-defined exit codes to the range 64 - 113 (in addition to 0, for success), to conform with the C/C++ standard
ref: https://tldp.org/LDP/abs/html/exitcodes.html