### PR TITLE
fix: make sure to redact RAY_ADDRESS env var

### DIFF
--- a/src/exec/ray-submit.ts
+++ b/src/exec/ray-submit.ts
@@ -127,6 +127,7 @@ async function saveEnvToFile(
   // visibility in the ray workers; keep it as __PATH for debugging
   const curatedEnvVars = Object.assign({ __PATH: memos.env.PATH }, memos.env)
   delete curatedEnvVars.PATH
+  delete curatedEnvVars.RAY_ADDRESS
 
   const runtimeEnv: Record<string, any> = Object.assign(
     {},


### PR DESCRIPTION
Ray is a bit particular here. If we pass through a RAY_ADDRESS with an http:// prefix, one may see this:

https://github.com/ray-project/ray/issues/21592

> AssertionError: Module: http does not have ClientBuilder