### PR TITLE
feat: allow clients to intercept shell executions

### DIFF
--- a/packages/madwizard/src/exec/handled-by-client.ts
+++ b/packages/madwizard/src/exec/handled-by-client.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Memos } from "../memoization/index.js"
+import { ExecOptions } from "./options.js"
+
+export default function handledByClient(cmdline: string | boolean, memos: Memos, opts: ExecOptions = { quiet: false }) {
+  console.error("!!!!!!!!!!XXXXXX", cmdline, opts)
+  if (typeof opts.shell === "object" && opts.shell.willHandle(cmdline)) {
+    return opts.shell.exec(cmdline, memos.env)
+  }
+}

--- a/packages/madwizard/src/exec/index.ts
+++ b/packages/madwizard/src/exec/index.ts
@@ -27,6 +27,7 @@ import raySubmit from "./ray-submit.js"
 import exporter, { isExport } from "./export.js"
 import addPipDependences from "./pip-install.js"
 import addCondaDependences from "./conda-install.js"
+import handledByClient from "./handled-by-client.js"
 
 export { Env, ExecOptions, isExport }
 
@@ -54,6 +55,7 @@ export async function shellExec(
       exporter(cmdline, memos, opts) || // export FOO=3
       which(cmdline) || // which foo
       pipShow(cmdline, memos) || // optimized pip show
+      handledByClient(cmdline, memos, opts) || // maybe the client wants to handle some executions directly?
       shell(cmdline, memos, opts, undefined, async) // vanilla shell exec
     )
   } else if (isPythonic(language)) {

--- a/packages/madwizard/src/fe/MadWizardOptions.ts
+++ b/packages/madwizard/src/fe/MadWizardOptions.ts
@@ -53,6 +53,15 @@ export interface RunOptions {
 
   /** Assert answers to certain questions */
   assertions: Record<string, string>
+
+  /**
+   * In case clients want to handle certain command line executions
+   * directly (rather than by shelling them out to a PTY).
+   */
+  shell: {
+    willHandle(cmdline: string | boolean): boolean
+    exec(cmdline: string | boolean, env: import("../memoization/index.js").Memos["env"]): Promise<"success">
+  }
 }
 
 export interface DisplayOptions<R extends RawImpl = RawImpl> {

--- a/packages/madwizard/src/fe/guide/index.ts
+++ b/packages/madwizard/src/fe/guide/index.ts
@@ -371,6 +371,7 @@ export class Guide {
                         this.memos,
                         {
                           write: this.write,
+                          shell: this.options.shell,
                           dryRun: this.options.dryRun,
                           verbose: this.options.verbose,
                           profile: this.options.profile,


### PR DESCRIPTION
Pass a `shell` option:

```typescript
  /**
   * In case clients want to handle certain command line executions
   * directly (rather than by shelling them out to a PTY).
   */
  shell: {
    willHandle(cmdline: string | boolean): boolean
    exec(cmdline: string | boolean, env: import('../memoization/index.js').Memos['env']): Promise<"success">
  }
```