### PR TITLE
fix: broken variable expansions for users with zsh as their shell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest] # windows-latest
         node-version: [16.x]
         python-version: [3.9]
+        shell: [/bin/bash, /bin/zsh]
 
     steps:
     - uses: actions/checkout@v3
@@ -27,6 +28,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - name: Install zsh
+      run: if [ "$(uname)" = "Linux" ]; then sudo apt-get update; sudo apt-get install zsh; fi
     - run: npm ci
     - run: npm run build
-    - run: npm test
+    - run: export SHELL=${{ matrix.shell }}; npm test

--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -15,7 +15,7 @@ function opts {
 }
 
 echo -n A
-for i in {1..33}
+for i in {1..34}
 do
     if [ -n "$WHICH" ] && [ $i != $WHICH ]; then continue; fi
 
@@ -35,7 +35,7 @@ done
 echo
 
 echo -n B
-for i in {1..8} {11..18} {20..22} {24..33}
+for i in {1..8} {11..18} {20..22} {24..34}
 do
     if [ -n "$WHICH" ] && [ $i != $WHICH ]; then continue; fi
 

--- a/test/inputs/34/in.md
+++ b/test/inputs/34/in.md
@@ -1,0 +1,14 @@
+# Test support for zsh variable expansion
+
+By default zsh does not do word splitting on unquoted variable
+expansions. This test ensures that madwizard's shell executor has zsh
+behave like bash, in that `${=OPT}` is not needed to perform
+word-splitting.
+    
+```shell
+export OPT='-v foo=bar'
+```
+
+```shell
+awk ${OPT} 'BEGIN {print foo}'
+```

--- a/test/inputs/34/run.txt
+++ b/test/inputs/34/run.txt
@@ -1,0 +1,3 @@
+export OPT='-v foo=bar'
+awk ${OPT} 'BEGIN {print foo}'
+bar

--- a/test/inputs/34/tree-noaprioris.txt
+++ b/test/inputs/34/tree-noaprioris.txt
@@ -1,0 +1,3 @@
+Test support for zsh variable expansion
+├── export OPT='-v foo=bar'
+└── awk ${OPT} 'BEGIN {print foo}'

--- a/test/inputs/34/tree-noopt.txt
+++ b/test/inputs/34/tree-noopt.txt
@@ -1,0 +1,3 @@
+Test support for zsh variable expansion
+├── export OPT='-v foo=bar'
+└── awk ${OPT} 'BEGIN {print foo}'

--- a/test/inputs/34/tree.txt
+++ b/test/inputs/34/tree.txt
@@ -1,0 +1,3 @@
+Test support for zsh variable expansion
+├── export OPT='-v foo=bar'
+└── awk ${OPT} 'BEGIN {print foo}'

--- a/test/inputs/34/wizard-noaprioris.json
+++ b/test/inputs/34/wizard-noaprioris.json
@@ -1,0 +1,50 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Test support for zsh variable expansion",
+      "title": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "export OPT='-v foo=bar'",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Test support for zsh variable expansion",
+      "title": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "awk ${OPT} 'BEGIN {print foo}'",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n"
+    }
+  }
+]

--- a/test/inputs/34/wizard-noopt.json
+++ b/test/inputs/34/wizard-noopt.json
@@ -1,0 +1,50 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Test support for zsh variable expansion",
+      "title": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "export OPT='-v foo=bar'",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Test support for zsh variable expansion",
+      "title": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "awk ${OPT} 'BEGIN {print foo}'",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n"
+    }
+  }
+]

--- a/test/inputs/34/wizard.json
+++ b/test/inputs/34/wizard.json
@@ -1,0 +1,50 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Test support for zsh variable expansion",
+      "title": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "export OPT='-v foo=bar'",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Test support for zsh variable expansion",
+      "title": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "awk ${OPT} 'BEGIN {print foo}'",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Test support for zsh variable expansion",
+      "description": "By default zsh does not do word splitting on unquoted variable expansions. This test ensures that madwizard's shell executor has zsh behave like bash, in that `${=OPT}` is not needed to perform word-splitting.\n"
+    }
+  }
+]


### PR DESCRIPTION
zsh by default does not perform word splitting when it expands unquoted shell variables. as a result

```shell
export FOO='--namespace bar'
```

```shell
kubectl get pods ${FOO}
```

would result in an "unknown option '--namespace bar'" from kubectl.

This PR adds zsh to the test matrix.