### PR TITLE
fix: regression in file-level validation

### DIFF
--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -15,7 +15,7 @@ function opts {
 }
 
 echo -n A
-for i in {1..34}
+for i in {1..39}
 do
     if [ -n "$WHICH" ] && [ $i != $WHICH ]; then continue; fi
 
@@ -35,7 +35,7 @@ done
 echo
 
 echo -n B
-for i in {1..8} {11..18} {20..22} {24..34}
+for i in {1..8} {11..18} {20..22} {24..39}
 do
     if [ -n "$WHICH" ] && [ $i != $WHICH ]; then continue; fi
 

--- a/src/graph/compile.ts
+++ b/src/graph/compile.ts
@@ -30,6 +30,7 @@ import {
   seq,
   sequence,
   subtask,
+  isValidatable,
 } from "./index.js"
 
 import { Memos } from "../memoization/index.js"
@@ -144,6 +145,19 @@ export async function compile(
       }
     }
 
+    /** Find the nearest enclosing Import, and return its validation */
+    const nearestValidate = () => {
+      for (let idx = currentNesting.length - 1; idx >= 0; idx--) {
+        const nest = currentNesting[idx]
+        if (isImportNesting(nest)) {
+          if (isValidatable(nest.graph)) {
+            return nest.graph.validate
+          }
+          break
+        }
+      }
+    }
+
     const newChoice = (block: CodeBlockProps, parent: CodeBlockChoice, isDeepest: boolean) => ({
       member: parent.member,
       graph: isDeepest ? seq(block) : emptySequence(),
@@ -168,6 +182,7 @@ export async function compile(
         source: parent.groupDetail.source,
         provenance: currentProvenance(),
         choices: [newChoice(block, parent, isDeepest)],
+        validate: nearestValidate(),
       }
     }
 

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -140,6 +140,7 @@ export type ChoicePart<T extends Unordered | Ordered = Unordered> = Title &
 export type Choice<T extends Unordered | Ordered = Unordered> = Source &
   T &
   Title &
+  Partial<Validatable> &
   Partial<Provenance> & {
     /** identifier for this choice */
     group: ChoiceGroup
@@ -234,8 +235,13 @@ export function subtask<T extends Unordered | Ordered = Unordered>(
 }
 
 /** @return a `Graph` that inherits the given `EnTitled` properties */
-export function withTitle(block: LeafNode, { title, description, source }: EnTitled, barrier = false) {
-  return subtask(title, title, title, description, "", seq(block), source, barrier)
+export function withTitle(
+  block: LeafNode,
+  { title, description, source }: EnTitled,
+  barrier = false,
+  validate?: Validatable["validate"]
+) {
+  return subtask(title, title, title, description, "", seq(block), source, barrier, validate)
 }
 
 export function asSubTask(step: TitledStep): SubTask {

--- a/test/inputs/10/wizard-darwin.json
+++ b/test/inputs/10/wizard-darwin.json
@@ -38,7 +38,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/10/wizard-linux.json
+++ b/test/inputs/10/wizard-linux.json
@@ -38,7 +38,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/10/wizard-noaprioris.json
+++ b/test/inputs/10/wizard-noaprioris.json
@@ -93,7 +93,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/10/wizard-noopt.json
+++ b/test/inputs/10/wizard-noopt.json
@@ -91,7 +91,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/10/wizard-win32.json
+++ b/test/inputs/10/wizard-win32.json
@@ -38,7 +38,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/12/wizard-noaprioris.json
+++ b/test/inputs/12/wizard-noaprioris.json
@@ -17,7 +17,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": "echo true"
     },
     "step": {
       "name": "Codeblocks in enclosing markdown",

--- a/test/inputs/12/wizard-noopt.json
+++ b/test/inputs/12/wizard-noopt.json
@@ -17,7 +17,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": "echo true"
     },
     "step": {
       "name": "Codeblocks in enclosing markdown",

--- a/test/inputs/12/wizard.json
+++ b/test/inputs/12/wizard.json
@@ -17,7 +17,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": "echo true"
     },
     "step": {
       "name": "Codeblocks in enclosing markdown",

--- a/test/inputs/17/wizard-noaprioris.json
+++ b/test/inputs/17/wizard-noaprioris.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/17/wizard-noopt.json
+++ b/test/inputs/17/wizard-noopt.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/17/wizard.json
+++ b/test/inputs/17/wizard.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/21/wizard-noaprioris.json
+++ b/test/inputs/21/wizard-noaprioris.json
@@ -113,7 +113,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": "[ \"$FOO\" = \"2:3\" ]"
     },
     "step": {
       "name": "Propagation check",

--- a/test/inputs/21/wizard-noopt.json
+++ b/test/inputs/21/wizard-noopt.json
@@ -113,7 +113,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": "[ \"$FOO\" = \"2:3\" ]"
     },
     "step": {
       "name": "Propagation check",

--- a/test/inputs/21/wizard.json
+++ b/test/inputs/21/wizard.json
@@ -113,7 +113,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": "[ \"$FOO\" = \"2:3\" ]"
     },
     "step": {
       "name": "Propagation check",

--- a/test/inputs/3/wizard-noaprioris.json
+++ b/test/inputs/3/wizard-noaprioris.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/3/wizard-noopt.json
+++ b/test/inputs/3/wizard-noopt.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/3/wizard.json
+++ b/test/inputs/3/wizard.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/35/foo.md
+++ b/test/inputs/35/foo.md
@@ -1,0 +1,7 @@
+---
+validate: true
+---
+
+```shell
+echo "Bug if this is printed"
+```

--- a/test/inputs/35/in.md
+++ b/test/inputs/35/in.md
@@ -1,0 +1,13 @@
+---
+imports:
+    - ./foo.md
+---
+
+# Yo
+
+Testing file-level validation.
+
+```shell
+echo "This should be printed"
+```
+

--- a/test/inputs/35/run.txt
+++ b/test/inputs/35/run.txt
@@ -1,0 +1,2 @@
+echo "This should be printed"
+This should be printed

--- a/test/inputs/35/tree-noaprioris.txt
+++ b/test/inputs/35/tree-noaprioris.txt
@@ -1,0 +1,6 @@
+Yo
+├── Prerequisites
+│   └── foo.md
+│       └── echo "Bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/35/tree-noopt.txt
+++ b/test/inputs/35/tree-noopt.txt
@@ -1,0 +1,5 @@
+Yo
+├── foo.md
+│   └── echo "Bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/35/tree.txt
+++ b/test/inputs/35/tree.txt
@@ -1,0 +1,6 @@
+Yo
+├── Prerequisites
+│   └── foo.md
+│       └── echo "Bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/35/wizard-noaprioris.json
+++ b/test/inputs/35/wizard-noaprioris.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/35/wizard-noopt.json
+++ b/test/inputs/35/wizard-noopt.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/35/wizard.json
+++ b/test/inputs/35/wizard.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/36/foo.md
+++ b/test/inputs/36/foo.md
@@ -1,0 +1,9 @@
+---
+validate: true
+---
+
+# Nope
+
+```shell
+echo "Bug if this is printed"
+```

--- a/test/inputs/36/in.md
+++ b/test/inputs/36/in.md
@@ -1,0 +1,13 @@
+---
+imports:
+    - ./foo.md
+---
+
+# Yo
+
+Testing file-level validation.
+
+```shell
+echo "This should be printed"
+```
+

--- a/test/inputs/36/run.txt
+++ b/test/inputs/36/run.txt
@@ -1,0 +1,2 @@
+echo "This should be printed"
+This should be printed

--- a/test/inputs/36/tree-noaprioris.txt
+++ b/test/inputs/36/tree-noaprioris.txt
@@ -1,0 +1,6 @@
+Yo
+├── Prerequisites
+│   └── Nope
+│       └── echo "Bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/36/tree-noopt.txt
+++ b/test/inputs/36/tree-noopt.txt
@@ -1,0 +1,5 @@
+Yo
+├── Nope
+│   └── echo "Bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/36/tree.txt
+++ b/test/inputs/36/tree.txt
@@ -1,0 +1,6 @@
+Yo
+├── Prerequisites
+│   └── Nope
+│       └── echo "Bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/36/wizard-noaprioris.json
+++ b/test/inputs/36/wizard-noaprioris.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Nope",
+      "title": "Nope",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "Nope"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/36/wizard-noopt.json
+++ b/test/inputs/36/wizard-noopt.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Nope",
+      "title": "Nope",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "Nope"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/36/wizard.json
+++ b/test/inputs/36/wizard.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Nope",
+      "title": "Nope",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "Nope"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/37/foo.md
+++ b/test/inputs/37/foo.md
@@ -1,0 +1,7 @@
+---
+validate: false
+---
+
+```shell
+echo "Ok if this is printed"
+```

--- a/test/inputs/37/in.md
+++ b/test/inputs/37/in.md
@@ -1,0 +1,13 @@
+---
+imports:
+    - ./foo.md
+---
+
+# Yo
+
+Testing file-level validation.
+
+```shell
+echo "This should be printed"
+```
+

--- a/test/inputs/37/run.txt
+++ b/test/inputs/37/run.txt
@@ -1,0 +1,4 @@
+echo "Ok if this is printed"
+Ok if this is printed
+echo "This should be printed"
+This should be printed

--- a/test/inputs/37/tree-noaprioris.txt
+++ b/test/inputs/37/tree-noaprioris.txt
@@ -1,0 +1,6 @@
+Yo
+├── Prerequisites
+│   └── foo.md
+│       └── echo "Ok if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/37/tree-noopt.txt
+++ b/test/inputs/37/tree-noopt.txt
@@ -1,0 +1,5 @@
+Yo
+├── foo.md
+│   └── echo "Ok if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/37/tree.txt
+++ b/test/inputs/37/tree.txt
@@ -1,0 +1,6 @@
+Yo
+├── Prerequisites
+│   └── foo.md
+│       └── echo "Ok if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/37/wizard-noaprioris.json
+++ b/test/inputs/37/wizard-noaprioris.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Ok if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": false
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/37/wizard-noopt.json
+++ b/test/inputs/37/wizard-noopt.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Ok if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": false
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/37/wizard.json
+++ b/test/inputs/37/wizard.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Ok if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": false
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/38/foo.md
+++ b/test/inputs/38/foo.md
@@ -1,0 +1,7 @@
+---
+validate: true
+---
+
+```shell
+echo "Bug if this is printed"
+```

--- a/test/inputs/38/in.md
+++ b/test/inputs/38/in.md
@@ -1,0 +1,10 @@
+# Yo
+
+Testing file-level validation.
+
+```shell
+echo "This should be printed"
+```
+
+:import{./foo.md}
+

--- a/test/inputs/38/run.txt
+++ b/test/inputs/38/run.txt
@@ -1,0 +1,2 @@
+echo "This should be printed"
+This should be printed

--- a/test/inputs/38/tree-noaprioris.txt
+++ b/test/inputs/38/tree-noaprioris.txt
@@ -1,0 +1,6 @@
+Yo
+├── Prerequisites
+│   └── foo.md
+│       └── echo "Bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/38/tree-noopt.txt
+++ b/test/inputs/38/tree-noopt.txt
@@ -1,0 +1,5 @@
+Yo
+├── Yo
+│   └── echo "This should be printed"
+└── foo.md
+    └── echo "Bug if this is printed"

--- a/test/inputs/38/tree.txt
+++ b/test/inputs/38/tree.txt
@@ -1,0 +1,6 @@
+Yo
+├── Prerequisites
+│   └── foo.md
+│       └── echo "Bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/38/wizard-noaprioris.json
+++ b/test/inputs/38/wizard-noaprioris.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/38/wizard-noopt.json
+++ b/test/inputs/38/wizard-noopt.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  }
+]

--- a/test/inputs/38/wizard.json
+++ b/test/inputs/38/wizard.json
@@ -1,0 +1,49 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if this is printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/39/foo.md
+++ b/test/inputs/39/foo.md
@@ -1,0 +1,17 @@
+---
+validate: true
+---
+
+```shell
+echo "Bug if any of this is printed."
+```
+
+=== "Tab1"
+    ```shell
+    echo "Bug if this is printed"
+    ```
+
+=== "Tab2"
+    ```shell
+    echo "Also a bug if this is printed"
+    ```

--- a/test/inputs/39/in.md
+++ b/test/inputs/39/in.md
@@ -1,0 +1,13 @@
+---
+imports:
+    - ./foo.md
+---
+
+# Yo
+
+Testing file-level validation.
+
+```shell
+echo "This should be printed"
+```
+

--- a/test/inputs/39/run.txt
+++ b/test/inputs/39/run.txt
@@ -1,0 +1,2 @@
+echo "This should be printed"
+This should be printed

--- a/test/inputs/39/tree-noaprioris.txt
+++ b/test/inputs/39/tree-noaprioris.txt
@@ -1,0 +1,11 @@
+Yo
+├── Prerequisites
+│   └── foo.md
+│       ├── echo "Bug if any of this is printed."
+│       └── foo.md
+│           ├── Option 1: Tab1
+│           │   └── echo "Bug if this is printed"
+│           └── Option 2: Tab2
+│               └── echo "Also a bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/39/tree-noopt.txt
+++ b/test/inputs/39/tree-noopt.txt
@@ -1,0 +1,10 @@
+Yo
+├── foo.md
+│   ├── echo "Bug if any of this is printed."
+│   └── Missing heading for choice
+│       ├── Option 1: Tab1
+│       │   └── echo "Bug if this is printed"
+│       └── Option 2: Tab2
+│           └── echo "Also a bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/39/tree.txt
+++ b/test/inputs/39/tree.txt
@@ -1,0 +1,11 @@
+Yo
+├── Prerequisites
+│   └── foo.md
+│       ├── echo "Bug if any of this is printed."
+│       └── foo.md
+│           ├── Option 1: Tab1
+│           │   └── echo "Bug if this is printed"
+│           └── Option 2: Tab2
+│               └── echo "Also a bug if this is printed"
+└── Yo
+    └── echo "This should be printed"

--- a/test/inputs/39/wizard-noaprioris.json
+++ b/test/inputs/39/wizard-noaprioris.json
@@ -1,0 +1,107 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if any of this is printed.\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "group": "Tab1####Tab2",
+      "groupContext": "Tab1####Tab2",
+      "title": "foo.md",
+      "source": "placeholder",
+      "provenance": ["test/inputs/39/foo.md"],
+      "choices": [
+        {
+          "member": 0,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo \"Bug if this is printed\"",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Tab1"
+        },
+        {
+          "member": 1,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo \"Also a bug if this is printed\"",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Tab2"
+        }
+      ],
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md",
+      "description": "This step requires you to choose how to proceed",
+      "content": [
+        {
+          "title": "Tab1",
+          "group": "Tab1####Tab2",
+          "member": 0,
+          "isFirstChoice": true
+        },
+        {
+          "title": "Tab2",
+          "group": "Tab1####Tab2",
+          "member": 1,
+          "isFirstChoice": true
+        }
+      ]
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/39/wizard-noopt.json
+++ b/test/inputs/39/wizard-noopt.json
@@ -1,0 +1,105 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if any of this is printed.\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "group": "Tab1####Tab2",
+      "groupContext": "Tab1####Tab2",
+      "source": "placeholder",
+      "provenance": ["test/inputs/39/foo.md"],
+      "choices": [
+        {
+          "member": 0,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo \"Bug if this is printed\"",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Tab1"
+        },
+        {
+          "member": 1,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo \"Also a bug if this is printed\"",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Tab2"
+        }
+      ],
+      "validate": true
+    },
+    "step": {
+      "description": "This step requires you to choose how to proceed",
+      "content": [
+        {
+          "title": "Tab1",
+          "group": "Tab1####Tab2",
+          "member": 0,
+          "isFirstChoice": true
+        },
+        {
+          "title": "Tab2",
+          "group": "Tab1####Tab2",
+          "member": 1,
+          "isFirstChoice": true
+        }
+      ]
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/39/wizard.json
+++ b/test/inputs/39/wizard.json
@@ -1,0 +1,107 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "foo.md",
+      "title": "foo.md",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"Bug if any of this is printed.\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder",
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md"
+    }
+  },
+  {
+    "graph": {
+      "group": "Tab1####Tab2",
+      "groupContext": "Tab1####Tab2",
+      "title": "foo.md",
+      "source": "placeholder",
+      "provenance": ["test/inputs/39/foo.md"],
+      "choices": [
+        {
+          "member": 0,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo \"Bug if this is printed\"",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Tab1"
+        },
+        {
+          "member": 1,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo \"Also a bug if this is printed\"",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Tab2"
+        }
+      ],
+      "validate": true
+    },
+    "step": {
+      "name": "foo.md",
+      "description": "This step requires you to choose how to proceed",
+      "content": [
+        {
+          "title": "Tab1",
+          "group": "Tab1####Tab2",
+          "member": 0,
+          "isFirstChoice": true
+        },
+        {
+          "title": "Tab2",
+          "group": "Tab1####Tab2",
+          "member": 1,
+          "isFirstChoice": true
+        }
+      ]
+    }
+  },
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Yo",
+      "title": "Yo",
+      "description": "Testing file-level validation.\n",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo \"This should be printed\"",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Yo",
+      "description": "Testing file-level validation.\n"
+    }
+  }
+]

