### PR TITLE
fix: choice descriptions with non-plain text may be cropped

### DIFF
--- a/bin/regen.sh
+++ b/bin/regen.sh
@@ -25,7 +25,7 @@ export STORE="--store $PWD"
 FAKEENV=$(mktemp)
 
 echo -n A
-for i in {1..41}
+for i in {1..42}
 do
     if [ -n "$WHICH" ] && [ $i != $WHICH ]; then continue; fi
 
@@ -51,7 +51,7 @@ done
 echo
 
 echo -n B
-for i in {1..8} {11..18} {20..22} {24..41}
+for i in {1..8} {11..18} {20..22} {24..42}
 do
     if [ -n "$WHICH" ] && [ $i != $WHICH ]; then continue; fi
 

--- a/src/parser/markdown/util/isElement.ts
+++ b/src/parser/markdown/util/isElement.ts
@@ -17,12 +17,39 @@
 import { Node, Parent } from "unist"
 import { Element, ElementContent, Literal, Root, Text } from "hast"
 
+type ElementWithTag<T extends string> = Element & { tagName: T }
+type Pre = ElementWithTag<"pre">
+type Anchor = ElementWithTag<"a">
+type Strong = ElementWithTag<"strong">
+type Em = ElementWithTag<"em">
+
 export function isLiteral(node: Node): node is Literal {
   return typeof (node as Literal).value === "string"
 }
 
 export function isText(node: Node): node is Text {
   return node.type === "text" && typeof (node as Text).value === "string"
+}
+
+export function isPre(node: Node): node is Pre {
+  return isElementWithProperties(node) && node.tagName === "pre"
+}
+
+export function isAnchor(node): node is Anchor {
+  return isElementWithProperties(node) && node.tagName === "a"
+}
+
+export function isStrong(node): node is Strong {
+  return isElementWithProperties(node) && node.tagName === "strong"
+}
+
+export function isEm(node): node is Em {
+  return isElementWithProperties(node) && node.tagName === "em"
+}
+
+/** Is this content without an implicit prefix line break? */
+export function isInlineContent(node: Node): boolean {
+  return isText(node) || isAnchor(node) || isStrong(node) || isEm(node)
 }
 
 export function isParagraph(node: Node): node is Element & { tagName: "p" } {

--- a/src/parser/markdown/util/toMarkdownString.ts
+++ b/src/parser/markdown/util/toMarkdownString.ts
@@ -16,6 +16,7 @@
 
 import { u } from "unist-builder"
 import { Raw } from "hast-util-raw"
+import { Node as UNode } from "unist"
 import { toMdast } from "hast-util-to-mdast"
 import { Content, Element, Parent } from "hast"
 import { visit, CONTINUE, SKIP } from "unist-util-visit"
@@ -163,7 +164,8 @@ function munge(root: Node): Node {
   return paragraphs(stringifyTabs(pruneComments(pruneImports(root))))
 }
 
-export type Something = Node | Content | Parent
+/** The types of content that we know how to turn into a markdown string */
+export type Something = Node | Content | Parent | UNode
 
 function hasValue(node: Something): node is Something & { value: string } {
   return typeof (node as { value: string }).value === "string"

--- a/test/inputs/19/wizard-noaprioris.json
+++ b/test/inputs/19/wizard-noaprioris.json
@@ -188,7 +188,7 @@
                                                 ]
                                               },
                                               "title": "Miniconda",
-                                              "description": "\nMiniconda is a free minimal installer for conda. It is a small, bootstrap version of Anaconda that includes only conda, Python, the packages they depend on, and a small number of other useful packages, including pip, zlib and a few others. "
+                                              "description": "\nMiniconda is a free minimal installer for conda. It is a small, bootstrap version of Anaconda that includes only conda, Python, the packages they depend on, and a small number of other useful packages, including pip, zlib and a few others. [See if Miniconda is right for you.](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda)"
                                             },
                                             {
                                               "member": 1,

--- a/test/inputs/19/wizard-noopt.json
+++ b/test/inputs/19/wizard-noopt.json
@@ -184,7 +184,7 @@
                                                 ]
                                               },
                                               "title": "Miniconda",
