### PR TITLE
feat: support input from stdin and passed programmatically

### DIFF
--- a/packages/madwizard/src/fe/MadWizardOptions.ts
+++ b/packages/madwizard/src/fe/MadWizardOptions.ts
@@ -98,3 +98,6 @@ export type MadWizardOptions = Partial<CompilerOptions> &
   Partial<DisplayOptions> &
   Partial<FetchOptions> &
   Partial<RunOptions>
+
+/** The front-end modules allow passing through input programmatically */
+export type MadWizardOptionsWithInput = MadWizardOptions & { input?: string }

--- a/packages/madwizard/src/fe/cli/commands/guide/handler.ts
+++ b/packages/madwizard/src/fe/cli/commands/guide/handler.ts
@@ -18,7 +18,7 @@ import { Writable } from "stream"
 import { Arguments } from "yargs"
 
 import { UI } from "../../../tree/index.js"
-import { MadWizardOptions } from "../../../MadWizardOptions.js"
+import { MadWizardOptionsWithInput } from "../../../MadWizardOptions.js"
 
 import { getBlocksModel, loadAssertions, loadSuggestions, makeMemos } from "../util.js"
 
@@ -31,7 +31,7 @@ export type GuideRet = {
 
 export default async function guideHandler<Writer extends Writable["write"]>(
   task: "run" | "guide",
-  providedOptions: MadWizardOptions,
+  providedOptions: MadWizardOptionsWithInput,
   argv: Arguments<GuideOpts>,
   write?: Writer,
   ui?: UI<string>
@@ -84,7 +84,8 @@ export default async function guideHandler<Writer extends Writable["write"]>(
   }
 
   // this is the block model we parse from the source
-  const blocks = await getBlocksModel(input, choices, options)
+  // re: | "-", see https://github.com/yargs/yargs/issues/1312
+  const blocks = await getBlocksModel(input || "-", choices, options)
 
   // a name we might want to associate with the run, in the logs
   const name = options.name ? ` (${options.name})` : ""

--- a/packages/madwizard/src/fe/cli/commands/plan/handler.ts
+++ b/packages/madwizard/src/fe/cli/commands/plan/handler.ts
@@ -20,10 +20,10 @@ import { Arguments } from "yargs"
 import { InputOpts } from "../input.js"
 import { assembleOptions } from "../../options.js"
 import { getBlocksModel, loadAssertions } from "../util.js"
-import { MadWizardOptions } from "../../../MadWizardOptions.js"
+import { MadWizardOptionsWithInput } from "../../../MadWizardOptions.js"
 
 export default async function planHandler<Writer extends Writable["write"]>(
-  providedOptions: MadWizardOptions,
+  providedOptions: MadWizardOptionsWithInput,
   argv: Arguments<InputOpts>,
   write?: Writer
 ) {
@@ -34,7 +34,9 @@ export default async function planHandler<Writer extends Writable["write"]>(
     providedOptions,
     argv
   )
-  const blocks = await getBlocksModel(argv.input, choices, options)
+
+  // re: | "-", see https://github.com/yargs/yargs/issues/1312
+  const blocks = await getBlocksModel(argv.input || "-", choices, options)
   await import("../../../tree/index.js").then((_) =>
     _.prettyPrintUITreeFromBlocks(blocks, choices, Object.assign({ write }, options))
   )

--- a/packages/madwizard/src/fe/cli/index.ts
+++ b/packages/madwizard/src/fe/cli/index.ts
@@ -30,7 +30,7 @@ import mirror from "./commands/mirror.js"
 import profile from "./commands/profile.js"
 import guideMod, { GuideRet } from "./commands/guide/index.js"
 
-import { MadWizardOptions } from "../MadWizardOptions.js"
+import { MadWizardOptionsWithInput } from "../MadWizardOptions.js"
 
 import strings from "./strings.js"
 import examples from "./examples.js"
@@ -43,7 +43,7 @@ function hasCode(err?: Error): err is Error & { code: number | string } {
 export async function guide<Writer extends Writable["write"]>(
   _argv: string[],
   write?: Writer,
-  providedOptions: MadWizardOptions = {},
+  providedOptions: MadWizardOptionsWithInput = {},
   ui?: UI<string>
 ) {
   const argv = _argv.slice(1)
@@ -83,7 +83,7 @@ export async function guide<Writer extends Writable["write"]>(
 export async function cli<Writer extends Writable["write"]>(
   _argv: string[],
   write?: Writer,
-  providedOptions: MadWizardOptions = {},
+  providedOptions: MadWizardOptionsWithInput = {},
   ui?: UI<string>
 ) {
   const argv = _argv.slice(1)

--- a/packages/madwizard/src/fe/cli/madwizardRead.ts
+++ b/packages/madwizard/src/fe/cli/madwizardRead.ts
@@ -34,7 +34,13 @@ export async function madwizardRead(
   store = "https://github.com/guidebooks/store/blob/main/guidebooks",
   searchStore = false
 ): Promise<VFile> {
-  if (/^https?:/.test(file.path)) {
+  if (file.path === "-") {
+    // read from stdin
+    Debug("madwizard/read/0")("reading from stdin")
+    const { readFileSync } = await import("fs")
+    file.value = await readFileSync(0, "utf-8")
+    return file
+  } else if (/^https?:/.test(file.path)) {
     // remote fetch
     const res = await get(file.path)
     file.value = (await res.buffer()).toString()

--- a/packages/madwizard/src/parser/index.ts
+++ b/packages/madwizard/src/parser/index.ts
@@ -18,7 +18,7 @@ import { VFileCompatible } from "vfile"
 import { extname as pathExtname } from "path"
 
 import { ChoiceState } from "../choices/index.js"
-import { MadWizardOptions } from "../fe/index.js"
+import { MadWizardOptionsWithInput } from "../fe/index.js"
 import { Reader } from "./markdown/fetch.js"
 
 export * from "./markdown/index.js"
@@ -42,7 +42,7 @@ export async function parse(
   reader: Reader,
   choices?: ChoiceState,
   uuid?: string,
-  madwizardOptions?: MadWizardOptions
+  madwizardOptions?: MadWizardOptionsWithInput
 ) {
   const ext = extname(input)
   if (ext === ".md" || !ext) {

--- a/packages/madwizard/src/parser/markdown/index.ts
+++ b/packages/madwizard/src/parser/markdown/index.ts
@@ -23,8 +23,8 @@ import remarkParse from "remark-parse"
 import remarkRehype from "remark-rehype"
 import { unified, PluggableList } from "unified"
 
-import { MadWizardOptions } from "../../fe/index.js"
 import { Reader, fetcherFor } from "./fetch.js"
+import { MadWizardOptions, MadWizardOptionsWithInput } from "../../fe/index.js"
 
 import { ChoiceState } from "../../choices/index.js"
 import { CodeBlockProps } from "../../codeblock/index.js"
@@ -135,10 +135,12 @@ export async function blockify(
   reader: Reader,
   choices?: ChoiceState,
   uuid?: string,
-  madwizardOptions: MadWizardOptions = {}
+  madwizardOptions: MadWizardOptionsWithInput = {}
 ) {
   const file =
-    typeof input === "string"
+    input === "-" && typeof madwizardOptions.input === "string"
+      ? new VFile({ cwd: process.cwd(), path: "-", value: madwizardOptions.input })
+      : typeof input === "string"
       ? await reader(
           new VFile({ cwd: process.cwd(), path: toRawGithubUserContent(expandHomeDir(input)) }),
           madwizardOptions.store,

--- a/packages/madwizard/src/test/programmatic-inputs.ts
+++ b/packages/madwizard/src/test/programmatic-inputs.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** These will be passed as programmatic inputs to `madwizard run` */
+export default [{ input: "```shell\necho AAA\n```", output: "AAA" }]


### PR DESCRIPTION
```shell
cat foo.md | madwizard -
```

or, programmatically:

```
import { CLI } from 'madwizard'
CLI.cli(['madwizard', 'guide', '-'], undefined, { input })
```

In either case, the `-` part of the command line is necessary to indicate the desire not to treat the input as a file/uri.