### PR TITLE
fix: profile import should not by default overwrite an existing profile

### DIFF
--- a/packages/madwizard/src/fe/MadWizardOptions.ts
+++ b/packages/madwizard/src/fe/MadWizardOptions.ts
@@ -138,6 +138,7 @@ export interface FetchOptions {
 type FileSystemOptions = {
   fs: Partial<{
     mkdirp(filepath: string): Promise<void>
+    access?(filepath: string, mode: number | undefined): Promise<void>
     readFile(filepath: string, cb: (err: NodeJS.ErrnoException | null, data: Buffer) => void): void
     writeFile(filepath: string, cb: (err: NodeJS.ErrnoException | null) => void): void
     writeFileAtomic: typeof import("write-file-atomic")

--- a/packages/madwizard/src/fe/cli/commands/profile/builder.ts
+++ b/packages/madwizard/src/fe/cli/commands/profile/builder.ts
@@ -17,6 +17,7 @@
 import { Argv } from "yargs"
 
 import Opts from "../../options.js"
+import { group } from "../../strings.js"
 
 type NamedProfileOpts = Opts & {
   profile: string
@@ -24,6 +25,7 @@ type NamedProfileOpts = Opts & {
 
 type UriOpts = Opts & {
   uri: string
+  force: boolean
 }
 
 type SrcProfileOpts = {
@@ -42,10 +44,26 @@ export function namedProfileBuilder(yargs: Argv<Opts>): Argv<NamedProfileOpts> {
 }
 
 export function uriBuilder(yargs: Argv<Opts>): Argv<UriOpts> {
-  return yargs.positional("uri", {
-    type: "string",
-    describe: "URI of profile",
-  })
+  return yargs
+    .positional("uri", {
+      type: "string",
+      describe: "URI of profile",
+    })
+    .options({
+      name: {
+        alias: "n",
+        type: "string" as const,
+        group: group("Profile Options"),
+        describe: "Save the profile with the given name",
+      },
+      force: {
+        alias: "f",
+        default: false,
+        type: "boolean" as const,
+        group: group("Profile Options"),
+        describe: "Force overwrite an existing profile",
+      },
+    })
 }
 
 export function srcAndTargetNamedProfileBuilder(yargs: Argv<Opts>): Argv<SrcProfileOpts & TargetProfileOpts> {

--- a/packages/madwizard/src/profiles/exists.ts
+++ b/packages/madwizard/src/profiles/exists.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from "path"
+import { constants } from "node:fs"
+
+import { profilesPath } from "./paths.js"
+import { MadWizardOptions } from "../fe/index.js"
+
+/** Check if the named `profile` exists */
+export default async function exists(options: MadWizardOptions, profile: string): Promise<boolean> {
+  const access = options.fs?.access || (await import("fs/promises").then((_) => _.access))
+  const filepath = join(await profilesPath(options), profile)
+
+  return access(filepath, constants.F_OK)
+    .then(() => true)
+    .catch(() => false)
+}


### PR DESCRIPTION
This adds `-f/--force` and `-n/--name` options to `profile import`.