### PR TITLE
feat: new `--ifor` option (interactive only for a given guidebook)

### DIFF
--- a/src/fe/MadWizardOptions.ts
+++ b/src/fe/MadWizardOptions.ts
@@ -19,11 +19,12 @@ import { CompilerOptions } from "../graph/compile"
 export interface RunOptions {
   /**
    * Interactive mode: even if a choice has a prior selection that is
-   * still valid, ask the user again to make that choice. Note, in interactive mode, some attempt will still be madxxe
-   * to notify the user of their prior choices, and to prioritize the
-   * UI to highlight those prior choices. [default: true]
+   * still valid, ask the user again to make that choice.
    */
   interactive: boolean
+
+  /** Interactive mode for a given guidebook */
+  ifor: string
 
   /** Don't actually execute anything, but making choices and
    * validation and expanding lists is ok

--- a/src/fe/guide/index.ts
+++ b/src/fe/guide/index.ts
@@ -113,7 +113,14 @@ export class Guide {
       const thisChoiceIsAForm = isForm(content)
       const suggestionForm = !thisChoiceIsAForm || !suggestion ? {} : JSON.parse(suggestion)
 
-      if (suggestion && !this.options.interactive) {
+      // should we ask the user to answer/re-answer this question? yes
+      // if a) we have no suggestion; or b) we were asked to run in
+      // interactive mode always, interactive === true; or c) we were
+      // asked to run in interactive mode for the last question, and
+      // this is the last question
+      const askIt = !suggestion || this.options.interactive === true || this.options.ifor === choice.groupContext
+
+      if (!askIt) {
         if (thisChoiceIsAForm) {
           if (suggestionForm && eqSet(new Set(Object.keys(suggestionForm)), new Set(content.map((_) => _.title)))) {
             return {


### PR DESCRIPTION
This PR adds this option, which allows for a run that only asks the user questions in the given guidebook.