### PR TITLE
feat: remove now-unused `dependencies` field of `Memos`

### DIFF
--- a/packages/madwizard/src/exec/ray-submit.ts
+++ b/packages/madwizard/src/exec/ray-submit.ts
@@ -98,11 +98,11 @@ async function readRuntimeEnvFromTemplate(parsedOptions, memos: Memos) {
 
 /** express any pip dependencies we have collected */
 async function dependencies(memos: Memos, parsedOptions: ParsedOptions): Promise<RuntimeEnvDependencies> {
-  const pips = new Set(!memos.dependencies || !memos.dependencies.pip ? [] : memos.dependencies.pip)
+  const pips = new Set<string>()
   await addPipsFromTemplate(pips, parsedOptions, memos)
   pips.delete("ray")
 
-  const condas = new Set(!memos.dependencies || !memos.dependencies.conda ? [] : memos.dependencies.conda)
+  const condas = new Set<string>()
 
   if (condas.size === 0 && pips.size === 0) {
     return {}

--- a/packages/madwizard/src/memoization/index.ts
+++ b/packages/madwizard/src/memoization/index.ts
@@ -35,9 +35,6 @@ export interface Memos {
   /** Any captured environment variable assignments. For example, a guidebook may want to update via `export FOO=bar` */
   env: typeof process.env
 
-  /** Any collected dependencies that need to be injected into the runtime */
-  dependencies: Record<string, string[]>
-
   /** Any forked subprocesses that we should wait for? */
   subprocesses: ChildProcess[]
 
@@ -69,9 +66,6 @@ export class Memoizer implements Memos {
 
   /** Any captured environment variable assignments. For example, a guidebook may want to update via `export FOO=bar` */
   public readonly env: typeof process.env = {}
-
-  /** Any collected dependencies that need to be injected into the runtime */
-  public readonly dependencies = {}
 
   /** Any forked subprocesses that we should wait for? */
   public readonly subprocesses: ChildProcess[] = []


### PR DESCRIPTION
BREAKING CHANGE: since this was part of the public Memos interface, this is a breaking change