### PR TITLE
fix: bump to '2.3.7' of enquirier starpit fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "madwizard-packages",
-  "version": "4.2.0",
+  "version": "4.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "madwizard-packages",
-      "version": "4.2.0",
+      "version": "4.3.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/madwizard",
@@ -1451,8 +1451,8 @@
       }
     },
     "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "git+ssh://git@github.com/starpit/enquirer.git#61450fb17a6f1c9991deaeeb9a4778ac9ffa2382",
+      "version": "2.3.7",
+      "resolved": "git+ssh://git@github.com/starpit/enquirer.git#4aa150dfd8a26eeaf033ec4e4ffb22e37c4e6600",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1",
@@ -5563,7 +5563,7 @@
       }
     },
     "packages/madwizard": {
-      "version": "4.2.0",
+      "version": "4.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.2.0",
@@ -5625,25 +5625,25 @@
       }
     },
     "packages/madwizard-cli": {
-      "version": "4.2.0",
+      "version": "4.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@guidebooks/store": "^1.11.1",
-        "madwizard-cli-core": "^4.2.0"
+        "madwizard-cli-core": "^4.3.1"
       },
       "bin": {
         "madwizard": "bin/madwizard"
       }
     },
     "packages/madwizard-cli-core": {
-      "version": "4.2.0",
+      "version": "4.3.1",
       "bin": {
         "madwizard": "bin/madwizard",
         "madwizard~": "bin/madwizard~"
       },
       "devDependencies": {
         "esbuild": "^0.16.15",
-        "madwizard": "^4.2.0"
+        "madwizard": "^4.3.1"
       }
     },
     "packages/madwizard/node_modules/ansi-regex": {
@@ -6572,7 +6572,7 @@
       }
     },
     "enquirer": {
-      "version": "git+ssh://git@github.com/starpit/enquirer.git#61450fb17a6f1c9991deaeeb9a4778ac9ffa2382",
+      "version": "git+ssh://git@github.com/starpit/enquirer.git#4aa150dfd8a26eeaf033ec4e4ffb22e37c4e6600",
       "from": "enquirer@starpit/enquirer#starpit",
       "requires": {
         "ansi-colors": "^4.1.1",
@@ -7813,14 +7813,14 @@
       "version": "file:packages/madwizard-cli",
       "requires": {
         "@guidebooks/store": "^1.11.1",
-        "madwizard-cli-core": "^4.2.0"
+        "madwizard-cli-core": "^4.3.1"
       }
     },
     "madwizard-cli-core": {
       "version": "file:packages/madwizard-cli-core",
       "requires": {
         "esbuild": "^0.16.15",
-        "madwizard": "^4.2.0"
+        "madwizard": "^4.3.1"
       }
     },
     "make-fetch-happen": {


### PR DESCRIPTION
This is to avoid 2.3.6 conflicts from other deps. npm sometimes installs them in preference, even if those other deps are devdeps. I've never understood its proclivity to favor devdeps over deps.