### PR TITLE
fix: madwizard-cli should have a devdep on @guidebooks/store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "madwizard-packages",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "madwizard-packages",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/madwizard",
@@ -5654,7 +5654,7 @@
       }
     },
     "packages/madwizard": {
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.1.2",
@@ -5718,20 +5718,20 @@
       }
     },
     "packages/madwizard-cli": {
-      "version": "2.2.1",
-      "dependencies": {
-        "@guidebooks/store": "^1.7.1"
-      },
+      "version": "2.2.2",
+      "hasInstallScript": true,
       "bin": {
         "madwizard": "bin/madwizard"
       },
       "devDependencies": {
+        "@guidebooks/store": "^1.7.1",
         "esbuild": "^0.16.2",
-        "madwizard": "^2.2.1"
+        "madwizard": "^2.2.2"
       }
     },
     "packages/madwizard-cli/node_modules/@guidebooks/store": {
       "version": "1.7.1",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "madwizard": ">=1.10.1"
@@ -7734,11 +7734,12 @@
       "requires": {
         "@guidebooks/store": "^1.7.1",
         "esbuild": "^0.16.2",
-        "madwizard": "^2.2.1"
+        "madwizard": "^2.2.2"
       },
       "dependencies": {
         "@guidebooks/store": {
           "version": "1.7.1",
+          "dev": true,
           "requires": {}
         }
       }

--- a/packages/madwizard-cli/bin/madwizard
+++ b/packages/madwizard-cli/bin/madwizard
@@ -1,3 +1,13 @@
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 
-node "$SCRIPTDIR"/../dist/madwizard.min.cjs $@
+# ugh, macos prior to 12.3 didn't support readlink -f, which is what
+# we really want instead of dirname
+if [ -d "$SCRIPTDIR"/../dist ]; then
+   DIST="$SCRIPTDIR"/../dist
+else
+   DIST="$SCRIPTDIR"/../madwizard-cli/dist
+fi
+
+export GUIDEBOOK_STORE="$DIST"/store
+
+node "$DIST"/madwizard.min.cjs $@

--- a/packages/madwizard-cli/madwizard.js
+++ b/packages/madwizard-cli/madwizard.js
@@ -25,15 +25,12 @@
  */
 
 import { cli } from "madwizard/dist/fe/cli/index.js" // load just the CLI bits
-import { dirname, join } from "path"
 
 /** MadWizardOptions */
 const opts = {}
 
 if (!process.env.MWSTORE && !process.argv.find((_) => /-s|--store/.test(_))) {
-  // use the built-in store shipped with the `@guidebook/store` npm
-  opts.store =
-    process.env.GUIDEBOOK_STORE || join(dirname(require.resolve("@guidebooks/store/package.json")), "dist/store")
+  opts.store = process.env.GUIDEBOOK_STORE
 }
 
 cli(process.argv.slice(1), undefined, opts).catch((err) => {

--- a/packages/madwizard-cli/package.json
+++ b/packages/madwizard-cli/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "sideEffects": false,
   "files": [
-    "./bin/madwizard",
-    "./dist/madwizard.min.cjs"
+    "./bin/*",
+    "./dist/*"
   ],
   "directories": {
     "bin": "./bin"
@@ -16,12 +16,11 @@
     "bundle": "esbuild ./madwizard.js --bundle --platform=node --outfile=./dist/madwizard.min.cjs --external:@guidebooks/store/package.json",
     "build": "npm run bundle -- --minify",
     "watch": "npm run bundle -- --watch",
-    "test": "./bin/madwizard version"
-  },
-  "dependencies": {
-    "@guidebooks/store": "^1.7.1"
+    "test": "./bin/madwizard version",
+    "postinstall": "mkdir -p dist && cp -a node_modules/@guidebooks/store/dist/store dist"
   },
   "devDependencies": {
+    "@guidebooks/store": "^1.7.1",
     "esbuild": "^0.16.2",
     "madwizard": "^2.2.2"
   }


### PR DESCRIPTION
to avoid a circular dependence of store on madwizard-cli