### PR TITLE
fix: improved fix for up/down arrow sometimes causing funky scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "madwizard-packages",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "madwizard-packages",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/madwizard",
@@ -1645,13 +1645,33 @@
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
-      "resolved": "git+ssh://git@github.com/starpit/enquirer.git#a183e33efc95cd10e8515f6483ea223310ce38b6",
+      "resolved": "git+ssh://git@github.com/starpit/enquirer.git#69fe9305791a4d43e78568dc2f8b52d1f754b21f",
       "license": "MIT",
       "dependencies": {
-        "ansi-colors": "^4.1.1"
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/enquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/enquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/env-paths": {
@@ -6150,7 +6170,7 @@
       }
     },
     "packages/madwizard": {
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.1.2",
@@ -6216,25 +6236,25 @@
       }
     },
     "packages/madwizard-cli": {
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@guidebooks/store": "^1.9.1",
-        "madwizard-cli-core": "^2.4.2"
+        "madwizard-cli-core": "^2.4.3"
       },
       "bin": {
         "madwizard": "bin/madwizard"
       }
     },
     "packages/madwizard-cli-core": {
-      "version": "2.4.2",
+      "version": "2.4.3",
       "bin": {
         "madwizard": "bin/madwizard",
         "madwizard~": "bin/madwizard~"
       },
       "devDependencies": {
         "esbuild": "^0.16.2",
-        "madwizard": "^2.4.2"
+        "madwizard": "^2.4.3"
       }
     },
     "packages/madwizard/node_modules/ansi-regex": {
@@ -7403,10 +7423,26 @@
       }
     },
     "enquirer": {
-      "version": "git+ssh://git@github.com/starpit/enquirer.git#a183e33efc95cd10e8515f6483ea223310ce38b6",
+      "version": "git+ssh://git@github.com/starpit/enquirer.git#69fe9305791a4d43e78568dc2f8b52d1f754b21f",
       "from": "enquirer@starpit/enquirer#starpit",
       "requires": {
-        "ansi-colors": "^4.1.1"
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "env-paths": {
@@ -8889,14 +8925,14 @@
       "version": "file:packages/madwizard-cli",
       "requires": {
         "@guidebooks/store": "^1.9.1",
-        "madwizard-cli-core": "^2.4.2"
+        "madwizard-cli-core": "^2.4.3"
       }
     },
     "madwizard-cli-core": {
       "version": "file:packages/madwizard-cli-core",
       "requires": {
         "esbuild": "^0.16.2",
-        "madwizard": "^2.4.2"
+        "madwizard": "^2.4.3"
       }
     },
     "make-fetch-happen": {

--- a/packages/madwizard/src/fe/guide/index.ts
+++ b/packages/madwizard/src/fe/guide/index.ts
@@ -180,7 +180,7 @@ export class Guide {
         }
       }
 
-      const choices = content.map((tile) => {
+      const choices = content.map((tile, idx, A) => {
         const isSuggested = suggestion === tile.title
 
         return {
@@ -190,7 +190,9 @@ export class Guide {
           message:
             chalk.bold(tile.title) +
             (isSuggested ? this.suggestionHint : "") +
-            (!tile.description ? "" : chalk.reset(EOL) + this.format(tile.description) + EOL),
+            (!tile.description
+              ? ""
+              : chalk.reset(EOL) + this.format(tile.description) + (idx < A.length - 1 ? chalk.reset(EOL) : "")),
         }
       })
 


### PR DESCRIPTION
This pulls in a fix in `enquirer` that uses `strip-ansi` rather than `ansi-colors.unstyle` to strip off ansi control characters. What was happening: the latter does not understand how to strip off the terminal link/anchor ansi extension. The former does. Choice messages that contain terminal links would cause this problem to surface: up arrowing/down arrow would cause funky scrolling of the choice list.

https://github.com/enquirer/enquirer/pull/413