### PR TITLE
feat: do not attach stdin by default to code block execs

### DIFF
--- a/packages/madwizard/src/codeblock/CodeBlockProps.ts
+++ b/packages/madwizard/src/codeblock/CodeBlockProps.ts
@@ -183,6 +183,9 @@ export type CodeBlockProps = Partial<CustomExecutable> &
      * completes.
      */
     async?: boolean
+
+    /** Should we attach stdin to the code block execution [default: false] */
+    stdin?: boolean
   }
 
 export function addNesting(props: CodeBlockProps, nesting: CodeBlockNestingParent, insertIdx?: number) {

--- a/packages/madwizard/src/exec/custom.ts
+++ b/packages/madwizard/src/exec/custom.ts
@@ -82,7 +82,7 @@ export default async function execAsCustom(
                 }
               }
 
-              shellItOut(exec, memos, opts, mwenv, async, myOnClose).then(resolve, reject)
+              shellItOut(exec, memos, opts, mwenv, async, undefined, myOnClose).then(resolve, reject)
             }
           })
         })

--- a/packages/madwizard/src/exec/index.ts
+++ b/packages/madwizard/src/exec/index.ts
@@ -35,7 +35,8 @@ export async function shellExec(
   opts: ExecOptions = { quiet: false },
   language: SupportedLanguage = "shell",
   exec?: CustomExecutable["exec"] /* execute code block with custom exec, rather than `sh` */,
-  async?: boolean /* fire and forget, until this process exits? */
+  async?: boolean /* fire and forget, until this process exits? */,
+  needsStdin?: boolean /* attach stdin? */
 ): Promise<"success"> {
   // maybe the client wants to handle some executions directly?
   const respFromClient = handledByClient(cmdline, memos, opts, exec)
@@ -51,7 +52,7 @@ export async function shellExec(
     return (
       exporter(cmdline, memos, opts) || // export FOO=3
       which(cmdline) || // which foo
-      shell(cmdline, memos, opts, undefined, async) // vanilla shell exec
+      shell(cmdline, memos, opts, undefined, async, needsStdin) // vanilla shell exec
     )
   } else if (isPythonic(language)) {
     // then the code block has been declared with a `python` language

--- a/packages/madwizard/src/exec/shell.ts
+++ b/packages/madwizard/src/exec/shell.ts
@@ -39,6 +39,7 @@ export default async function shellItOut(
   opts: ExecOptions = { quiet: false },
   extraEnv: Record<string, string> = {},
   async?: boolean /* fire and forget, until this process exits? */,
+  needsStdin?: boolean /* attach stdin? */,
   onClose?: () => void | Promise<void> /* callback when the process exits */
 ): Promise<"success"> {
   const cmdline = typeof _cmdline === "boolean" ? _cmdline : _cmdline.replace(/\\\n/g, " ")
@@ -76,11 +77,12 @@ export default async function shellItOut(
     env.GUIDEBOOK_DASHDASH = shellEscape(memos.cliDashDash)
   }
 
+  const stdin = needsStdin ? "inherit" : "ignore"
   const stdio: StdioOptions = opts.quiet
-    ? ["inherit", "ignore", "pipe"]
+    ? [stdin, "ignore", "pipe"]
     : capture
-    ? ["inherit", "pipe", "pipe"]
-    : ["inherit", "inherit", "inherit"]
+    ? [stdin, "pipe", "pipe"]
+    : [stdin, "inherit", "inherit"]
   if (opts.write) {
     stdio[1] = "pipe"
   }

--- a/packages/madwizard/src/fe/guide/index.ts
+++ b/packages/madwizard/src/fe/guide/index.ts
@@ -105,10 +105,7 @@ export class Guide {
       this._currentRunner.kill()
     }
 
-    if (!signal) {
-      // only run finally blocks on clean exit, not ctrl+c
-      await this.runOnStackFinallies()
-    }
+    await this.runOnStackFinallies()
   }
 
   private get hasReceivedExitSignalFromUser() {
@@ -562,7 +559,8 @@ export class Guide {
                           },
                           block.language,
                           block.exec,
-                          block.async
+                          block.async,
+                          block.stdin
                         ))
                     }
 

--- a/packages/madwizard/src/parser/markdown/rehype-code-indexer/index.ts
+++ b/packages/madwizard/src/parser/markdown/rehype-code-indexer/index.ts
@@ -189,12 +189,14 @@ export function rehypeCodeIndexer(
         if (isElement(node) && node.tagName === "code") {
           // react-markdown v6+ places the language in the className
           const match = node.properties.className
-            ? /language-({\.)?(\w+)(\.async)?/.exec(node.properties.className.toString())
+            ? /language-({\.)?(\w+)(\.async)?(\.stdin)?/.exec(node.properties.className.toString())
             : ""
           const language = match ? match[2] : undefined
           const async = match && match[3] ? true : undefined
+          const stdin = match && match[4] ? true : undefined
           // re: {. bit: this is a bit of a hack to support {.bash .no-copy} style languages from pymdown
           // re: .async bit: allow markdown to specify that a code block's execution should be executed asynchronously
+          // re: .stdin bit: allow markdown to specify that a code block's execution should be attached to stdin
 
           if (isExecutable(language)) {
             const myCodeIdx = codeIdx++
@@ -214,10 +216,10 @@ export function rehypeCodeIndexer(
                 }
 
                 const dumpCodeBlockProps = !base64
-                  ? () => Object.assign({ body, language, async }, attributes)
+                  ? () => Object.assign({ body, language, async, stdin }, attributes)
                   : () =>
                       Buffer.from(
-                        JSON.stringify(Object.assign({ body, language, async }, attributes), (key, value) =>
+                        JSON.stringify(Object.assign({ body, language, async, stdin }, attributes), (key, value) =>
                           key === "nesting" || key === "source" ? undefined : value
                         )
                       ).toString("base64")


### PR DESCRIPTION
This is dangerous, as e.g. putting one's laptop to sleep can send a signal to stdin, which can result in random subprocesses being suspended and never resuming. ctrl+z is another example.

This backs out https://github.com/guidebooks/madwizard/pull/694 which was a poor attempt at addressing this problem (that PR refused to process finally blocks on *any* signal)

With this change, you must now use `shell.stdin` to get a stdin attachment, as in:

```shell.stdin
while read line
do
  echo "$line"
done < "${1:-/dev/stdin}"
```