### PR TITLE
fix: improved behavior w.r.t. ctrl+c cleanup

### DIFF
--- a/packages/madwizard/src/fe/cli/commands/guide/handler.ts
+++ b/packages/madwizard/src/fe/cli/commands/guide/handler.ts
@@ -106,9 +106,14 @@ export default async function guideHandler<Writer extends Writable["write"]>(
     if (!cleanExitPromise) {
       // eslint-disable-next-line no-async-promise-executor
       cleanExitPromise = new Promise(async (resolve) => {
-        Debug("madwizard/cleanup")("attempting a clean exit")
-        await Promise.all([memoizer.cleanup(signal), signal ? guide.onExitSignalFromUser(signal) : Promise.resolve()])
-        Debug("madwizard/cleanup")("attempting a clean exit... done")
+        try {
+          Debug("madwizard/cleanup")("attempting a clean exit")
+          await Promise.all([memoizer.cleanup(signal), signal ? guide.onExitSignalFromUser(signal) : Promise.resolve()])
+        } catch (err) {
+          console.error(err)
+        } finally {
+          Debug("madwizard/cleanup")("attempting a clean exit... done")
+        }
         resolve()
       })
     }

--- a/packages/madwizard/src/fe/raw/ask.ts
+++ b/packages/madwizard/src/fe/raw/ask.ts
@@ -33,7 +33,7 @@ function askViaHandler(ask: Prompt, description: string, onRaw: WithRawViaHandle
 }
 
 /** Ask a question via the raw api */
-export async function ask(ask: Prompt, description: string | undefined, options: WithRawViaCLI | WithRawViaHandler) {
+export function ask(ask: Prompt, description: string | undefined, options: WithRawViaCLI | WithRawViaHandler) {
   if (isRawViaHandler(options)) {
     return askViaHandler(ask, description, options.raw)
   } else {

--- a/packages/madwizard/src/util/ora-delayed-promise.ts
+++ b/packages/madwizard/src/util/ora-delayed-promise.ts
@@ -29,10 +29,14 @@ export async function oraPromise<T>(
     .then(() => (isResolved = true))
     .catch(() => (isResolved = true))
 
+  // re: hideCursor: false, ugh, otherwise ctrl+c doesn't work reliably
+  // https://github.com/sindresorhus/ora/issues/27
+  // https://github.com/tapjs/signal-exit/issues/49
+
   if (!isResolved) {
     setTimeout(() => {
       if (!isResolved) {
-        theRealOraPromise(Promise.resolve(action), options).catch(() => {
+        theRealOraPromise(Promise.resolve(action), Object.assign({ hideCursor: false }, options)).catch(() => {
           /* the caller will be alerted by our `return action` */
         })
       }


### PR DESCRIPTION
when `ora` hides the cursor... it installs a SIGINT handler to clean up the hiding of the cursor. this causes major unreliability with ctrl+c handling.

```
  // re: hideCursor: false, ugh, otherwise ctrl+c doesn't work reliably
  // https://github.com/sindresorhus/ora/issues/27
  // https://github.com/tapjs/signal-exit/issues/49
```