### PR TITLE
fix: stop publishing the guidebook store to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,4 +5,5 @@ tsconfig.json
 *~
 .*
 dist/types.d.ts.map
+dist/store
 *.tgz


### PR DESCRIPTION
BREAKING CHANGE: any consumers that want the store will now need to install `@guidebooks/store` themselves. They can then version the store on their own.