### PR TITLE
feat: allow clients to pass in a raw api callback function

### DIFF
--- a/packages/madwizard/src/fe/MadWizardOptions.ts
+++ b/packages/madwizard/src/fe/MadWizardOptions.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { CompilerOptions } from "../graph/compile"
+import { RawImpl } from "./raw/index.js"
+import { CompilerOptions } from "../graph/compile.js"
 
 export interface RunOptions {
   /**
@@ -54,7 +55,7 @@ export interface RunOptions {
   assertions: Record<string, string>
 }
 
-export interface DisplayOptions {
+export interface DisplayOptions<R extends RawImpl = RawImpl> {
   /** name to display in log messages */
   name: string
 
@@ -70,11 +71,13 @@ export interface DisplayOptions {
   /** Bump the lastUsedTime attribute of the profile? [default: true] */
   bump: boolean
 
-  /** In raw mode, any questions will be emitted as a raw json model to the stdout */
-  raw: boolean
-
-  /** In raw mode, any raw models emitted to the stdout will be prefixed with this string [default: "MADWIZARD_RAW"] */
-  rawPrefix: string
+  /**
+   * In raw mode, any questions will be emitted as a raw json model
+   * either to stdout (if `raw` is a string; with control limits
+   * prefixed by this given string ) or to a callback (if `raw` is a
+   * function).
+   */
+  raw: R
 }
 
 export interface FetchOptions {
@@ -94,8 +97,8 @@ export interface FetchOptions {
   dataPath: string
 }
 
-export type MadWizardOptions = Partial<CompilerOptions> &
-  Partial<DisplayOptions> &
+export type MadWizardOptions<R extends RawImpl = RawImpl> = Partial<CompilerOptions> &
+  Partial<DisplayOptions<R>> &
   Partial<FetchOptions> &
   Partial<RunOptions>
 

--- a/packages/madwizard/src/fe/cli/commands/guide/options.ts
+++ b/packages/madwizard/src/fe/cli/commands/guide/options.ts
@@ -59,11 +59,8 @@ type GuideOpts = InputOpts &
     /** Run in interactive mode, and overridden by value of `yes` (default: true) */
     interactive?: boolean
 
-    /** Emit computer-readable output for Q&A interactions */
-    raw?: boolean
-
-    /** When emitting raw output, prefix every line with this string */
-    "raw-prefix"?: string
+    /** Emit computer-readable output for Q&A interactions. When emitting raw output, prefix every line with this string. */
+    raw?: string
   }
 
 const mainGroup = group("Guide Options:")
@@ -124,14 +121,10 @@ export const guideOptions = {
   },
   raw: {
     alias: "r",
-    type: "boolean" as const,
-    group: developersGroup,
-    describe: "Emit computer-readable output for Q&A interactions",
-  },
-  "raw-prefix": {
     type: "string" as const,
     group: developersGroup,
-    describe: "When emitting raw output, prefix every line with this string",
+    describe:
+      "Emit computer-readable output for Q&A interactions. When emitting raw output, prefix every line with this string.",
   },
 }
 

--- a/packages/madwizard/src/fe/cli/defaults.ts
+++ b/packages/madwizard/src/fe/cli/defaults.ts
@@ -42,9 +42,6 @@ const defaults: MadWizardOptions = {
    * have launched (via `shell.async`).
    */
   clean: true,
-
-  /** In raw mode, any raw models emitted to the stdout will be prefixed with this string [default: "MADWIZARD_RAW"] */
-  rawPrefix: "MADWIZARD_RAW",
 }
 
 export default defaults

--- a/packages/madwizard/src/fe/raw/RawEvent.ts
+++ b/packages/madwizard/src/fe/raw/RawEvent.ts
@@ -14,5 +14,25 @@
  * limitations under the License.
  */
 
-export * from "./MadWizardOptions.js"
-export { RawEvent } from "./raw/RawEvent.js"
+import { Prompt } from "../Prompts.js"
+import { ValidAnswer } from "../tree/ui.js"
+
+export { ValidAnswer }
+
+export type RawAskEvent = {
+  type: "ask"
+  ask: Prompt
+  onChoose(value: ValidAnswer): void
+  onCancel(): void
+}
+
+export type RawQADoneEvent = {
+  type: "qa-done"
+}
+
+export type RawAllDoneEvent = {
+  type: "all-done"
+  success: boolean
+}
+
+export type RawEvent = RawAskEvent | RawQADoneEvent | RawAllDoneEvent

--- a/packages/madwizard/src/fe/raw/alldone.ts
+++ b/packages/madwizard/src/fe/raw/alldone.ts
@@ -14,5 +14,15 @@
  * limitations under the License.
  */
 
-export * from "./MadWizardOptions.js"
-export { RawEvent } from "./raw/RawEvent.js"
+import { RawAllDoneEvent } from "./RawEvent.js"
+import { isRawViaHandler, WithRawViaCLI, WithRawViaHandler } from "./index.js"
+
+export function alldone(options: WithRawViaCLI | WithRawViaHandler, success: RawAllDoneEvent["success"]) {
+  const event: RawAllDoneEvent = { type: "all-done", success }
+
+  if (isRawViaHandler(options)) {
+    options.raw(event)
+  } else {
+    console.log(options.raw + " " + JSON.stringify(event) + "\n")
+  }
+}

