### PR TITLE
feat: allow guidebooks to specify a choice via env var

### DIFF
--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -25,7 +25,7 @@ export STORE="--store $PWD"
 FAKEENV=$(mktemp)
 
 echo -n A
-for i in {1..40}
+for i in {1..41}
 do
     if [ -n "$WHICH" ] && [ $i != $WHICH ]; then continue; fi
 
@@ -51,7 +51,7 @@ done
 echo
 
 echo -n B
-for i in {1..8} {11..18} {20..22} {24..40}
+for i in {1..8} {11..18} {20..22} {24..41}
 do
     if [ -n "$WHICH" ] && [ $i != $WHICH ]; then continue; fi
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "format": "cross-env prettier --write '**/*.{scss,css,html,js,json,md,ts,tsx}'",
     "format:test:input": "cross-env prettier --write test/inputs",
     "mirror": "T=$(mktemp -d); (cd $T && git clone --depth=1 git@github.com:guidebooks/store.git) && echo \"mirror stage in $T/store\" && ./bin/madwizard.js mirror $T/store/guidebooks $PWD/dist/store",
-    "prepack": "npm run build && npm run mirror && npm test && cp src/version.json dist/version.json",
     "prepare": "cross-env husky install"
   },
   "keywords": [

--- a/test/inputs/41/in.md
+++ b/test/inputs/41/in.md
@@ -1,0 +1,14 @@
+```shell
+export KEY=333
+```
+
+=== "expand(garbage this should fail if ever executed, Testing env var keying, KEY)"
+    ```shell
+    echo "These two should be equal $choice===$KEY"
+    ```
+
+=== "Alternate plan"
+    ```shell
+    echo "Error if we get here"
+    exit 90
+    ```

--- a/test/inputs/41/run-noaprioris.txt
+++ b/test/inputs/41/run-noaprioris.txt
@@ -1,0 +1,3 @@
+export KEY=333
+echo "These two should be equal 333===$KEY"
+These two should be equal 333===333

--- a/test/inputs/41/run-noopt.txt
+++ b/test/inputs/41/run-noopt.txt
@@ -1,0 +1,2 @@
+export KEY=333
+Unable to run this guidebook, due to 1 unresolved question

--- a/test/inputs/41/run.txt
+++ b/test/inputs/41/run.txt
@@ -1,0 +1,3 @@
+export KEY=333
+echo "These two should be equal 333===$KEY"
+These two should be equal 333===333

--- a/test/inputs/41/tree-noaprioris.txt
+++ b/test/inputs/41/tree-noaprioris.txt
@@ -1,0 +1,6 @@
+Sequence
+├── export KEY=333
+└── Missing heading for choice
+    └── Option 2: Alternate plan
+        └── echo "Error if we get here"
+            exit 90

--- a/test/inputs/41/tree-noopt.txt
+++ b/test/inputs/41/tree-noopt.txt
@@ -1,0 +1,6 @@
+Sequence
+├── export KEY=333
+└── Missing heading for choice
+    └── Option 2: Alternate plan
+        └── echo "Error if we get here"
+            exit 90

--- a/test/inputs/41/tree.txt
+++ b/test/inputs/41/tree.txt
@@ -1,0 +1,6 @@
+Sequence
+├── export KEY=333
+└── Missing heading for choice
+    └── Option 2: Alternate plan
+        └── echo "Error if we get here"
+            exit 90

--- a/test/inputs/41/wizard-noaprioris.json
+++ b/test/inputs/41/wizard-noaprioris.json
@@ -1,0 +1,46 @@
+[
+  {
+    "graph": {
+      "body": "export KEY=333",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\nexport KEY=333\n```"
+    }
+  },
+  {
+    "graph": {
+      "group": "expand(garbage this should fail if ever executed, Testing env var keying, KEY)####Alternate plan",
+      "groupContext": "expand(garbage this should fail if ever executed, Testing env var keying, KEY)####Alternate plan",
+      "source": "placeholder",
+      "choices": [
+        {
+          "member": 1,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo \"Error if we get here\"\nexit 90",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Alternate plan"
+        }
+      ]
+    },
+    "step": {
+      "content": [
+        {
+          "title": "Alternate plan",
+          "group": "expand(garbage this should fail if ever executed, Testing env var keying, KEY)####Alternate plan",
+          "member": 1,
+          "isFirstChoice": true
+        }
+      ]
+    }
+  }
+]

--- a/test/inputs/41/wizard-noopt.json
+++ b/test/inputs/41/wizard-noopt.json
@@ -1,0 +1,46 @@
+[
+  {
+    "graph": {
+      "body": "export KEY=333",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\nexport KEY=333\n```"
+    }
+  },
+  {
+    "graph": {
+      "group": "expand(garbage this should fail if ever executed, Testing env var keying, KEY)####Alternate plan",
+      "groupContext": "expand(garbage this should fail if ever executed, Testing env var keying, KEY)####Alternate plan",
+      "source": "placeholder",
+      "choices": [
+        {
+          "member": 1,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo \"Error if we get here\"\nexit 90",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Alternate plan"
+        }
+      ]
+    },
+    "step": {
+      "content": [
+        {
+          "title": "Alternate plan",
+          "group": "expand(garbage this should fail if ever executed, Testing env var keying, KEY)####Alternate plan",
+          "member": 1,
+          "isFirstChoice": true
+        }
+      ]
+    }
+  }
+]

--- a/test/inputs/41/wizard.json
+++ b/test/inputs/41/wizard.json
@@ -1,0 +1,46 @@
+[
+  {
+    "graph": {
+      "body": "export KEY=333",
+      "language": "shell",
+      "id": "somekey"
+    },
+    "step": {
+      "name": "Missing title",
+      "content": "```shell\nexport KEY=333\n```"
+    }
+  },
+  {
+    "graph": {
+      "group": "expand(garbage this should fail if ever executed, Testing env var keying, KEY)####Alternate plan",
+      "groupContext": "expand(garbage this should fail if ever executed, Testing env var keying, KEY)####Alternate plan",
+      "source": "placeholder",
+      "choices": [
+        {
+          "member": 1,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo \"Error if we get here\"\nexit 90",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Alternate plan"
+        }
+      ]
+    },
+    "step": {
+      "content": [
+        {
+          "title": "Alternate plan",
+          "group": "expand(garbage this should fail if ever executed, Testing env var keying, KEY)####Alternate plan",
+          "member": 1,
+          "isFirstChoice": true
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
If a tab expansion has the form:
```markdown
=== "expand(expr, message, key)"
```

i.e. it specifies the third argument `key`, then `key` will be interpreted as the name of an environment variable. If that environment variable has a value, then this value will be used not only as the result of the expansion, but also will be forced through as the desired choice.

This feature allows one guidebook to control another. For example, guidebook A may initialize some cluster resources. Later, guidebook B will want to clean up those resources. The names to be cleaned up should match, but guidebook B may also want to be general-purpose to allow any specified (i.e. via  choice) resource to be cleaned up.

See tests/input/41/in.md for an example.