### PR TITLE
feat: support choice expansion via the client's `shell`

### DIFF
--- a/packages/madwizard/src/exec/Executor.ts
+++ b/packages/madwizard/src/exec/Executor.ts
@@ -15,9 +15,8 @@
  */
 
 import { ExecOptions } from "./options.js"
+import { MadWizardOptions } from "../fe/MadWizardOptions.js"
 
 export type Executor = (cmdline: string, opts?: ExecOptions) => Promise<string>
 
-export type ExecutorOptions = Partial<ExecOptions> & {
-  exec: Executor
-}
+export type ExecutorOptions = Partial<ExecOptions> & Pick<MadWizardOptions, "shell">

--- a/packages/madwizard/src/exec/handled-by-client.ts
+++ b/packages/madwizard/src/exec/handled-by-client.ts
@@ -19,6 +19,11 @@ import { ExecOptions } from "./options.js"
 
 export default function handledByClient(cmdline: string | boolean, memos: Memos, opts: ExecOptions = { quiet: false }) {
   if (typeof opts.shell === "object" && opts.shell.willHandle(cmdline)) {
-    return opts.shell.exec(cmdline, memos.env)
+    return opts.shell.exec(cmdline, memos.env).then((response) => {
+      if (typeof opts.capture === "string") {
+        opts.capture = Array.isArray(response) ? response.join("\n") : response.toString()
+      }
+      return "success" as const
+    })
   }
 }

--- a/packages/madwizard/src/fe/MadWizardOptions.ts
+++ b/packages/madwizard/src/fe/MadWizardOptions.ts
@@ -63,7 +63,7 @@ export interface RunOptions {
     willHandle(cmdline: string | boolean): boolean
 
     /** Execute the given `cmdline` with the given `env` */
-    exec(cmdline: string | boolean, env: import("../memoization/index.js").Memos["env"]): Promise<"success">
+    exec(cmdline: string | boolean, env: import("../memoization/index.js").Memos["env"]): Promise<string>
   }
 
   /** Optional conduit for process.stdin and process.stdout data */

--- a/packages/madwizard/src/graph/optimize.ts
+++ b/packages/madwizard/src/graph/optimize.ts
@@ -60,9 +60,10 @@ async function optimize2(
   graph: Graph,
   choices: ChoiceState,
   memos: Memos,
+  options: CompileOptions,
   doExpand: (...params: Parameters<typeof expand>) => Graph | Promise<Graph>
 ) {
-  const expanded = await doExpand(graph, choices, memos)
+  const expanded = await doExpand(graph, choices, memos, options)
   return collapseMadeChoices(expanded, choices)
 }
 
@@ -70,7 +71,7 @@ export default async function fullOptimize(
   graph: Graph | undefined,
   choices: ChoiceState,
   memos: Memos,
-  options?: CompileOptions,
+  options: CompileOptions,
   title?: string,
   description?: string
 ): Promise<Graph> {
@@ -83,7 +84,7 @@ export default async function fullOptimize(
   const doExpand: (...params: Parameters<typeof expand>) => Graph | Promise<Graph> =
     options.expand === false ? (x) => x : expand
 
-  const unoptimized = workaroundMultipleChoicesPerFile(await doExpand(graph, choices, memos))
+  const unoptimized = workaroundMultipleChoicesPerFile(await doExpand(graph, choices, memos, options))
 
   let optimized = willNotOptimize ? unoptimized : await optimize(unoptimized, choices, memos, options)
 
@@ -99,5 +100,5 @@ export default async function fullOptimize(
     )
   }
 
-  return willNotOptimize ? unoptimized : await optimize2(optimized, choices, memos, doExpand)
+  return willNotOptimize ? unoptimized : await optimize2(optimized, choices, memos, options, doExpand)
 }

--- a/packages/madwizard/src/util/ora-delayed-promise.ts
+++ b/packages/madwizard/src/util/ora-delayed-promise.ts
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
-import { oraPromise as theRealOraPromise, PromiseOptions } from "ora"
+import { PromiseOptions } from "ora"
 
 /** Fire of an `oraPromise` with a delay */
-export function oraPromise<T>(action: T | Promise<T>, options?: string | PromiseOptions<T>, delayMs = 500): Promise<T> {
+export async function oraPromise<T>(
+  action: T | Promise<T>,
+  options?: string | PromiseOptions<T>,
+  delayMs = 500
+): Promise<T> {
+  const { oraPromise: theRealOraPromise } = await import("ora")
+
   let isResolved = false
   Promise.resolve(action)
     .then(() => (isResolved = true))


### PR DESCRIPTION
BREAKING CHANGE: This removes untested and unused `exec` support in the Graph submodule.