--- a/test/inputs/4/wizard-noaprioris.json
+++ b/test/inputs/4/wizard-noaprioris.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/4/wizard-noopt.json
+++ b/test/inputs/4/wizard-noopt.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/4/wizard.json
+++ b/test/inputs/4/wizard.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/5/wizard-noaprioris.json
+++ b/test/inputs/5/wizard-noaprioris.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/5/wizard-noopt.json
+++ b/test/inputs/5/wizard-noopt.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/5/wizard.json
+++ b/test/inputs/5/wizard.json
@@ -16,7 +16,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/6/wizard-noaprioris.json
+++ b/test/inputs/6/wizard-noaprioris.json
@@ -88,7 +88,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/6/wizard-noopt.json
+++ b/test/inputs/6/wizard-noopt.json
@@ -88,7 +88,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/6/wizard.json
+++ b/test/inputs/6/wizard.json
@@ -88,7 +88,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/7/wizard-noaprioris.json
+++ b/test/inputs/7/wizard-noaprioris.json
@@ -88,7 +88,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/7/wizard-noopt.json
+++ b/test/inputs/7/wizard-noopt.json
@@ -88,7 +88,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/7/wizard.json
+++ b/test/inputs/7/wizard.json
@@ -88,7 +88,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/9/wizard-darwin.json
+++ b/test/inputs/9/wizard-darwin.json
@@ -38,7 +38,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/9/wizard-linux.json
+++ b/test/inputs/9/wizard-linux.json
@@ -38,7 +38,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/9/wizard-noaprioris.json
+++ b/test/inputs/9/wizard-noaprioris.json
@@ -93,7 +93,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/9/wizard-noopt.json
+++ b/test/inputs/9/wizard-noopt.json
@@ -91,7 +91,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {

--- a/test/inputs/9/wizard-win32.json
+++ b/test/inputs/9/wizard-win32.json
@@ -38,7 +38,8 @@
           }
         ]
       },
-      "source": "placeholder"
+      "source": "placeholder",
+      "validate": true
     },
     "status": "success",
     "step": {


### PR DESCRIPTION
We recently stopped prematurely pruning the task graph based on validation clauses. Unfortunately this caused a regression in support for file-level (frontmatter at the top of the a file.md) validation.