--- a/packages/madwizard/src/fe/raw/ask.ts
+++ b/packages/madwizard/src/fe/raw/ask.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Prompt } from "../Prompts.js"
+import { RawAskEvent, ValidAnswer } from "./RawEvent.js"
+import { isRawViaHandler, WithRawViaCLI, WithRawViaHandler } from "./index.js"
+
+async function askViaCLI(prompt: Prompt, description: string | undefined, rawPrefix: WithRawViaCLI["raw"]) {
+  const readline = await import("readline")
+  const r1 = readline.createInterface({
+    terminal: false,
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise<ValidAnswer>((resolve, reject) => {
+    try {
+      r1.question(
+        rawPrefix +
+          " " +
+          JSON.stringify({
+            type: "ask",
+            ask: {
+              type: prompt.type,
+              name: prompt.name,
+              description: description,
+              initial: prompt.initial,
+              choices: prompt.choices,
+            },
+          }) +
+          "\n",
+        (resp) => {
+          r1.close()
+          try {
+            resolve(JSON.parse(resp) as Record<string, string>)
+          } catch (err) {
+            resolve(resp)
+          }
+        }
+      )
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+function askViaHandler(ask: Prompt, description: string, onRaw: WithRawViaHandler["raw"]) {
+  return new Promise<ValidAnswer>((resolve, reject) => {
+    const event: RawAskEvent = {
+      type: "ask",
+      ask,
+      onChoose: resolve,
+      onCancel: reject,
+    }
+
+    onRaw(event)
+  })
+}
+
+export async function ask(ask: Prompt, description: string | undefined, options: WithRawViaCLI | WithRawViaHandler) {
+  if (isRawViaHandler(options)) {
+    return askViaHandler(ask, description, options.raw)
+  } else {
+    const { raw: rawPrefix } = options
+    if (rawPrefix) {
+      return askViaCLI(ask, description, rawPrefix)
+    } else {
+      throw new Error("Misconfiguration: raw mode requested, but neither onRaw nor rawPrefix provided")
+    }
+  }
+}

--- a/packages/madwizard/src/fe/raw/index.ts
+++ b/packages/madwizard/src/fe/raw/index.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RawEvent } from "./RawEvent.js"
+import { MadWizardOptions } from "../MadWizardOptions.js"
+
+export { RawEvent }
+
+type CLI = string
+type Handler = (evt: RawEvent) => void
+export type RawImpl = CLI | Handler
+
+type RawMode<R extends RawImpl> = Required<Pick<MadWizardOptions<R>, "raw">>
+export type WithRawViaCLI = RawMode<CLI>
+export type WithRawViaHandler = RawMode<Handler>
+
+function isRawViaCLI(options: MadWizardOptions): options is WithRawViaCLI {
+  return typeof (options as WithRawViaCLI).raw === "string"
+}
+
+export function isRawViaHandler(options: MadWizardOptions): options is WithRawViaHandler {
+  return typeof (options as WithRawViaHandler).raw === "function"
+}
+
+export default function isRaw(options: MadWizardOptions): options is WithRawViaHandler | WithRawViaCLI {
+  return isRawViaCLI(options) || isRawViaHandler(options)
+}

--- a/packages/madwizard/src/fe/raw/qadone.ts
+++ b/packages/madwizard/src/fe/raw/qadone.ts
@@ -14,5 +14,15 @@
  * limitations under the License.
  */
 
-export * from "./MadWizardOptions.js"
-export { RawEvent } from "./raw/RawEvent.js"
+import { RawQADoneEvent } from "./RawEvent.js"
+import { isRawViaHandler, WithRawViaCLI, WithRawViaHandler } from "./index.js"
+
+export function qadone(options: WithRawViaCLI | WithRawViaHandler) {
+  const event: RawQADoneEvent = { type: "qa-done" }
+
+  if (isRawViaHandler(options)) {
+    options.raw(event)
+  } else {
+    console.log(options.raw + " " + JSON.stringify(event) + "\n")
+  }
+}

--- a/packages/madwizard/src/fe/tree/ui.ts
+++ b/packages/madwizard/src/fe/tree/ui.ts
@@ -22,7 +22,7 @@ import { Status } from "../../graph/index.js"
 export type Decoration = Modifiers | Color
 
 type ValidQuestion = import("enquirer").Prompt
-type ValidAnswer = string | string[] | import("enquirer").prompt.FormQuestion.Answer
+export type ValidAnswer = string | string[] | import("enquirer").prompt.FormQuestion.Answer
 
 export interface UI<Content> {
   span(body: string, ...decorations: Decoration[]): Content


### PR DESCRIPTION
Previously, the only option was to interact with the guide via stdin/stdout. Now, you can pass in a raw api handler `onRaw()` that allows for inversion of control (into a UI) via a programmatic interface.

```typescript
export type RawAskEvent = {
  type: "ask"
  ask: Prompt
  onChoose(value: ValidAnswer): void
  onCancel(): void
}

export type RawQADoneEvent = {
  type: "qa-done"
}

export type RawAllDoneEvent = {
  type: "all-done"
  success: boolean
}

export type RawEvent = RawAskEvent | RawQADoneEvent | RawAllDoneEvent
```