-                                              "description": "\nMiniconda is a free minimal installer for conda. It is a small, bootstrap version of Anaconda that includes only conda, Python, the packages they depend on, and a small number of other useful packages, including pip, zlib and a few others. "
+                                              "description": "\nMiniconda is a free minimal installer for conda. It is a small, bootstrap version of Anaconda that includes only conda, Python, the packages they depend on, and a small number of other useful packages, including pip, zlib and a few others. [See if Miniconda is right for you.](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda)"
                                             },
                                             {
                                               "member": 1,

--- a/test/inputs/23/wizard-darwin.json
+++ b/test/inputs/23/wizard-darwin.json
@@ -330,7 +330,7 @@
                             ]
                           },
                           "title": "New Dataset from Range",
-                          "description": "\nGet started by creating Datasets from synthetic data using\n"
+                          "description": "\nGet started by creating Datasets from synthetic data using"
                         },
                         {
                           "member": 1,
@@ -345,7 +345,7 @@
                             ]
                           },
                           "title": "New Dataset from File",
-                          "description": "\nDatasets can be created from files on local disk or remote datasources\nsuch as S3. Any filesystem "
+                          "description": "\nDatasets can be created from files on local disk or remote datasources\nsuch as S3. Any filesystem [supported by pyarrow](http://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html)"
                         }
                       ]
                     }

--- a/test/inputs/23/wizard-linux.json
+++ b/test/inputs/23/wizard-linux.json
@@ -330,7 +330,7 @@
                             ]
                           },
                           "title": "New Dataset from Range",
-                          "description": "\nGet started by creating Datasets from synthetic data using\n"
+                          "description": "\nGet started by creating Datasets from synthetic data using"
                         },
                         {
                           "member": 1,
@@ -345,7 +345,7 @@
                             ]
                           },
                           "title": "New Dataset from File",
-                          "description": "\nDatasets can be created from files on local disk or remote datasources\nsuch as S3. Any filesystem "
+                          "description": "\nDatasets can be created from files on local disk or remote datasources\nsuch as S3. Any filesystem [supported by pyarrow](http://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html)"
                         }
                       ]
                     }

--- a/test/inputs/23/wizard-noaprioris.json
+++ b/test/inputs/23/wizard-noaprioris.json
@@ -168,7 +168,7 @@
                                       ]
                                     },
                                     "title": "Install Miniconda",
-                                    "description": "\nMiniconda is a free minimal installer for conda. It is a small, bootstrap version of Anaconda that includes only conda, Python, the packages they depend on, and a small number of other useful packages, including pip, zlib and a few others. "
+                                    "description": "\nMiniconda is a free minimal installer for conda. It is a small, bootstrap version of Anaconda that includes only conda, Python, the packages they depend on, and a small number of other useful packages, including pip, zlib and a few others. [See if Miniconda is right for you.](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda)"
                                   },
                                   {
                                     "member": 1,
@@ -909,7 +909,7 @@
                             ]
                           },
                           "title": "New Dataset from Range",
-                          "description": "\nGet started by creating Datasets from synthetic data using\n"
+                          "description": "\nGet started by creating Datasets from synthetic data using"
                         },
                         {
                           "member": 1,
@@ -924,7 +924,7 @@
                             ]
                           },
                           "title": "New Dataset from File",
-                          "description": "\nDatasets can be created from files on local disk or remote datasources\nsuch as S3. Any filesystem "
+                          "description": "\nDatasets can be created from files on local disk or remote datasources\nsuch as S3. Any filesystem [supported by pyarrow](http://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html)"
                         }
                       ]
                     }

--- a/test/inputs/23/wizard-noopt.json
+++ b/test/inputs/23/wizard-noopt.json
@@ -164,7 +164,7 @@
                                       ]
                                     },
                                     "title": "Install Miniconda",
