### PR TITLE
fix: regression new shorter uuids were using uppercase letters

### DIFF
--- a/packages/madwizard/src/choices/groups/expansion.ts
+++ b/packages/madwizard/src/choices/groups/expansion.ts
@@ -40,7 +40,7 @@ export type ExpansionMap = Record<string, Promise<string[] | null>>
 type ExpansionKind = "singleselect" | "multiselect" | "form"
 type ExpansionExpression = { expr: string; kind: ExpansionKind; message?: string; key?: string }
 
-const v4 = new ShortUniqueId({ length: 10 })
+const v4 = new ShortUniqueId({ length: 12, dictionary: "alphanum_lower" })
 
 function expandHomeDir(path: string) {
   const homedir = process.env.HOME_FOR_TEST || process.env[process.platform == "win32" ? "USERPROFILE" : "HOME"]


### PR DESCRIPTION
kubernetes does not like uppercase letters in resource names