### PR TITLE
fix: madwizard-cli should not have a postinstall script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "madwizard-packages",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "madwizard-packages",
-      "version": "2.2.2",
+      "version": "2.2.3",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
         "packages/madwizard",
@@ -5654,7 +5655,7 @@
       }
     },
     "packages/madwizard": {
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.1.2",
@@ -5718,15 +5719,14 @@
       }
     },
     "packages/madwizard-cli": {
-      "version": "2.2.2",
-      "hasInstallScript": true,
+      "version": "2.2.3",
       "bin": {
         "madwizard": "bin/madwizard"
       },
       "devDependencies": {
         "@guidebooks/store": "^1.7.1",
         "esbuild": "^0.16.2",
-        "madwizard": "^2.2.2"
+        "madwizard": "^2.2.3"
       }
     },
     "packages/madwizard-cli/node_modules/@guidebooks/store": {
@@ -7734,7 +7734,7 @@
       "requires": {
         "@guidebooks/store": "^1.7.1",
         "esbuild": "^0.16.2",
-        "madwizard": "^2.2.2"
+        "madwizard": "^2.2.3"
       },
       "dependencies": {
         "@guidebooks/store": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "cross-env npm run test --workspaces --if-present",
     "format": "cross-env prettier --write '**/*.{scss,css,html,js,json,md,ts,tsx}'",
     "format:test:input": "cross-env prettier --write test/inputs",
+    "postinstall": "cd packages/madwizard-cli && mkdir -p dist && cp -a node_modules/@guidebooks/store/dist/store dist",
     "prepack": "npm run build && npm run prepack --workspaces --if-present",
     "prepare": "cross-env husky install"
   },

--- a/packages/madwizard-cli/package.json
+++ b/packages/madwizard-cli/package.json
@@ -16,8 +16,7 @@
     "bundle": "esbuild ./madwizard.js --bundle --platform=node --outfile=./dist/madwizard.min.cjs --external:@guidebooks/store/package.json",
     "build": "npm run bundle -- --minify",
     "watch": "npm run bundle -- --watch",
-    "test": "./bin/madwizard version",
-    "postinstall": "mkdir -p dist && cp -a node_modules/@guidebooks/store/dist/store dist"
+    "test": "./bin/madwizard version"
   },
   "devDependencies": {
     "@guidebooks/store": "^1.7.1",


### PR DESCRIPTION
move it to the top-level package.json