-                                    "description": "\nMiniconda is a free minimal installer for conda. It is a small, bootstrap version of Anaconda that includes only conda, Python, the packages they depend on, and a small number of other useful packages, including pip, zlib and a few others. "
+                                    "description": "\nMiniconda is a free minimal installer for conda. It is a small, bootstrap version of Anaconda that includes only conda, Python, the packages they depend on, and a small number of other useful packages, including pip, zlib and a few others. [See if Miniconda is right for you.](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda)"
                                   },
                                   {
                                     "member": 1,
@@ -878,7 +878,7 @@
                       ]
                     },
                     "title": "New Dataset from Range",
-                    "description": "\nGet started by creating Datasets from synthetic data using\n"
+                    "description": "\nGet started by creating Datasets from synthetic data using"
                   },
                   {
                     "member": 1,
@@ -893,7 +893,7 @@
                       ]
                     },
                     "title": "New Dataset from File",
-                    "description": "\nDatasets can be created from files on local disk or remote datasources\nsuch as S3. Any filesystem "
+                    "description": "\nDatasets can be created from files on local disk or remote datasources\nsuch as S3. Any filesystem [supported by pyarrow](http://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html)"
                   }
                 ]
               }

--- a/test/inputs/23/wizard-win32.json
+++ b/test/inputs/23/wizard-win32.json
@@ -330,7 +330,7 @@
                             ]
                           },
                           "title": "New Dataset from Range",
-                          "description": "\nGet started by creating Datasets from synthetic data using\n"
+                          "description": "\nGet started by creating Datasets from synthetic data using"
                         },
                         {
                           "member": 1,
@@ -345,7 +345,7 @@
                             ]
                           },
                           "title": "New Dataset from File",
-                          "description": "\nDatasets can be created from files on local disk or remote datasources\nsuch as S3. Any filesystem "
+                          "description": "\nDatasets can be created from files on local disk or remote datasources\nsuch as S3. Any filesystem [supported by pyarrow](http://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html)"
                         }
                       ]
                     }

--- a/test/inputs/42/assert.txt
+++ b/test/inputs/42/assert.txt
@@ -1,0 +1,1 @@
+test/inputs/42/in=Tab1

--- a/test/inputs/42/in.md
+++ b/test/inputs/42/in.md
@@ -1,0 +1,41 @@
+# Test choice descriptions with non-plain text
+
+## Testing!
+
+=== "Tab1"
+    Description without newline after tab [with link](https://foo.com). That link should be visible.
+    
+    Do not include this!
+    
+    ```shell
+    echo AAA
+    ```
+
+=== "Tab2"
+
+    Description with newline after tab [with link](https://foo.com). That link should also be visible.
+    
+    Do not include this either!
+
+    ```shell
+    echo BBB
+    ```
+
+=== "Tab3"
+    Description without newline after tab **with bold**. This text should also be visible.
+    
+    Also do not include this!
+
+    ```shell
+    echo CCC
+    ```
+
+=== "Tab4"
+    Description without newline after tab *with emphasis*. This text should also be visible.
+    
+    Also do not include this!
+
+    ```shell
+    echo DDD
+    ```
+

--- a/test/inputs/42/run-noaprioris.txt
+++ b/test/inputs/42/run-noaprioris.txt
@@ -1,0 +1,2 @@
+echo AAA
+AAA

--- a/test/inputs/42/run-noopt.txt
+++ b/test/inputs/42/run-noopt.txt
@@ -1,0 +1,1 @@
+Unable to run this guidebook, due to 1 unresolved question

--- a/test/inputs/42/run.txt
+++ b/test/inputs/42/run.txt
@@ -1,0 +1,2 @@
+echo AAA
+AAA

--- a/test/inputs/42/tree-noaprioris.txt
+++ b/test/inputs/42/tree-noaprioris.txt
@@ -1,0 +1,2 @@
+Testing!
+└── echo AAA

--- a/test/inputs/42/tree-noopt.txt
+++ b/test/inputs/42/tree-noopt.txt
@@ -1,0 +1,9 @@
+Test choice descriptions with non-plain text
+├── Option 1: Tab1
+│   └── echo AAA
+├── Option 2: Tab2
+│   └── echo BBB
+├── Option 3: Tab3
+│   └── echo CCC
+└── Option 4: Tab4
+    └── echo DDD

--- a/test/inputs/42/tree.txt
+++ b/test/inputs/42/tree.txt
@@ -1,0 +1,2 @@
+Testing!
+└── echo AAA

--- a/test/inputs/42/wizard-noaprioris.json
+++ b/test/inputs/42/wizard-noaprioris.json
@@ -1,0 +1,24 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Testing!",
+      "title": "Testing!",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo AAA",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Testing!"
+    }
+  }
+]

