### PR TITLE
feat: improved support for running in browser

### DIFF
--- a/packages/madwizard/src/fe/MadWizardOptions.ts
+++ b/packages/madwizard/src/fe/MadWizardOptions.ts
@@ -106,10 +106,21 @@ export interface FetchOptions {
   dataPath: string
 }
 
+/** Allow clients to provide alternative impls of certain shell operations */
+type FileSystemOptions = {
+  fs: Partial<{
+    mkdirp(filepath: string): Promise<void>
+    readFile(filepath: string, cb: (err: NodeJS.ErrnoException | null, data: Buffer) => void): void
+    writeFile(filepath: string, cb: (err: NodeJS.ErrnoException | null) => void): void
+    writeFileAtomic: typeof import("write-file-atomic")
+  }>
+}
+
 export type MadWizardOptions<R extends RawImpl = RawImpl> = Partial<CompilerOptions> &
   Partial<DisplayOptions<R>> &
   Partial<FetchOptions> &
-  Partial<RunOptions>
+  Partial<RunOptions> &
+  Partial<FileSystemOptions>
 
 /** The front-end modules allow passing through input programmatically */
 export type MadWizardOptionsWithInput = MadWizardOptions & { vfile?: import("vfile").VFile }

--- a/packages/madwizard/src/fe/cli/commands/util.ts
+++ b/packages/madwizard/src/fe/cli/commands/util.ts
@@ -66,12 +66,12 @@ export function loadAssertions(
 /** @return the block model, either by using a precompiled model from the store, or by parsing the source */
 export async function getBlocksModel(input: string, choices: ChoiceState, options: MadWizardOptionsWithInput) {
   // check to see if the compiled model exists
-  const [{ access, readFile }, { targetPathForAst }] = await Promise.all([
-    import("fs/promises"),
-    import("../../../parser/markdown/snippets/mirror-paths.js"),
-  ])
-
   if (input !== "-") {
+    const [{ access, readFile }, { targetPathForAst }] = await Promise.all([
+      import("fs/promises"),
+      import("../../../parser/markdown/snippets/mirror-paths.js"),
+    ])
+
     const ast1 = targetPathForAst(input + "/index.md", options.store)
     const ast2 = targetPathForAst(input + ".md", options.store)
     const mightBeAst = !/\.md$/.test(input) && !/^http/.test(options.store)

--- a/packages/madwizard/src/fe/cli/madwizardRead.ts
+++ b/packages/madwizard/src/fe/cli/madwizardRead.ts
@@ -18,13 +18,13 @@ import Debug from "debug"
 import { VFile } from "vfile"
 import { isAbsolute, join } from "path"
 
-import fetch from "make-fetch-happen"
 import { read as vfileRead } from "to-vfile"
 
 import { cachePath } from "../../util/cache.js"
 import { toRawGithubUserContent } from "../../parser/markdown/snippets/urls.js"
 
 export async function get(uri: string) {
+  const { default: fetch } = await import("make-fetch-happen")
   return fetch(uri, { cachePath: cachePath() })
 }
 

--- a/packages/madwizard/src/fe/guide/EchoStream.ts
+++ b/packages/madwizard/src/fe/guide/EchoStream.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Writable } from "stream"
+
+/** This helps implement a `process.stdout` in a browser */
+export default class EchoStream extends Writable {
+  _write(chunk, enc, next) {
+    console.log(chunk.toString())
+    next()
+  }
+}

--- a/packages/madwizard/src/fe/guide/taskrunner.ts
+++ b/packages/madwizard/src/fe/guide/taskrunner.ts
@@ -16,6 +16,7 @@
 
 import { EOL } from "os"
 import ora, { Ora } from "ora"
+import { Writable } from "stream"
 import { mainSymbols } from "figures"
 import chalk, { ChalkInstance } from "chalk"
 import promiseEach from "../../util/promise-each.js"
@@ -55,7 +56,7 @@ export function skip(ora: Ora, text: string) {
 class TaskWrapperImpl implements TaskWrapper {
   public constructor(
     private readonly title: string,
-    private readonly write = process.stdout.write.bind(process.stdout),
+    private readonly write: Writable["write"] = process.stdout.write.bind(process.stdout),
     private readonly quiet = false,
     private readonly spinner?: ReturnType<typeof ora>
   ) {}
@@ -107,7 +108,7 @@ export default class TaskRunner {
   public async run(
     tasks: Task[],
     options: TaskRunnerOptions = {},
-    write = process.stdout.write.bind(process.stdout),
+    write: Writable["write"] = process.stdout.write.bind(process.stdout),
     depth = 0
   ) {
     await promiseEach(tasks, async ({ title, task, spinner, quiet }, idx) => {

--- a/packages/madwizard/src/profiles/paths.ts
+++ b/packages/madwizard/src/profiles/paths.ts
@@ -39,7 +39,7 @@ export async function profilesPath(options: MadWizardOptions, mkdir = true) {
   const filepath =
     options.profilesPath || process.env.MWPROFILES_PATH || join(guidebookGlobalDataPath(options), "profiles")
   if (mkdir) {
-    const mkdirp = await import("mkdirp").then((_) => _.default)
+    const mkdirp = options.fs?.mkdirp || (await import("mkdirp").then((_) => _.default))
     await mkdirp(filepath)
   }
   return filepath

--- a/packages/madwizard/src/profiles/persist.ts
+++ b/packages/madwizard/src/profiles/persist.ts
@@ -31,7 +31,7 @@ export function isTemporary(profile: string) {
 }
 
 export async function save(choices: ChoiceState, options: MadWizardOptions = {}, profileName = choices.profile.name) {
-  const writeFile = await import("write-file-atomic").then((_) => _.default)
+  const writeFile = options.fs?.writeFileAtomic || (await import("write-file-atomic").then((_) => _.default))
   const filepath = join(await profilesPath(options, true), profileName)
 
   try {

--- a/packages/madwizard/src/profiles/restore.ts
+++ b/packages/madwizard/src/profiles/restore.ts
@@ -23,7 +23,7 @@ import { ChoiceState, deserialize, newChoiceState } from "../choices/index.js"
 
 /** Restore the named `profile` */
 export default async function restore(options: MadWizardOptions, profile: string): Promise<ChoiceState> {
-  const readFile = await import("fs").then((_) => _.readFile)
+  const readFile = options.fs?.readFile || (await import("fs").then((_) => _.readFile))
   const filepath = join(await profilesPath(options), profile)
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
This adds a `fs` field option to MadWizardOptions, that lets clients define shims for filesystem behavior. It also defers importing some of the non-browser-friendly bits (that aren't needed anyway, when in `raw` mode).