### PR TITLE
fix: ctrl+c exit emits "Run failed: undefined"

### DIFF
--- a/packages/madwizard/src/fe/guide/index.ts
+++ b/packages/madwizard/src/fe/guide/index.ts
@@ -747,7 +747,9 @@ export class Guide {
         if (this.options.raw) {
           throw err
         } else {
-          throw new Error(this.chalk.red(mainSymbols.cross) + " Run failed" + name + ": " + err.message)
+          throw new Error(
+            this.chalk.red(mainSymbols.cross) + " Run failed" + name + (err.message ? ": " + err.message : "")
+          )
         }
       }
     }


### PR DESCRIPTION
this PR fixes the "undefined" part. we will need to investigate why a ctrl+c results in a Run failed.