--- a/test/inputs/42/wizard-noopt.json
+++ b/test/inputs/42/wizard-noopt.json
@@ -1,0 +1,106 @@
+[
+  {
+    "graph": {
+      "group": "Tab1####Tab2####Tab3####Tab4",
+      "groupContext": "test/inputs/42/in",
+      "title": "Testing!",
+      "source": "placeholder",
+      "provenance": ["test/inputs/42/in"],
+      "choices": [
+        {
+          "member": 0,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo AAA",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Tab1",
+          "description": "\nDescription without newline after tab [with link](https://foo.com). That link should be visible."
+        },
+        {
+          "member": 1,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo BBB",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Tab2",
+          "description": "Description with newline after tab [with link](https://foo.com). That link should also be visible.\n"
+        },
+        {
+          "member": 2,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo CCC",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Tab3",
+          "description": "\nDescription without newline after tab **with bold**. This text should also be visible."
+        },
+        {
+          "member": 3,
+          "graph": {
+            "key": "somekey",
+            "sequence": [
+              {
+                "body": "echo DDD",
+                "language": "shell",
+                "id": "somekey"
+              }
+            ]
+          },
+          "title": "Tab4",
+          "description": "\nDescription without newline after tab *with emphasis*. This text should also be visible."
+        }
+      ]
+    },
+    "step": {
+      "name": "Testing!",
+      "content": [
+        {
+          "title": "Tab1",
+          "group": "Tab1####Tab2####Tab3####Tab4",
+          "member": 0,
+          "isFirstChoice": true,
+          "description": "\nDescription without newline after tab [with link](https://foo.com). That link should be visible."
+        },
+        {
+          "title": "Tab2",
+          "group": "Tab1####Tab2####Tab3####Tab4",
+          "member": 1,
+          "isFirstChoice": true,
+          "description": "Description with newline after tab [with link](https://foo.com). That link should also be visible.\n"
+        },
+        {
+          "title": "Tab3",
+          "group": "Tab1####Tab2####Tab3####Tab4",
+          "member": 2,
+          "isFirstChoice": true,
+          "description": "\nDescription without newline after tab **with bold**. This text should also be visible."
+        },
+        {
+          "title": "Tab4",
+          "group": "Tab1####Tab2####Tab3####Tab4",
+          "member": 3,
+          "isFirstChoice": true,
+          "description": "\nDescription without newline after tab *with emphasis*. This text should also be visible."
+        }
+      ]
+    }
+  }
+]

--- a/test/inputs/42/wizard.json
+++ b/test/inputs/42/wizard.json
@@ -1,0 +1,24 @@
+[
+  {
+    "graph": {
+      "key": "somekey",
+      "group": "Testing!",
+      "title": "Testing!",
+      "filepath": "",
+      "graph": {
+        "key": "somekey",
+        "sequence": [
+          {
+            "body": "echo AAA",
+            "language": "shell",
+            "id": "somekey"
+          }
+        ]
+      },
+      "source": "placeholder"
+    },
+    "step": {
+      "name": "Testing!"
+    }
+  }
+]


### PR DESCRIPTION
Descriptions that contain links or boldface, or any other non-plain text were being cropped so as only to show the content up to that non-plain content. Though this was only the case for descriptions occuring immediately after the choice marker, without an extra newline.

Was working properly:

```
=== "Choice"

    Description **with bold** and trailing text
```

Was not working (madwizard only showed "Description", i.e. the text up to the bold part), and now fixed by this PR:

```
=== "Choice"
    Description **with bold** and trailing text
```

See tests/inputs/42/in.md for an example.