### PR TITLE
chore: madwizard-cli only needs a devdep on madwizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "madwizard-packages",
-  "version": "2.1.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "madwizard-packages",
-      "version": "2.1.0",
+      "version": "2.2.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/madwizard",
@@ -5654,7 +5654,7 @@
       }
     },
     "packages/madwizard": {
-      "version": "2.1.0",
+      "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.1.2",
@@ -5718,16 +5718,16 @@
       }
     },
     "packages/madwizard-cli": {
-      "version": "2.1.0",
+      "version": "2.2.1",
       "dependencies": {
-        "@guidebooks/store": "^1.7.1",
-        "madwizard": "^2.1.0"
+        "@guidebooks/store": "^1.7.1"
       },
       "bin": {
         "madwizard": "bin/madwizard"
       },
       "devDependencies": {
-        "esbuild": "^0.16.2"
+        "esbuild": "^0.16.2",
+        "madwizard": "^2.2.1"
       }
     },
     "packages/madwizard-cli/node_modules/@guidebooks/store": {
@@ -7734,7 +7734,7 @@
       "requires": {
         "@guidebooks/store": "^1.7.1",
         "esbuild": "^0.16.2",
-        "madwizard": "^2.1.0"
+        "madwizard": "^2.2.1"
       },
       "dependencies": {
         "@guidebooks/store": {

--- a/packages/madwizard-cli/package.json
+++ b/packages/madwizard-cli/package.json
@@ -19,10 +19,10 @@
     "test": "./bin/madwizard version"
   },
   "dependencies": {
-    "@guidebooks/store": "^1.7.1",
-    "madwizard": "^2.2.1"
+    "@guidebooks/store": "^1.7.1"
   },
   "devDependencies": {
-    "esbuild": "^0.16.2"
+    "esbuild": "^0.16.2",
+    "madwizard": "^2.2.1"
   }
 }


### PR DESCRIPTION
now that we are using esbuild to build a single-file madwizard-cli bundle...