### PR TITLE
fix: switch programmatic input from `input: string` to `vfile: VFile`

### DIFF
--- a/packages/madwizard/src/fe/MadWizardOptions.ts
+++ b/packages/madwizard/src/fe/MadWizardOptions.ts
@@ -112,4 +112,4 @@ export type MadWizardOptions<R extends RawImpl = RawImpl> = Partial<CompilerOpti
   Partial<RunOptions>
 
 /** The front-end modules allow passing through input programmatically */
-export type MadWizardOptionsWithInput = MadWizardOptions & { input?: string }
+export type MadWizardOptionsWithInput = MadWizardOptions & { vfile?: import("vfile").VFile }

--- a/packages/madwizard/src/parser/markdown/index.ts
+++ b/packages/madwizard/src/parser/markdown/index.ts
@@ -138,8 +138,8 @@ export async function blockify(
   madwizardOptions: MadWizardOptionsWithInput = {}
 ) {
   const file =
-    input === "-" && typeof madwizardOptions.input === "string"
-      ? new VFile({ cwd: process.cwd(), path: "-", value: madwizardOptions.input })
+    input === "-" && typeof madwizardOptions.vfile === "object"
+      ? madwizardOptions.vfile
       : typeof input === "string"
       ? await reader(
           new VFile({ cwd: process.cwd(), path: toRawGithubUserContent(expandHomeDir(input)) }),

--- a/packages/madwizard/src/test/programmatic-inputs.ts
+++ b/packages/madwizard/src/test/programmatic-inputs.ts
@@ -15,4 +15,4 @@
  */
 
 /** These will be passed as programmatic inputs to `madwizard run` */
-export default [{ input: "```shell\necho AAA\n```", output: "AAA" }]
+export default [{ input: "```shell\necho AAA\n```", path: "/xxx/yyy", output: "AAA" }]


### PR DESCRIPTION
BREAKING CHANGE: this is to allow for specifying the filepath of the programmatic input.