### PR TITLE
fix: ctrl+c while enquirer prompt is active does not invoke cleanup handlers

### DIFF
--- a/bin/madwizard
+++ b/bin/madwizard
@@ -3,4 +3,4 @@ TOP=$(cd $(dirname "$0")/.. && pwd)
 DIST="$TOP"/packages/madwizard-cli-core/dist
 export GUIDEBOOK_STORE="$TOP"/node_modules/@guidebooks/store/dist/store
 
-node "$DIST"/madwizard.min.cjs "$@"
+exec node "$DIST"/madwizard.min.cjs "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "madwizard-packages",
-  "version": "4.6.0",
+  "version": "5.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "madwizard-packages",
-      "version": "4.6.0",
+      "version": "5.0.6",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/madwizard",
@@ -5817,7 +5817,7 @@
       }
     },
     "packages/madwizard": {
-      "version": "4.6.0",
+      "version": "5.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.2.0",
@@ -5881,25 +5881,25 @@
       }
     },
     "packages/madwizard-cli": {
-      "version": "4.6.0",
+      "version": "5.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@guidebooks/store": "^2.1.2",
-        "madwizard-cli-core": "^4.6.0"
+        "madwizard-cli-core": "^5.0.6"
       },
       "bin": {
         "madwizard": "bin/madwizard"
       }
     },
     "packages/madwizard-cli-core": {
-      "version": "4.6.0",
+      "version": "5.0.6",
       "bin": {
         "madwizard": "bin/madwizard",
         "madwizard~": "bin/madwizard~"
       },
       "devDependencies": {
         "esbuild": "^0.16.15",
-        "madwizard": "^4.6.0"
+        "madwizard": "^5.0.6"
       }
     },
     "packages/madwizard/node_modules/chalk": {
@@ -8465,14 +8465,14 @@
       "version": "file:packages/madwizard-cli",
       "requires": {
         "@guidebooks/store": "^2.1.2",
-        "madwizard-cli-core": "^4.6.0"
+        "madwizard-cli-core": "^5.0.6"
       }
     },
     "madwizard-cli-core": {
       "version": "file:packages/madwizard-cli-core",
       "requires": {
         "esbuild": "^0.16.15",
-        "madwizard": "^4.6.0"
+        "madwizard": "^5.0.6"
       }
     },
     "make-fetch-happen": {

--- a/packages/madwizard/src/memoization/index.ts
+++ b/packages/madwizard/src/memoization/index.ts
@@ -50,6 +50,9 @@ export interface Memos {
   /** Invalidate any memos that make use of the given shell variable */
   invalidate(variable: string): void
 
+  /** Do we have anything to clean up? */
+  currentlyNeedsCleanup(): boolean
+
   /** Cleanup any state, e.g. spawned subprocesses */
   cleanup(signal?: "SIGINT" | "SIGTERM"): void | Promise<void>
 }
@@ -94,6 +97,11 @@ export class Memoizer implements Memos {
         Debug("madwizard/cleanup")("invalidating expansion", variable, pattern, matchingKey)
         delete this.expansionMemo[matchingKey]
       })
+  }
+
+  /** Do we have anything to clean up? */
+  public currentlyNeedsCleanup(): boolean {
+    return this.onExit.length > 0 || this.subprocesses.length > 0
   }
 
   /** Cleanup any state, e.g. spawned subprocesses */


### PR DESCRIPTION
wow, nodejs is a mess in this respect. enquirer isn't helping; it rejects with an empty string when a prompt is cancelled... we weren't handling that situation well.

This PR also removes the useless "please wait while we clean up" message when there's nothing to clean up